### PR TITLE
Update kserve example to include specific framework support

### DIFF
--- a/docs/examples/kserve.yaml
+++ b/docs/examples/kserve.yaml
@@ -57,7 +57,12 @@ spec:
           priorityClassNamePath: .spec.predictor.priorityClassName
           schedulerNamePath: .spec.predictor.schedulerName
           labelsPath: .spec.predictor.labels
-          annotationsPath: .spec.predictor.annotations
+          annotationsPath: .spec.predictor.annotations\
+          # Targets the built-in framework predictor cases (e.g., 'tensorflow', 'pytorch').
+          # This query uses 'storageUri' existence as the marker for built-in framework.
+          # If a built-in runtime is defined, this path resolves to the runtime object.
+          # If a Custom Predictor is used (defined via 'containers'), this path resolves to **null**,
+          # allowing the 'containersPath' definition to take precedence and resolve the PodSpec.
           containerPath: '.spec.predictor | ( (.[]?  | select(type =="object" and  .storageUri )))'
           containersPath: .spec.predictor.containers
       scaleDefinition:

--- a/docs/examples/kserve.yaml
+++ b/docs/examples/kserve.yaml
@@ -51,7 +51,15 @@ spec:
         kind: "Deployment"
       ownerRef: "inferenceservice"
       specDefinition:
-        podTemplateSpecPath: ".spec.predictor.template"
+        fragmentedPodSpecDefinition:
+          nodeAffinityPath: .spec.predictor.affinity.nodeAffinity
+          podAffinityPath: .spec.predictor.affinity.podAffinity
+          priorityClassNamePath: .spec.predictor.priorityClassName
+          schedulerNamePath: .spec.predictor.schedulerName
+          labelsPath: .spec.predictor.labels
+          annotationsPath: .spec.predictor.annotations
+          containerPath: '.spec.predictor | ( (.[]?  | select(type =="object" and  .storageUri )))'
+          containersPath: .spec.predictor.containers
       scaleDefinition:
         minReplicasPath: ".spec.predictor.minReplicas"
         maxReplicasPath: ".spec.predictor.maxReplicas"


### PR DESCRIPTION
After looking on the crd, there is a predictor field that could have the pod spec but also optional “one of” of a specific model (could be model, tensorflow, pytorch, etc). which could contain a container and then predicator could override podspec (expect the container)
tensorflow example : 
```
apiVersion: "serving.kserve.io/v1beta1"
kind: "InferenceService"
metadata:
  name: "tf-mnist-predictor"
  namespace: "default" 
spec:
  predictor:
    tensorflow: # expands container
      storageUri: "pvc://tf-models-pvc/mnist/savedmodel"
      resources:
        requests:
          cpu: "500m"
          memory: "1Gi"
        limits:
          cpu: "1"
          memory: "2Gi"
    imagePullSecrets: #Root level pod spec
    - name: "my-registry-secret"
    tolerations:
    - key: "special-node"
      operator: "Equal"
      value: "true"
      effect: "NoSchedule"
```

and without custom model
```
apiVersion: "serving.kserve.io/v1beta1"
kind: "InferenceService"
metadata:
  name: "custom-model-server"
  namespace: "default" 
spec:
  predictor: # inline PodSpec
    containers:
      - name: my-custom-predictor-container
        image: **your-registry.io/your-custom-server:v1.0**
        resources:
          requests:
            cpu: "250m"
            memory: "512Mi"
          limits:
            cpu: "1"
            memory: "1Gi"
        env:
          - name: MODEL_NAME
            value: "my_custom_model"
          - name: MODEL_URI
            value: "s3://my-model-bucket/custom_model_artifacts/"
    imagePullSecrets:
    - name: **my-private-registry-secret**
    nodeSelector:
      kubernetes.io/hostname: **gpu-node-01**
```
Explanation for  '.spec.predictor | ( (.[]?  | select(type =="object" and  .storageUri )))' : 
If tensorflow for example would exist, containerRef will resolve to .spec.predicator.tensorflow

otherwise it will be null
For containersPath - as there mutual exclusive , it will be null when tensorflow exists and would point to the containers array.

