### PR TITLE
Annotate chart with OCI source for repo linking on GHCR

### DIFF
--- a/charts/krt/Chart.yaml
+++ b/charts/krt/Chart.yaml
@@ -7,3 +7,6 @@ description: A Helm chart for deploying Karta (Krt) by NVIDIA.
 type: application
 version: 0.0.1
 appVersion: "0.0.0"
+annotations:
+  org.opencontainers.image.source: https://github.com/run-ai/karta
+  org.opencontainers.image.licenses: Apache-2.0


### PR DESCRIPTION
## Summary

Add OCI annotations to `charts/krt/Chart.yaml` so the published GHCR package shows up on the karta repo's "Packages" sidebar, instead of only at `github.com/orgs/run-ai/packages`.

```yaml
annotations:
  org.opencontainers.image.source: https://github.com/run-ai/karta
  org.opencontainers.image.licenses: Apache-2.0
```

Helm bakes these into the OCI manifest at `helm package` time. GitHub reads `org.opencontainers.image.source` to link the package to the repo. Without this annotation, the published chart is "orphan" - lives in GHCR, visible at the org level, but not linked anywhere on the repo page.

## Why

Today, when we publish `ghcr.io/run-ai/karta/krt:X.Y.Z`, the package is visible only at:
- the registry (via `helm pull` / `crane manifest`)
- `github.com/orgs/run-ai/packages` (org-wide list)

After this change, the package will also appear at:
- the karta repo's "Packages" sidebar (`github.com/run-ai/karta`)

This is the standard pattern. Sister project [KAI-Scheduler](https://github.com/kai-scheduler/KAI-Scheduler) does the same (see https://github.com/kai-scheduler/KAI-Scheduler/pkgs/container/kai-scheduler%2Fkai-scheduler).

## Test plan

- [x] `helm lint charts/krt` passes
- [ ] After merge + next tagged release, verify the package appears on the karta repo's main page sidebar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added source repository and license metadata to Helm chart annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->