### PR TITLE
Add chart version bump policy with CI enforcement (ct lint)

### DIFF
--- a/.github/workflows/chart-lint.yaml
+++ b/.github/workflows/chart-lint.yaml
@@ -1,0 +1,34 @@
+# Copyright 2025 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+name: Chart lint
+on:
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  ct-lint:
+    name: Helm chart-testing (lint)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up python (required by chart-testing)
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Set up helm
+        uses: azure/setup-helm@v5
+
+      - name: Install chart-testing
+        uses: helm/chart-testing-action@v2
+
+      - name: Run chart-testing (lint)
+        run: ct lint --target-branch ${{ github.base_ref }} --chart-dirs charts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,57 @@ For more information about the DCO, please visit: https://developercertificate.o
 3. Address any feedback or requested changes
 4. Once approved, your changes will be merged
 
+## Versioning
+
+`charts/krt/Chart.yaml` carries two version fields. Each tracks a different concern and is bumped at a different point in the workflow.
+
+| Field | Tracks | When to bump |
+|---|---|---|
+| `version` | Chart semver (RBAC, templates, values defaults, README) | every PR that changes files under `charts/krt/` (excluding `Chart.yaml` itself) |
+| `appVersion` | Controller/CRD release (the code we ship) | as part of the release prep before tagging |
+
+Both follow [semver](https://semver.org/). Pick the bump level (patch / minor / major) using the same rules you would for any semver release.
+
+This convention follows the pattern used by [prometheus-community/helm-charts](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/Chart.yaml), [argoproj/argo-helm](https://github.com/argoproj/argo-helm/blob/main/charts/argo-cd/Chart.yaml), and [kubernetes/ingress-nginx](https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/Chart.yaml).
+
+### Day-to-day: chart changes bump `version`
+
+Any PR that touches a file under `charts/krt/` (other than `Chart.yaml`) must bump `version` in `charts/krt/Chart.yaml`. Edit the file directly:
+
+```yaml
+# charts/krt/Chart.yaml
+version: 0.1.1   # was 0.1.0
+```
+
+The [chart-lint workflow](.github/workflows/chart-lint.yaml) runs [`ct lint`](https://github.com/helm/chart-testing) (the official helm chart-testing tool) on every PR. With its default `--check-version-increment=true`, it fails the PR if a modified chart's `version` was not bumped. Same enforcement [prometheus-community/helm-charts](https://github.com/prometheus-community/helm-charts/blob/main/.github/workflows/lint-test.yaml) and [argoproj/argo-helm](https://github.com/argoproj/argo-helm/blob/main/.github/workflows/lint-and-test.yml) use.
+
+### Code changes don't bump on every PR
+
+PRs that change `pkg/` (or anything else outside `charts/krt/`) don't need to bump `version` or `appVersion`. The CI doesn't enforce one. `appVersion` stays at the last released value while code accumulates on main.
+
+### Release prep: bump `appVersion` to match the next tag
+
+When ready to release a new controller version (for example, `v1.2.3`):
+
+1. Open a release-prep PR that bumps `appVersion` (and usually `version` too) in `charts/krt/Chart.yaml`:
+
+   ```yaml
+   version: 0.5.0
+   appVersion: "1.2.3"
+   ```
+
+2. Merge the PR.
+3. Tag the merge commit:
+
+   ```bash
+   git tag v1.2.3
+   git push origin v1.2.3
+   ```
+
+4. The [push-artifacts workflow](.github/workflows/push-artifacts.yaml) validates `tag == appVersion` and publishes the chart. If the tag doesn't match `appVersion`, it fails loudly.
+
+This is the same release-prep flow used by [openbao-operator](https://github.com/dc-tec/openbao-operator/blob/main/.github/workflows/release.yml) and [ingress-nginx](https://github.com/kubernetes/ingress-nginx).
+
 ## Code of Conduct
 
 Please be respectful and professional in all interactions. We are committed to providing a welcoming and inclusive environment for all contributors.


### PR DESCRIPTION
## Summary

Adopt a decoupled versioning convention for `charts/krt/Chart.yaml`, enforced by [`ct lint`](https://github.com/helm/chart-testing) (the official helm chart-testing tool).

| Field | Tracks | When to bump |
|---|---|---|
| `version` | Chart semver (RBAC, templates, values defaults) | every PR that changes files under `charts/krt/` |
| `appVersion` | Controller/CRD release | as part of the release-prep PR right before tagging |

`appVersion` is **not** enforced on every code PR. The tag-time validation in `push-artifacts.yaml` already catches `tag != appVersion`, so it's enough to bump it as part of release prep.

## What's in this PR

1. **`.github/workflows/chart-lint.yaml`** - runs `ct lint` on every PR. With the default `--check-version-increment=true`, it fails the PR if a modified chart's `version` was not bumped. Also runs `helm lint` and Chart.yaml schema validation as a bonus.
2. **`CONTRIBUTING.md`** - new "Versioning" section documenting the day-to-day vs release-prep flows.

No Makefile changes. Bumping is just editing `Chart.yaml`.

## Why `ct lint` over a custom shell check

`ct lint` is the standard helm tool, maintained by the helm core team, used by:
- [prometheus-community/helm-charts](https://github.com/prometheus-community/helm-charts/blob/main/.github/workflows/lint-test.yaml)
- [argoproj/argo-helm](https://github.com/argoproj/argo-helm/blob/main/.github/workflows/lint-and-test.yml)
- grafana/helm-charts

Per Isan's review on the previous iteration: less custom code, more features for free, easier to extend (install testing, etc).

## Why this convention

This matches the pattern used by big OSS chart repos:
- [prometheus-community/helm-charts](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/Chart.yaml) — `version: 84.1.2`, `appVersion: v0.90.1`
- [argoproj/argo-helm](https://github.com/argoproj/argo-helm/blob/main/charts/argo-cd/Chart.yaml) — `version: 9.5.4`, `appVersion: v3.3.8`
- [kubernetes/ingress-nginx](https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/Chart.yaml) — `version: 4.15.1`, `appVersion: 1.15.1` (monorepo, closest precedent for our future state with a controller)

The release-prep flow (bump `appVersion` in a PR, then tag, CI validates) matches [openbao-operator](https://github.com/dc-tec/openbao-operator/blob/main/.github/workflows/release.yml) and [ingress-nginx](https://github.com/kubernetes/ingress-nginx).

## The release flow (recap)

**Day-to-day**:
- Chart PR → edit `version` in Chart.yaml → CI (`ct lint`) enforces it.
- Code PR (`pkg/`) → no bump required, `appVersion` stays at last released value.

**Release prep (when we have a controller)**:
1. Open release-prep PR: bump `appVersion` (and `version` if needed) in Chart.yaml.
2. Merge.
3. `git tag vX.Y.Z && git push origin vX.Y.Z`.
4. `push-artifacts.yaml` validates `tag == appVersion` and publishes.

## Test plan

- [ ] `ct lint` workflow passes when chart isn't changed
- [ ] `ct lint` workflow fails when chart is changed without a `version` bump
- [ ] `ct lint` workflow passes when chart is changed with a proper `version` bump

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines with Helm chart versioning conventions, including rules for bumping version and appVersion fields, and release workflow procedures.

* **Chores**
  * Added automated Helm chart linting on pull requests to validate chart integrity and enforce versioning consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->