### PR TITLE
docs(agents): add Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,3 +111,14 @@ Unit tests live next to the code (`*_test.go` in the same package). Mocks are re
 - Conduct concerns: `CODE_OF_CONDUCT.md`.
 
 For feature discussion or bug reports, open a GitHub issue using the templates under `.github/ISSUE_TEMPLATE/`.
+
+## Cursor Cloud specific instructions
+
+This repository is a Go library plus generated CRDs and a Helm chart (CRDs only). There is no `cmd/` binary or long-running service to start for local development.
+
+- Primary validation: `make check` (see Makefile). CI also runs `make lint` separately; run both before pushing.
+- Go is pinned in `go.mod`; the toolchain auto-downloads when needed.
+- Tools install into `bin/` on first `make validate` or `make lint` (`controller-gen`, `golangci-lint`, `go-licence-detector`). The Makefile prepends `bin/` to `PATH` for its own targets.
+- If `golangci-lint` download via the Makefile `curl` install script fails, install with the module Go version: `GOTOOLCHAIN=$(grep '^go ' go.mod | awk '{print $2}') GOBIN=$PWD/bin go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2`. The linter must be built with Go >= the `go` directive in `go.mod`.
+- Cluster-free integration coverage: `go test ./test/blackbox/` (full suspend/resume stack with a real JQ runner).
+- Optional: `kubectl` plus a cluster for `make install-crd`; `helm` for `make helm-lint` and `make helm-validate` (not included in `make check`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to AGENTS.md so cloud agents can set up and validate this repo without guessing.

Covers:
- No local server binary (library + CRD + Helm CRDs only)
- `make check` vs `make lint`
- `bin/` tool installation and golangci-lint fallback when curl install fails
- Blackbox tests as cluster-free integration coverage
- Optional kubectl/helm usage

## Testing
- `make check` and `make lint` run successfully in the cloud VM.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df996536-4eff-4452-a038-8bf7c4edeb03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df996536-4eff-4452-a038-8bf7c4edeb03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

