### PR TITLE
fix(examples): repair mpijob YAML and simplify pytorch running mapping

### DIFF
--- a/docs/examples/mpijob.yaml
+++ b/docs/examples/mpijob.yaml
@@ -22,14 +22,16 @@ spec:
               - type: Created
                 status: "True"
               - type: Running
-                status: "False"          running:
+                status: "False"
+          running:
           - byConditions:
               - type: Running
                 status: "True"
               - type: Succeeded
                 status: "False"
               - type: Failed
-                status: "False"          completed:
+                status: "False"
+          completed:
           - byConditions:
               - type: Succeeded
                 status: "True"

--- a/docs/examples/pytorch.yaml
+++ b/docs/examples/pytorch.yaml
@@ -25,10 +25,6 @@ spec:
           - byConditions:
               - type: Running
                 status: "True"
-              - type: "Succeeded"
-                status: "False"
-              - type: Failed
-                status: "False"
           completed:
           - byConditions:
               - type: Succeeded


### PR DESCRIPTION
## Summary

Two fixes to `docs/examples/` Karta definitions surfaced while building a CLI consumer against a live cluster.

### `mpijob.yaml` — repair malformed YAML (parser-blocking)

Two YAML keys were mashed onto preceding value lines, making the file unparseable:

```yaml
# before — line 25 and line 33 were broken
                status: "False"          running:
                ...
                status: "False"          completed:
```

`sigs.k8s.io/yaml` (the loader Karta uses) errors out with `did not find expected key`, so this file can't be applied to a cluster. Split each onto its own line.

### `pytorch.yaml` — simplify the `running` mapping

The `running` byConditions matcher required all three of `Running:True`, `Succeeded:False`, `Failed:False` to fire. The Kubeflow training-operator only emits `Succeeded` and `Failed` conditions on terminal transitions — actively-running jobs only carry `Created:True` and `Running:True`. The current matcher's `if !found { return false }` semantics (`pkg/resource/accessor.go:611`) treats absent conditions as non-matches, so the `running` mapping never fires for running jobs. Result: every actively-running PyTorchJob reads as `Initializing` for its entire runtime.

Drop the negative-condition requirements; `Running:True` alone is the correct signal for an active job. After the fix, the workload matches both `initializing` (Created=True) and `running` (Running=True), which the data model (`MatchedStatuses []ResourceStatus`) supports — consumers can render multi-phase or pick precedence.

## Test plan

- [x] `sigs.k8s.io/yaml` parses both files without error
- [x] `kubectl apply -f docs/examples/pytorch.yaml` and `mpijob.yaml` succeed against a live cluster
- [x] Live PyTorchJob with `Created:True, Running:True` conditions returns `Phases: [Running, Initializing]` instead of just `[Initializing]`
- [x] Scanned remaining `docs/examples/*.yaml` for similar mashed-key issues — none found
- [ ] CI green on this PR

## Notes

- The `Running, Initializing` dual-phase output for the PyTorchJob fix is intentional given the `MatchedStatuses` data model; consumers that want a single phase should add precedence (e.g. Running > Initializing) at the display layer.
- Considering a follow-up to revisit `match()` semantics in `pkg/resource/accessor.go` so that absent conditions can match `status: "False"` requirements without depending on the controller having published the negative condition. Happy to draft that separately if the appetite is there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected status mapping structures in example configuration files to ensure proper nesting and separation of state definitions (initializing, running, completed, failed).
  * Updated running state condition logic in examples for accurate status matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->