### PR TITLE
Update Go version from 1.25.7 to 1.25.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/run-ai/karta
 
-go 1.25.7
+go 1.25.9
 
 require (
 	github.com/itchyny/gojq v0.12.18


### PR DESCRIPTION
* **Chores**
  * Updated the Go development toolchain to the latest compatible version for improved stability and build efficiency.
