### PR TITLE
Add Grove PodCliqueSet (grove.io/v1alpha1) Karta example

### DIFF
--- a/docs/examples/grove-podcliqueset.yaml
+++ b/docs/examples/grove-podcliqueset.yaml
@@ -28,7 +28,9 @@ spec:
                   status: "True"
           running:
             - byExpression:
-                expression: '(.spec.replicas // 0) > 0 and (.status.availableReplicas // 0) >= (.spec.replicas // 0)'
+                # Matches when all desired replicas are available (including the
+                # vacuous replicas=0 case, same as k8s Deployment Available=True).
+                expression: '(.status.availableReplicas // 0) >= (.spec.replicas // 0)'
                 expectedResult: "true"
           initializing:
             - byExpression:

--- a/docs/examples/grove-podcliqueset.yaml
+++ b/docs/examples/grove-podcliqueset.yaml
@@ -11,10 +11,11 @@ spec:
         version: v1alpha1
         kind: PodCliqueSet
       statusDefinition:
-        # Grove leaves .status.podGangStatuses[] empty in practice, and PCS has
-        # no aggregate phase. The reliable signal is replica counts:
-        # availableReplicas vs spec.replicas. Failure is signalled by the
-        # TopologyLevelsUnavailable condition.
+        # Grove PCS has no aggregate phase field. The reliable signal for
+        # running/initializing is replica counts (availableReplicas vs
+        # spec.replicas). TopologyLevelsUnavailable is the only PCS-level
+        # failure condition (TAS-specific); broader failures surface on
+        # child PodClique/Pod resources.
         conditionsDefinition:
           path: .status.conditions
           typeFieldName: type

--- a/docs/examples/grove-podcliqueset.yaml
+++ b/docs/examples/grove-podcliqueset.yaml
@@ -1,0 +1,117 @@
+apiVersion: run.ai/v1alpha1
+kind: Karta
+metadata:
+  name: grove-io-podcliqueset-v1alpha1
+spec:
+  structureDefinition:
+    rootComponent:
+      name: podcliqueset
+      kind:
+        group: grove.io
+        version: v1alpha1
+        kind: PodCliqueSet
+      statusDefinition:
+        # Grove leaves .status.podGangStatuses[] empty in practice, and PCS has
+        # no aggregate phase. The reliable signal is replica counts:
+        # availableReplicas vs spec.replicas. Failure is signalled by the
+        # TopologyLevelsUnavailable condition.
+        conditionsDefinition:
+          path: .status.conditions
+          typeFieldName: type
+          statusFieldName: status
+          reasonFieldName: reason
+          messageFieldName: message
+        statusMappings:
+          failed:
+            - byConditions:
+                - type: TopologyLevelsUnavailable
+                  status: "True"
+          running:
+            - byExpression:
+                expression: '(.spec.replicas // 0) > 0 and (.status.availableReplicas // 0) >= (.spec.replicas // 0)'
+                expectedResult: "true"
+          initializing:
+            - byExpression:
+                expression: '(.spec.replicas // 0) > 0 and (.status.availableReplicas // 0) < (.spec.replicas // 0)'
+                expectedResult: "true"
+    childComponents:
+      # Standalone PodCliques (entries under .spec.template.cliques that are NOT
+      # referenced by any .spec.template.podCliqueScalingGroups[].cliqueNames).
+      # PodCliques inside a scaling group are owned by the PodCliqueScalingGroup,
+      # so they are reached through the `scalinggroup` child below.
+      - name: clique
+        kind:
+          group: grove.io
+          version: v1alpha1
+          kind: PodClique
+        ownerRef: podcliqueset
+        specDefinition:
+          fragmentedPodSpecDefinition:
+            schedulerNamePath: .spec.template.cliques[].spec.podSpec.schedulerName
+            labelsPath: .spec.template.cliques[].labels
+            annotationsPath: .spec.template.cliques[].annotations
+            containersPath: .spec.template.cliques[].spec.podSpec.containers
+            resourceClaimsPath: .spec.template.cliques[].spec.podSpec.resourceClaims
+            priorityClassNamePath: .spec.template.cliques[].spec.podSpec.priorityClassName
+            podAffinityPath: .spec.template.cliques[].spec.podSpec.affinity.podAffinity
+            nodeAffinityPath: .spec.template.cliques[].spec.podSpec.affinity.nodeAffinity
+        scaleDefinition:
+          # PCS multiplies replicas: total pods = PCS.replicas * clique.replicas
+          replicasPath: (.spec.replicas // 1) * (.spec.template.cliques[].spec.replicas // 1)
+          minReplicasPath: .spec.template.cliques[].spec.autoScalingConfig.minReplicas
+          maxReplicasPath: .spec.template.cliques[].spec.autoScalingConfig.maxReplicas
+        instanceIdPath: .spec.template.cliques[].name
+        podSelector:
+          componentInstanceSelector:
+            idPath: .metadata.labels["grove.io/podclique"]
+          replicaSelector:
+            keyPath: .metadata.labels["grove.io/podcliqueset-replica-index"]
+      # PodCliqueScalingGroups (each entry under .spec.template.podCliqueScalingGroups
+      # becomes a PodCliqueScalingGroup CR per PCS replica).
+      - name: scalinggroup
+        kind:
+          group: grove.io
+          version: v1alpha1
+          kind: PodCliqueScalingGroup
+        ownerRef: podcliqueset
+        scaleDefinition:
+          replicasPath: (.spec.replicas // 1) * (.spec.template.podCliqueScalingGroups[].replicas // 1)
+          minReplicasPath: .spec.template.podCliqueScalingGroups[].scaleConfig.minReplicas
+          maxReplicasPath: .spec.template.podCliqueScalingGroups[].scaleConfig.maxReplicas
+        instanceIdPath: .spec.template.podCliqueScalingGroups[].name
+        podSelector:
+          componentInstanceSelector:
+            idPath: .metadata.labels["grove.io/podcliquescalinggroup"]
+          replicaSelector:
+            keyPath: .metadata.labels["grove.io/podcliquescalinggroup-replica-index"]
+    additionalChildKinds:
+      # PodCliques owned indirectly via PodCliqueScalingGroups also live in the tree.
+      - group: grove.io
+        version: v1alpha1
+        kind: PodClique
+      # PodCliqueScalingGroup must also appear here (even though it is a childComponent
+      # above) so the external-workload-integrator's top-owner walker recognises it as
+      # part of this workload and continues past it to reach the PCS root. Without this,
+      # scaling-group pods get a top-owner of their own PodClique CR and form a separate workload.
+      - group: grove.io
+        version: v1alpha1
+        kind: PodCliqueScalingGroup
+      # Gang-scheduling primitive emitted by Grove for each PCS replica.
+      - group: scheduler.grove.io
+        version: v1alpha1
+        kind: PodGang
+  optimizationInstructions:
+    # Each PodCliqueSet replica is a gang: every pod (from standalone cliques and
+    # scaling groups) sharing the same PCS name + replica index must be co-scheduled.
+    gangScheduling:
+      podGroups:
+        - name: podcliqueset-replica
+          members:
+            - componentName: clique
+              groupByKeyPaths:
+                - .metadata.labels["app.kubernetes.io/part-of"]
+                - .metadata.labels["grove.io/podcliqueset-replica-index"]
+            - componentName: scalinggroup
+              groupByKeyPaths:
+                - .metadata.labels["app.kubernetes.io/part-of"]
+                - .metadata.labels["grove.io/podcliqueset-replica-index"]


### PR DESCRIPTION
Closes #65

Reference Karta definition for the Grove PodCliqueSet CRD covering
status mappings, clique/scaling-group child components, additional
child kinds, and gang-scheduling optimization instructions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a complete example configuration for Grove PodCliqueSet workloads: shows replica-based status mappings, formulas for scaling replicas, definitions for standalone and scaling-group child components, registration of child kinds for resource traversal, and guidance for gang scheduling to co-schedule pods per replica.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->