### PR TITLE
Update Go version to 1.25.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/run-ai/karta
 
-go 1.25.7
+go 1.25.9
 
 require (
 	github.com/itchyny/gojq v0.12.18


### PR DESCRIPTION
## What does this PR do?
Update Go version to 1.25.9



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go development toolchain to the latest compatible version for improved stability and build efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->