### PR TITLE
docs: add ROADMAP and GOVERNANCE

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,64 @@
+# Karta Governance
+
+This document describes how the Karta project is governed. It is a starting point
+that will grow as the contributor community grows.
+
+## Principles
+
+Karta is run as an open, vendor-neutral project. We aim to:
+
+- **Balance the interests of all stakeholders** — contributors, adopters, and the
+  broader ecosystem — without favoring any single organization.
+- **Keep the contract thin and neutral.** Karta describes workload *structure*; it
+  does not schedule, queue, or own a workload's lifecycle. Keeping the core small
+  is what lets any tool — from any vendor — depend on it.
+- **Decide in the open.** Significant technical decisions are made through public
+  issues, pull requests, and discussions, so that any contributor or adopter can
+  follow and weigh in.
+
+## Maintainers and decision-making
+
+The current maintainers, their areas of responsibility, and affiliations are
+listed in [MAINTAINERS.md](MAINTAINERS.md). Maintainers are responsible for
+reviewing contributions, setting technical direction, and stewarding releases.
+
+Decisions are made by lazy consensus among maintainers on the relevant issue or
+pull request. Where consensus cannot be reached, maintainers resolve the matter by
+a simple majority. No single organization is the deciding authority for the
+project.
+
+## Vendor neutrality
+
+Karta originated at Run:ai (NVIDIA) but is intended as a community standard, not a
+vendor-owned one. To keep it neutral:
+
+- **No organization-specific gating.** Features are not withheld or paywalled to
+  drive purchase of any commercial product. The API and the bundled examples stay
+  generally useful to any consumer.
+- **Neutral, stable consumption surface.** Karta is consumed both as a CRD and as a
+  Go library. The API group and the library follow a documented versioning and
+  deprecation policy so that any downstream project — regardless of vendor — can
+  depend on Karta with predictable upgrade expectations. (This is why the roadmap
+  prioritizes moving off a vendor-prefixed API group before the API stabilizes.)
+- **Open contribution and review.** Contributors and adopters get a fair
+  opportunity to reach consensus on features and PRs through the public review
+  process, without one organization's priorities overriding the community's.
+
+## Project home and evolution
+
+Karta is committed to vendor-neutral governance. Over time the project intends to
+move to a neutral, community-governed home (a cloud native foundation) once the API
+group is vendor-neutral and the project demonstrates adoption across multiple
+organizations. Until then it is developed in the open under its current
+organization, accepting external contributions.
+
+## Code of conduct
+
+All participation in the project is governed by the
+[Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Changing this document
+
+This governance document is itself maintained in the open. Proposed changes are
+made via pull request and require maintainer approval, following the same process
+as any other change to the project.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -39,7 +39,7 @@ vendor-owned one. To keep it neutral:
   Go library. The API group and the library follow a documented versioning and
   deprecation policy so that any downstream project — regardless of vendor — can
   depend on Karta with predictable upgrade expectations. (This is why the roadmap
-  prioritizes moving off a vendor-prefixed API group before the API stabilizes.)
+  includes moving off a vendor-prefixed API group before the API stabilizes.)
 - **Open contribution and review.** Contributors and adopters get a fair
   opportunity to reach consensus on features and PRs through the public review
   process, without one organization's priorities overriding the community's.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -5,7 +5,7 @@ that will grow as the contributor community grows.
 
 ## Principles
 
-Karta is run as an open, vendor-neutral project. We aim to:
+Karta is run as an open, vendor-neutral project. The project aims to:
 
 - **Balance the interests of all stakeholders** — contributors, adopters, and the
   broader ecosystem — without favoring any single organization.
@@ -47,7 +47,7 @@ vendor-owned one. To keep it neutral:
 ## Project home and evolution
 
 Karta is committed to vendor-neutral governance. Over time the project intends to
-move to a neutral, community-governed home (a cloud native foundation) once the API
+move to a neutral, community-governed home (a cloud-native foundation) once the API
 group is vendor-neutral and the project demonstrates adoption across multiple
 organizations. Until then it is developed in the open under its current
 organization, accepting external contributions.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,6 +16,10 @@ any Kubernetes workload** — so that schedulers, controllers, dashboards, and
 platforms can inspect, modify, and manage any workload type without writing
 bespoke per-CRD code.
 
+This removes the burden on workload-agnostic tools of diving into the internals
+of each workload type's operator. A tested, verified Karta encodes that structure
+once, so every consumer relies on the same vetted description.
+
 Success looks like: a workload type (built-in, Kubeflow, Ray, KServe, a custom
 CRD, or one that does not exist yet) can be described once with a Karta, and any
 Karta-aware tool understands it for free.
@@ -58,6 +62,7 @@ of the roadmap is itself public and reviewable.
   community can publish, find, and reuse descriptions for common workload types
   instead of every consumer re-bundling its own copies. Turns the bundled
   `docs/samples/` set into a shared, versioned source the ecosystem can pull from.
+  Tracked by [#86](https://github.com/run-ai/karta/issues/86).
 
 ## Next
 
@@ -89,8 +94,8 @@ vendor-neutral v1beta1.**
   prerequisite for vendor-neutral governance (see [GOVERNANCE.md](GOVERNANCE.md)).
 - **Karta-aware tooling ecosystem.** Karta is most valuable when many tools read
   and act on the same description. Karta itself stays a thin, neutral contract;
-  richer behavior lives in separately-governed consumer projects. The tools the
-  project intends to grow or integrate around the contract:
+  richer behavior lives in separate projects across the Karta ecosystem. Examples
+  of such ecosystem projects that read and act on the contract:
   - **CLI** — read-only visibility: list and drill into any Karta-described
     workload from the command line.
   - **Headlamp plugin** — the GUI face of visibility, built on the CNCF

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,133 @@
+# Karta Roadmap
+
+This document describes where Karta is headed. It is a **living document** — the
+direction is set by the community and reviewed regularly, so items move, change,
+or drop as we learn. Dates are intentionally avoided in favor of **Now / Next /
+Later** horizons; concrete delivery is tracked in
+[GitHub issues](https://github.com/run-ai/karta/issues) and milestones.
+
+For the day-to-day picture of what is actively being built, the issue tracker is
+the source of truth. This page is the *why* and the *order*.
+
+## Vision
+
+Karta aims to be **the standard, vendor-neutral way to describe the structure of
+any Kubernetes workload** — so that schedulers, controllers, dashboards, and
+platforms can inspect, modify, and manage any workload type without writing
+bespoke per-CRD code.
+
+Success looks like: a workload type (built-in, Kubeflow, Ray, KServe, a custom
+CRD, or one that does not exist yet) can be described once with a Karta, and any
+Karta-aware tool understands it for free.
+
+## How this roadmap works
+
+- **Now** — actively in progress; tracked by open issues with current activity.
+- **Next** — agreed direction, scheduled after the *Now* set lands.
+- **Later** — directional intent; shape and timing still open to community input.
+
+Anyone can propose a change to this roadmap by opening a GitHub issue or raising
+it in a community discussion. Roadmap changes are reviewed by the maintainers
+(see [MAINTAINERS.md](MAINTAINERS.md)) and merged via pull request, so the history
+of the roadmap is itself public and reviewable.
+
+---
+
+## Now
+
+**Theme: make Karta a standalone, shippable project.**
+
+- **Karta controller / operator.** A standalone controller that reconciles Karta
+  resources and the workloads they describe — today the core processing lives in
+  the Go library only. This is the foundational piece that turns Karta from a
+  library into a deployable project.
+  Tracked by [#34](https://github.com/run-ai/karta/issues/34) (epic) and
+  [#35](https://github.com/run-ai/karta/issues/35) (design), with task issues
+  #67–#72 (core logic, conditions, packaging, end-to-end tests).
+- **Validated, non-rotting examples.** Automated tests that check the bundled
+  Karta definitions against the upstream CRDs they target, so the
+  [`docs/examples/`](docs/examples/) set stays correct as upstream APIs evolve.
+  Tracked by [#79](https://github.com/run-ai/karta/issues/79).
+- **Workload visibility.** Tooling to render and explore the structure of any
+  Karta-described workload — the most approachable on-ramp to the project.
+  Tracked by [#32](https://github.com/run-ai/karta/issues/32).
+
+## Next
+
+**Theme: deepen the contract — discovery, hierarchy, breadth — on the path to a
+vendor-neutral v1beta1.**
+
+- **Workload tree / hierarchy.** First-class representation and traversal of a
+  workload's full resource tree — root component down through child components to
+  the pods — so consumers can reason about and render the whole structure, not
+  just individual fields. This is the structural backbone the visibility tooling
+  renders.
+- **Karta as a registry.** A discoverable catalog of Karta definitions, so the
+  community can publish, find, and reuse descriptions for common workload types
+  instead of every consumer re-bundling its own copies. Turns the bundled
+  `docs/examples/` set into a shared, versioned source the ecosystem can pull from.
+- **Broader, tested workload coverage.** Expand the pre-built, tested example set
+  and keep pace with upstream APIs of the workloads Karta describes — including
+  **Kubeflow Trainer v2** and Dynamo `v1beta1`
+  ([#78](https://github.com/run-ai/karta/issues/78)).
+- **Vendor-neutral API group.** Move the Karta API off the current
+  `run.ai`-prefixed group to a neutral group **before** the API stabilizes, so
+  adopters never have to migrate a vendor-prefixed group later. This is a
+  prerequisite for vendor-neutral governance (see [GOVERNANCE.md](GOVERNANCE.md)).
+- **API versioning toward v1beta1.** A documented versioning and deprecation
+  policy, and graduation of the CRD from `v1alpha1` toward `v1beta1` as the
+  schema settles.
+- **Cross-resource expressions.** Let a Karta reference values from related
+  resources in its path expressions
+  ([#80](https://github.com/run-ai/karta/issues/80)).
+- **Packaging & install.** Helm chart hardening, including a CRD upgrade hook
+  ([#43](https://github.com/run-ai/karta/issues/43)).
+
+## Later
+
+**Theme: ecosystem.**
+
+*Later items are directional, not commitments — order and shape will change with community input.*
+
+- **Karta-aware tooling ecosystem.** Karta is most valuable when many tools read
+  and act on the same description. Karta itself stays a thin, neutral contract;
+  richer behavior lives in separately-governed consumer projects. The tools we
+  intend to grow or integrate around the contract:
+  - **CLI** — read-only visibility: list and drill into any Karta-described
+    workload from the command line.
+  - **Headlamp plugin** — the GUI face of visibility, built on the CNCF
+    [Headlamp](https://github.com/kubernetes-sigs/headlamp) project rather than a
+    bespoke dashboard.
+  - **Mutation runtime** — a controller that submits and mutates workloads and
+    provisions secondary resources from a Karta description, without per-CRD code.
+  - **Governance / policy engine** — admission- and runtime-level rules
+    (filter / condition / action) applied to Karta-described workloads, including
+    descheduling and rebalancing.
+
+  We will document clear integration patterns so anyone can build their own
+  Karta-aware tool.
+- **Community engagement with related projects.** Engage the relevant upstream
+  communities (workload and scheduling SIGs/TAGs, queueing and gang-scheduling
+  projects) to position Karta as complementary infrastructure — *how to read and
+  modify the structure of a workload* — rather than as a competing scheduler or
+  queue.
+
+---
+
+## What we are *not* doing
+
+Karta deliberately stays narrow. It describes workload **structure**; it does not
+schedule, queue, autoscale, or own a workload's lifecycle. Those belong to the
+tools that consume a Karta description. Keeping Karta a thin contract is what lets
+it stay vendor-neutral and broadly adoptable.
+
+## Get involved
+
+- Browse [open issues](https://github.com/run-ai/karta/issues) and look for
+  `good first issue` and `help wanted` labels.
+- Have a workload type Karta should describe? Open an issue or contribute an
+  example to [`docs/examples/`](docs/examples/).
+- Read [CONTRIBUTING.md](CONTRIBUTING.md) to get started (DCO sign-off required).
+
+*This roadmap is reviewed regularly and updated as priorities shift with
+community input.*

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -46,34 +46,28 @@ of the roadmap is itself public and reviewable.
   #67–#72 (core logic, conditions, packaging, end-to-end tests).
 - **Validated, non-rotting examples.** Automated tests that check the bundled
   Karta definitions against the upstream CRDs they target, so the
-  [`docs/examples/`](docs/examples/) set stays correct as upstream APIs evolve.
+  [`docs/samples/`](docs/samples/) set stays correct as upstream APIs evolve.
   Tracked by [#79](https://github.com/run-ai/karta/issues/79).
 - **Workload visibility.** Tooling to render and explore the structure of any
-  Karta-described workload — the most approachable on-ramp to the project.
-  Tracked by [#32](https://github.com/run-ai/karta/issues/32).
-
-## Next
-
-**Theme: deepen the contract — discovery, hierarchy, breadth — on the path to a
-vendor-neutral v1beta1.**
-
-- **Workload tree / hierarchy.** First-class representation and traversal of a
-  workload's full resource tree — root component down through child components to
-  the pods — so consumers can reason about and render the whole structure, not
-  just individual fields. This is the structural backbone the visibility tooling
-  renders.
+  Karta-described workload — the most approachable on-ramp to the project. This
+  rests on a first-class workload tree: traversal of a workload's full resource
+  tree, from the root component down through child components to the pods, so
+  consumers can reason about and render the whole structure rather than individual
+  fields. Tracked by [#32](https://github.com/run-ai/karta/issues/32).
 - **Karta as a registry.** A discoverable catalog of Karta definitions, so the
   community can publish, find, and reuse descriptions for common workload types
   instead of every consumer re-bundling its own copies. Turns the bundled
-  `docs/examples/` set into a shared, versioned source the ecosystem can pull from.
+  `docs/samples/` set into a shared, versioned source the ecosystem can pull from.
+
+## Next
+
+**Theme: deepen the contract — breadth and richer expressions — on the path to a
+vendor-neutral v1beta1.**
+
 - **Broader, tested workload coverage.** Expand the pre-built, tested example set
   and keep pace with upstream APIs of the workloads Karta describes — including
   **Kubeflow Trainer v2** and Dynamo `v1beta1`
   ([#78](https://github.com/run-ai/karta/issues/78)).
-- **Vendor-neutral API group.** Move the Karta API off the current
-  `run.ai`-prefixed group to a neutral group **before** the API stabilizes, so
-  adopters never have to migrate a vendor-prefixed group later. This is a
-  prerequisite for vendor-neutral governance (see [GOVERNANCE.md](GOVERNANCE.md)).
 - **API versioning toward v1beta1.** A documented versioning and deprecation
   policy, and graduation of the CRD from `v1alpha1` toward `v1beta1` as the
   schema settles.
@@ -89,6 +83,10 @@ vendor-neutral v1beta1.**
 
 *Later items are directional, not commitments — order and shape will change with community input.*
 
+- **Vendor-neutral API group.** Move the Karta API off the current
+  `run.ai`-prefixed group to a neutral group **before** the API stabilizes, so
+  adopters never have to migrate a vendor-prefixed group later. This is a
+  prerequisite for vendor-neutral governance (see [GOVERNANCE.md](GOVERNANCE.md)).
 - **Karta-aware tooling ecosystem.** Karta is most valuable when many tools read
   and act on the same description. Karta itself stays a thin, neutral contract;
   richer behavior lives in separately-governed consumer projects. The tools the
@@ -126,7 +124,7 @@ it stay vendor-neutral and broadly adoptable.
 - Browse [open issues](https://github.com/run-ai/karta/issues) and look for
   `good first issue` and `help wanted` labels.
 - Have a workload type Karta should describe? Open an issue or contribute an
-  example to [`docs/examples/`](docs/examples/).
+  example to [`docs/samples/`](docs/samples/).
 - Read [CONTRIBUTING.md](CONTRIBUTING.md) to get started (DCO sign-off required).
 
 *This roadmap is reviewed regularly and updated as priorities shift with

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 This document describes where Karta is headed. It is a **living document** — the
 direction is set by the community and reviewed regularly, so items move, change,
-or drop as we learn. Dates are intentionally avoided in favor of **Now / Next /
+or drop as the project learns. Dates are intentionally avoided in favor of **Now / Next /
 Later** horizons; concrete delivery is tracked in
 [GitHub issues](https://github.com/run-ai/karta/issues) and milestones.
 
@@ -91,8 +91,8 @@ vendor-neutral v1beta1.**
 
 - **Karta-aware tooling ecosystem.** Karta is most valuable when many tools read
   and act on the same description. Karta itself stays a thin, neutral contract;
-  richer behavior lives in separately-governed consumer projects. The tools we
-  intend to grow or integrate around the contract:
+  richer behavior lives in separately-governed consumer projects. The tools the
+  project intends to grow or integrate around the contract:
   - **CLI** — read-only visibility: list and drill into any Karta-described
     workload from the command line.
   - **Headlamp plugin** — the GUI face of visibility, built on the CNCF
@@ -104,7 +104,7 @@ vendor-neutral v1beta1.**
     (filter / condition / action) applied to Karta-described workloads, including
     descheduling and rebalancing.
 
-  We will document clear integration patterns so anyone can build their own
+  Clear integration patterns will be documented so anyone can build their own
   Karta-aware tool.
 - **Community engagement with related projects.** Engage the relevant upstream
   communities (workload and scheduling SIGs/TAGs, queueing and gang-scheduling
@@ -114,7 +114,7 @@ vendor-neutral v1beta1.**
 
 ---
 
-## What we are *not* doing
+## Non-goals
 
 Karta deliberately stays narrow. It describes workload **structure**; it does not
 schedule, queue, autoscale, or own a workload's lifecycle. Those belong to the


### PR DESCRIPTION
## What does this PR do?

Adds a public `ROADMAP.md` and `GOVERNANCE.md`, validated against CNCF/K8s-ecosystem roadmap convention (Kueue, Karpenter, KEDA, Crossplane, Cluster API, Headlamp).

- **ROADMAP.md** — Now/Next/Later horizons (no hard dates, pre-1.0), each item linked to existing tracking issues; documents the roadmap change process.
- **GOVERNANCE.md** — maintainers/decision-making (points to MAINTAINERS.md), vendor-neutrality principles, and project-home/evolution intent.

Governance/vendor-neutrality prose is kept in GOVERNANCE.md rather than the roadmap, per ecosystem convention.

## Related issue(s)

Fixes #88

## Checklist

- [x] All commits are signed off with DCO (`git commit -s`)
- [x] New/modified files have SPDX license and copyright headers — N/A (docs; matches existing community files, none carry SPDX headers)
- [x] Documentation updated (this PR is documentation)
- [x] Tests pass (`make check`) — N/A (docs-only change)
- [x] No proprietary or internal information included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added governance documentation defining decision-making (lazy consensus/majority fallback), core principles (open, vendor-neutral operation), vendor-neutrality safeguards, intended evolution toward a neutral foundation, and the process for updating governance; references the project code of conduct.
  * Added a living roadmap outlining the project vision for vendor-neutral Kubernetes workload descriptions, Now/Next/Later horizons, planned initiatives, non-goals, and contribution/get-involved guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->