### PR TITLE
Add helm chart CI/CD for publishing Karta chart to GHCR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,3 +31,8 @@ jobs:
       - name: Run checks
         run: make check
 
+      - name: Lint helm chart
+        run: make helm-lint
+
+      - name: Validate helm chart renders
+        run: make helm-validate

--- a/.github/workflows/push-artifacts.yaml
+++ b/.github/workflows/push-artifacts.yaml
@@ -1,0 +1,54 @@
+# Copyright 2025 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+name: Karta - Upload artifacts to GitHub Container Registry
+on:
+  push:
+    tags:
+      - '*.*.*'
+
+permissions:
+  contents: write
+  packages: write
+
+env:
+  HELM_REGISTRY: "ghcr.io/run-ai/karta"
+
+jobs:
+  build-and-push:
+    name: Build & Push Helm Chart
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Extract package version from tag
+        run: |
+          PACKAGE_VERSION=${GITHUB_REF_NAME#v}
+          echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_ENV
+          echo $PACKAGE_VERSION
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Lint helm chart
+        run: helm lint ./charts/krt
+
+      - name: Build helm chart
+        run: |
+          helm package ./charts/krt -d ./charts --app-version $PACKAGE_VERSION --version $PACKAGE_VERSION
+
+      - name: Push Helm Chart
+        run: |
+          helm push ./charts/krt-$PACKAGE_VERSION.tgz oci://${{ env.HELM_REGISTRY }}
+
+      - name: Upload chart as release asset
+        uses: softprops/action-gh-release@v3
+        with:
+          files: charts/krt-${{ env.PACKAGE_VERSION }}.tgz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/push-artifacts.yaml
+++ b/.github/workflows/push-artifacts.yaml
@@ -1,7 +1,7 @@
 # Copyright 2025 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-name: Karta - Upload artifacts to GitHub Container Registry
+name: Upload artifacts to GitHub Container Registry
 on:
   push:
     tags:
@@ -49,7 +49,7 @@ jobs:
 
       - name: Verify version not already published
         run: |
-          if helm pull oci://${{ env.HELM_REGISTRY }}/krt --version "$PACKAGE_VERSION" -d /tmp 2>/dev/null; then
+          if helm show chart oci://${{ env.HELM_REGISTRY }}/krt --version "$PACKAGE_VERSION" >/dev/null 2>&1; then
             echo "Version $PACKAGE_VERSION already published to ${{ env.HELM_REGISTRY }}/krt. Bump charts/krt/Chart.yaml and re-tag." >&2
             exit 1
           fi

--- a/.github/workflows/push-artifacts.yaml
+++ b/.github/workflows/push-artifacts.yaml
@@ -5,7 +5,8 @@ name: Karta - Upload artifacts to GitHub Container Registry
 on:
   push:
     tags:
-      - '*.*.*'
+      - 'v[0-9]*.[0-9]*.[0-9]*'
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 permissions:
   contents: write
@@ -22,11 +23,22 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Install helm
+        uses: azure/setup-helm@v5
+
       - name: Extract package version from tag
         run: |
           PACKAGE_VERSION=${GITHUB_REF_NAME#v}
           echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_ENV
-          echo $PACKAGE_VERSION
+          echo "$PACKAGE_VERSION"
+
+      - name: Verify Chart.yaml version matches tag
+        run: |
+          chart_version=$(yq '.version' charts/krt/Chart.yaml)
+          if [[ "$chart_version" != "$PACKAGE_VERSION" ]]; then
+            echo "Chart.yaml version ($chart_version) does not match git tag ($PACKAGE_VERSION). Bump charts/krt/Chart.yaml before tagging." >&2
+            exit 1
+          fi
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4
@@ -35,8 +47,15 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Lint helm chart
-        run: helm lint ./charts/krt
+      - name: Verify version not already published
+        run: |
+          if helm pull oci://${{ env.HELM_REGISTRY }}/krt --version "$PACKAGE_VERSION" -d /tmp 2>/dev/null; then
+            echo "Version $PACKAGE_VERSION already published to ${{ env.HELM_REGISTRY }}/krt. Bump charts/krt/Chart.yaml and re-tag." >&2
+            exit 1
+          fi
+
+      - name: Lint and validate helm chart
+        run: make helm-lint helm-validate
 
       - name: Build helm chart
         run: |

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 KRT_CHART_DIR := $(PROJECT_DIR)/charts/krt
 KRT_CRDS_DIR := $(KRT_CHART_DIR)/crds
 
+HELM_CHART_VERSION ?= 0.0.1
+
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 MOCKGEN ?= $(LOCALBIN)/mockgen
 GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
@@ -123,3 +125,17 @@ download-dependencies:
 
 .PHONY: check
 check: download-dependencies validate test lint
+
+##@ Helm
+
+.PHONY: helm-build
+helm-build: ## Build the helm chart
+	helm package $(KRT_CHART_DIR) --version $(HELM_CHART_VERSION) --app-version $(HELM_CHART_VERSION)
+
+.PHONY: helm-lint
+helm-lint: ## Lint the helm chart
+	helm lint $(KRT_CHART_DIR)
+
+.PHONY: helm-validate
+helm-validate: ## Validate the helm chart renders
+	helm template $(KRT_CHART_DIR)


### PR DESCRIPTION
## Summary

Set up automated build and publish pipeline for the RI helm chart to GitHub Container Registry, following the same pattern used by [KAI-Scheduler](https://github.com/kai-scheduler/KAI-Scheduler).

- **New `push-artifacts.yaml` workflow** — on push to `main` or on a version tag, builds the RI chart and pushes it as an OCI artifact to `oci://ghcr.io/run-ai/karta/ri`. On tagged releases, also uploads the `.tgz` as a GitHub release asset.
- **CI validation** - added `helm lint` and `helm template` steps to `ci.yaml` so chart regressions are caught on every PR.
- **`charts/ri/Makefile`** - local targets for `build`, `validate`, and `lint` for developer convenience.
- **`charts/ri/Chart.yaml`** - version set to `0.0.0` (stamped dynamically via `helm package --version` at build time).

### Why

The RI CRD is currently manually copied into the [runai monorepo](https://github.com/run-ai/runai) helm chart and crd-upgrader. Publishing the RI chart to GHCR allows the monorepo to consume it as a proper helm dependency — eliminating manual copy steps and ensuring version tracking. The companion PR in the monorepo is linked below.

### Companion PR
- run-ai/runai - _Add RI helm chart as dependency, remove manually-copied CRDs_ (creating next)

## Test plan
- [ ] Verify `make -C charts/ri build` packages the chart locally
- [ ] Verify `helm lint ./charts/ri` and `helm template ./charts/ri` pass
- [ ] After merge, confirm chart appears at `ghcr.io/run-ai/karta/ri`
- [ ] Tag a release and verify the `.tgz` is attached as a release asset

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now runs Helm chart linting and template validation as part of checks.
  * New workflow automatically packages and publishes Helm charts to a container registry on release tags.
  * Build tooling updated with targets to lint, validate, and package charts plus a configurable chart version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->