### PR TITLE
docs: add AGENTS.md guide for AI coding agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,74 +34,23 @@ Never do:
 
 ## Repo Layout
 
-```text
-karta/
-  pkg/                  Go library source
-    api/runai/v1alpha1/ CRD types (group: run.ai)
-    resource/           Component extraction and update logic
-    instructions/       Gang scheduling and pod manipulation
-    jq/                 JQ path engine for spec/status traversal
-  charts/karta/         Helm chart (CRDs auto-generated)
-  docs/
-    Technical Guide.md  CRD anatomy, JQ paths, spec definitions
-    examples/           Pre-built Karta definitions
-  hack/                 Build and codegen scripts
-  test/                 Test fixtures and integration tests
-  .github/              CODEOWNERS, issue templates, PR template, CI workflows
-```
-
-If a directory has its own `AGENTS.md`, prefer that for subtree-specific rules.
+- `pkg/` Karta Go library source
+- `charts/` Helm chart (CRDs auto-generated)
+- `docs/` Pre-built Karta definitions and guides
 
 ## Build, Test, Lint
 
-| Command | What it does |
-|---------|--------------|
-| `make check` | Umbrella: validates generated artifacts, runs tests, runs lint. Run before every PR. |
-| `make test` | Run Go tests with mock regeneration. |
-| `make lint` | `go fmt`, `go vet`, `golangci-lint`. |
-| `make manifests` | Regenerate CRD YAML into `charts/karta/crds/`. |
-| `make generate` | Regenerate DeepCopy methods. |
-| `make generate-licenses` | Refresh `NOTICE` and `THIRD_PARTY_LICENSES`. |
-| `make validate` | Run all generators and fail if the working tree drifts. |
-
-Tools install into `./bin/` on first use. Versions are pinned in the Makefile.
-
-### Running a single test
-
-```bash
-go test ./pkg/resource/                          # one package
-go test ./pkg/resource/ -run TestComponentFactory # one test function
-go test ./pkg/resource/ -run TestComponentFactory -v -count=1
-```
-
-`make test` regenerates mocks first (`go generate ./pkg/...`); `go test` directly does not. If you change interfaces being mocked, run `make generate-mocks` before iterating.
+Use `Makefile` to build, test, lint, and generate code (e.g. `make test`, `make validate`). For a single test use `go test`.
 
 ## Code Style
-
-### Imports
-
-Three groups, separated by blank lines (enforced by `goimports` with `local-prefixes: github.com/run-ai/karta`):
-
-```go
-import (
-    // 1. Standard library
-    "context"
-    "fmt"
-
-    // 2. External dependencies
-    corev1 "k8s.io/api/core/v1"
-    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-    // 3. Internal packages
-    "github.com/run-ai/karta/pkg/api/runai/v1alpha1"
-)
-```
 
 ### Naming and Go patterns
 
 - Files `snake_case.go`; types `PascalCase`; interfaces `-er` suffix or `Interface`; boolean predicates use `is`/`has`/`should` prefix.
 - `context.Context` first parameter; pointer receivers for state-mutating methods; constructors return interface types when an interface exists; wrap errors with `%w`; do not log and return the same error.
 - Test files live next to the code (`*_test.go` in the same package).
+- Prefer idiomatic Go and Effective Go best practices (switch/case blocks, sentinel error types, etc.).
+- Keep code inline; only write helper functions if you test them later or they are re-used elsewhere.
 
 ### Linter
 
@@ -160,7 +109,3 @@ Unit tests live next to the code (`*_test.go` in the same package). Mocks are re
 - Conduct concerns: `CODE_OF_CONDUCT.md`.
 
 For feature discussion or bug reports, open a GitHub issue using the templates under `.github/ISSUE_TEMPLATE/`.
-
-## Subtree AGENTS.md Files
-
-When a subtree (e.g. `pkg/jq/`, `charts/karta/`) has non-obvious local conventions, add a nested `AGENTS.md` (under 200 lines). For Claude Code parity, add a sibling `CLAUDE.md` containing only `@AGENTS.md` (`printf '@AGENTS.md\n' > CLAUDE.md`). Do not use symlinks or put unique content in `CLAUDE.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,8 +49,8 @@ Use `Makefile` to build, test, lint, and generate code (e.g. `make test`, `make 
 - Files `snake_case.go`; types `PascalCase`; interfaces `-er` suffix or `Interface`; boolean predicates use `is`/`has`/`should` prefix.
 - `context.Context` first parameter; pointer receivers for state-mutating methods; constructors return interface types when an interface exists; wrap errors with `%w`; do not log and return the same error.
 - Test files live next to the code (`*_test.go` in the same package).
-- Prefer idiomatic Go and Effective Go best practices (switch/case blocks, sentinel error types, etc.).
-- Keep code inline; only write helper functions if you test them later or they are re-used elsewhere.
+- Prefer idiomatic go and effective go best practices (switch/case blocks, sentinel error types etc).
+- Keep code inline, only write helper functions if you test them later or they are re-used elsewhere.
 
 ### Linter
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,8 @@ Use the PR template at `.github/PULL_REQUEST_TEMPLATE.md`. Required: link to an 
 
 Every new source/Markdown file starts with `SPDX-License-Identifier: Apache-2.0` and `Copyright (c) 2026 NVIDIA Corporation`, in the file's comment syntax (Go `//`, Markdown `<!-- -->`, YAML/shell `#`).
 
+Exception: a Markdown file whose only content is an `@` import directive (for example, a sibling `CLAUDE.md` containing only `@AGENTS.md`) has no header.
+
 ## Third-Party Dependencies
 
 Allowed licenses: MIT, BSD-2/3, Apache 2.0, ISC. Disallowed: GPL, LGPL, AGPL, any copyleft. After adding a module:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,164 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright (c) 2026 NVIDIA Corporation -->
+
+# AGENTS.md - Guide for AI Coding Agents
+
+You are contributing to Karta, an Apache 2.0 open-source Kubernetes project. Stack: Go 1.25, controller-runtime, Helm. Goal: a CRD that lets controllers and platforms inspect, modify, and manage workloads of any type without per-CRD adapters.
+
+If you are an AI coding agent (Cursor, Codex, Claude Code, Aider, Continue, Copilot, etc.) opening this repo for the first time, read this file end to end before making changes. For Claude Code, the sibling `CLAUDE.md` imports this file via `@AGENTS.md`.
+
+## Boundaries
+
+Always do:
+- Run `make check` before pushing.
+- Sign off commits with `-s` (DCO).
+- Add SPDX + copyright header to new source and Markdown files.
+- Use Conventional Commits: `feat(scope):`, `fix(scope):`, `refactor(scope):`. Match an existing scope from `git log` when possible.
+- Reference an open GitHub issue in the PR.
+- Regenerate manifests after changing API types: `make generate && make manifests`.
+- Use `git mv` when moving files so history is preserved.
+
+Discuss in the PR description:
+- Adding a new third-party Go module (license, alternatives considered).
+- Breaking changes to public CRD fields or Helm values.
+- Renaming or moving Go packages.
+- Changes to `.github/workflows/`.
+
+Never do:
+- Hand-edit `charts/karta/crds/`. These are generated. Edit `pkg/api/runai/v1alpha1/` and run `make manifests` instead.
+- Disable a `golangci-lint` rule to silence a warning. Fix the underlying issue.
+- Include URLs to private or login-gated resources (e.g., company Confluence, Jira, or wikis) in commits, code, or docs.
+- Reference unannounced or non-public product features.
+- Reference customer or partner names without their explicit permission.
+- Push speculative commits to debug CI.
+
+## Repo Layout
+
+```text
+karta/
+  pkg/                  Go library source
+    api/runai/v1alpha1/ CRD types (group: run.ai)
+    resource/           Component extraction and update logic
+    instructions/       Gang scheduling and pod manipulation
+    jq/                 JQ path engine for spec/status traversal
+  charts/karta/         Helm chart (CRDs auto-generated)
+  docs/
+    Technical Guide.md  CRD anatomy, JQ paths, spec definitions
+    examples/           Pre-built Karta definitions
+  hack/                 Build and codegen scripts
+  test/                 Test fixtures and integration tests
+  .github/              CODEOWNERS, issue templates, PR template, CI workflows
+```
+
+If a directory has its own `AGENTS.md`, prefer that for subtree-specific rules.
+
+## Build, Test, Lint
+
+| Command | What it does |
+|---------|--------------|
+| `make check` | Umbrella: validates generated artifacts, runs tests, runs lint. Run before every PR. |
+| `make test` | Run Go tests with mock regeneration. |
+| `make lint` | `go fmt`, `go vet`, `golangci-lint`. |
+| `make manifests` | Regenerate CRD YAML into `charts/karta/crds/`. |
+| `make generate` | Regenerate DeepCopy methods. |
+| `make generate-licenses` | Refresh `NOTICE` and `THIRD_PARTY_LICENSES`. |
+| `make validate` | Run all generators and fail if the working tree drifts. |
+
+Tools install into `./bin/` on first use. Versions are pinned in the Makefile.
+
+### Running a single test
+
+```bash
+go test ./pkg/resource/                          # one package
+go test ./pkg/resource/ -run TestComponentFactory # one test function
+go test ./pkg/resource/ -run TestComponentFactory -v -count=1
+```
+
+`make test` regenerates mocks first (`go generate ./pkg/...`); `go test` directly does not. If you change interfaces being mocked, run `make generate-mocks` before iterating.
+
+## Code Style
+
+### Imports
+
+Three groups, separated by blank lines (enforced by `goimports` with `local-prefixes: github.com/run-ai/karta`):
+
+```go
+import (
+    // 1. Standard library
+    "context"
+    "fmt"
+
+    // 2. External dependencies
+    corev1 "k8s.io/api/core/v1"
+    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+    // 3. Internal packages
+    "github.com/run-ai/karta/pkg/api/runai/v1alpha1"
+)
+```
+
+### Naming and Go patterns
+
+- Files `snake_case.go`; types `PascalCase`; interfaces `-er` suffix or `Interface`; boolean predicates use `is`/`has`/`should` prefix.
+- `context.Context` first parameter; pointer receivers for state-mutating methods; constructors return interface types when an interface exists; wrap errors with `%w`; do not log and return the same error.
+- Test files live next to the code (`*_test.go` in the same package).
+
+### Linter
+
+`golangci-lint v2` (config: `.golangci.yml`). Active: `gofmt`, `goimports`, `errcheck`, `govet`, `unused`, plus standard presets. `errcheck` is relaxed for `*_test.go`; generated files (`zz_generated.*`) are skipped. Do not disable a rule to silence a warning; fix the issue.
+
+### Comments and Markdown
+
+- Self-documenting code; add a comment only when the *why* is non-obvious. No first-person pronouns (`I`, `we`).
+- Markdown: short sentences, no bold for emphasis, no emojis, no em-dash (U+2014), ASCII only.
+
+## Commits and Pull Requests
+
+Conventional Commits v1.0.0:
+
+```text
+<type>(<scope>): <short description>
+
+[optional body]
+```
+
+Types: `feat`, `fix`, `refactor`, `docs`, `test`, `build`, `ci`, `chore`.
+
+Sign off every commit with `-s` (DCO v1.1, real name required):
+
+```bash
+git commit -s -m "feat(cli): add tree alignment"
+```
+
+Use the PR template at `.github/PULL_REQUEST_TEMPLATE.md`. Required: link to an open issue, run `make check`, add or update tests (or explain why none).
+
+## SPDX Headers
+
+Every new source/Markdown file starts with `SPDX-License-Identifier: Apache-2.0` and `Copyright (c) 2026 NVIDIA Corporation`, in the file's comment syntax (Go `//`, Markdown `<!-- -->`, YAML/shell `#`).
+
+## Third-Party Dependencies
+
+Allowed licenses: MIT, BSD-2/3, Apache 2.0, ISC. Disallowed: GPL, LGPL, AGPL, any copyleft. After adding a module:
+
+1. `make generate-licenses` to refresh `NOTICE` and `THIRD_PARTY_LICENSES`.
+2. Name the dependency and version in the commit body.
+
+`go-licenses` runs in `make validate` and CI. License drift fails the build.
+
+## Tests
+
+Unit tests live next to the code (`*_test.go` in the same package). Mocks are regenerated by `make generate-mocks` (also run by `make test`). Integration fixtures live under `test/`.
+
+## Where to Ask
+
+- Contributing process: `CONTRIBUTING.md` (DCO text, PR flow).
+- Project owners: `OWNERS`, `MAINTAINERS.md`.
+- Code-area owners: `.github/CODEOWNERS`.
+- Security disclosures: `SECURITY.md`.
+- Conduct concerns: `CODE_OF_CONDUCT.md`.
+
+For feature discussion or bug reports, open a GitHub issue using the templates under `.github/ISSUE_TEMPLATE/`.
+
+## Subtree AGENTS.md Files
+
+When a subtree (e.g. `pkg/jq/`, `charts/karta/`) has non-obvious local conventions, add a nested `AGENTS.md` (under 200 lines). For Claude Code parity, add a sibling `CLAUDE.md` containing only `@AGENTS.md` (`printf '@AGENTS.md\n' > CLAUDE.md`). Do not use symlinks or put unique content in `CLAUDE.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,8 @@ Use `Makefile` to build, test, lint, and generate code (e.g. `make test`, `make 
 - Files `snake_case.go`; types `PascalCase`; interfaces `-er` suffix or `Interface`; boolean predicates use `is`/`has`/`should` prefix.
 - `context.Context` first parameter; pointer receivers for state-mutating methods; constructors return interface types when an interface exists; wrap errors with `%w`; do not log and return the same error.
 - Test files live next to the code (`*_test.go` in the same package).
+- Prefer idiomatic go and effective go best practices (switch/case blocks, sentinel error types etc) 
+- Keep code inline, only write helper functions if you test them later or they are re-used elsewhere  
 - Prefer idiomatic go and effective go best practices (switch/case blocks, sentinel error types etc).
 - Keep code inline, only write helper functions if you test them later or they are re-used elsewhere.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary

- Add `AGENTS.md` at repo root: build/test commands, code style, Conventional Commits, DCO, OSS compliance, three-tier boundaries (Always / Discuss / Never), and SPDX header rules.
- Add `CLAUDE.md` as a single-line `@AGENTS.md` import so Claude Code reads the same content (per https://code.claude.com/docs/en/memory).

AGENTS.md is the emerging cross-tool standard read natively by Cursor, OpenAI Codex, Aider, Continue, GitHub Copilot, Devin, and others. See https://agents.md.

Closes #76.

## Scope

Two files only. Replaces #59, which also added skills under `.agents/skills/` with platform pointers under `.claude/`, `.codex/`, `.cursor/` - those are dropped here. If useful they can land separately.

## Test plan

- [ ] AGENTS.md renders cleanly on GitHub
- [ ] Cursor / Codex / Aider find the file at repo root and follow it
- [ ] Claude Code follows the @AGENTS.md import in CLAUDE.md