### PR TITLE
Helm operator chart

### DIFF
--- a/charts/karta/templates/_helpers.tpl
+++ b/charts/karta/templates/_helpers.tpl
@@ -1,0 +1,54 @@
+{{/*
+Copyright 2025 NVIDIA CORPORATION
+SPDX-License-Identifier: Apache-2.0
+*/}}
+
+{{/*
+Base name for resources. Defaults to the chart name, overridable via nameOverride.
+*/}}
+{{- define "karta.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Fully qualified resource name. Defaults to "<name>-operator" (e.g. "karta-operator"),
+overridable wholesale via fullnameOverride. Truncated to 63 chars for the DNS label limit.
+*/}}
+{{- define "karta.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-operator" (include "karta.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Common labels stamped onto every resource.
+*/}}
+{{- define "karta.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{ include "karta.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels. These must be stable across upgrades, so they intentionally
+exclude version/chart labels (which change between releases).
+*/}}
+{{- define "karta.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "karta.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Name of the ServiceAccount to use. Honors serviceAccount.name when set,
+otherwise derives from the fullname.
+*/}}
+{{- define "karta.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "karta.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}

--- a/charts/karta/templates/_helpers.tpl
+++ b/charts/karta/templates/_helpers.tpl
@@ -49,6 +49,6 @@ otherwise derives from the fullname.
 {{- if .Values.serviceAccount.create -}}
 {{- default (include "karta.fullname" .) .Values.serviceAccount.name -}}
 {{- else -}}
-{{- default "default" .Values.serviceAccount.name -}}
++{{- required "serviceAccount.name must be set when serviceAccount.create=false" .Values.serviceAccount.name -}}
 {{- end -}}
 {{- end -}}

--- a/charts/karta/templates/_helpers.tpl
+++ b/charts/karta/templates/_helpers.tpl
@@ -1,7 +1,3 @@
-{{/*
-Copyright 2025 NVIDIA CORPORATION
-SPDX-License-Identifier: Apache-2.0
-*/}}
 
 {{/*
 Fully qualified resource name: "<chart-name>-operator" (e.g. "karta-operator").

--- a/charts/karta/templates/_helpers.tpl
+++ b/charts/karta/templates/_helpers.tpl
@@ -1,7 +1,5 @@
-{{/*
-Copyright 2025 NVIDIA CORPORATION
-SPDX-License-Identifier: Apache-2.0
-*/}}
+# Copyright 2025 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
 
 {{/*
 Base name for resources. Defaults to the chart name, overridable via nameOverride.

--- a/charts/karta/templates/_helpers.tpl
+++ b/charts/karta/templates/_helpers.tpl
@@ -1,10 +1,6 @@
 # Copyright 2025 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-{{- define "karta.name" -}}
-{{- .Chart.Name -}}
-{{- end -}}
-
 {{/*
 Fully qualified resource name: "<chart-name>-operator" (e.g. "karta-operator").
 Override wholesale via fullnameOverride.
@@ -13,7 +9,7 @@ Override wholesale via fullnameOverride.
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- printf "%s-operator" (include "karta.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-operator" .Chart.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 
@@ -32,7 +28,7 @@ Selector labels. These must be stable across upgrades, so they intentionally
 exclude version/chart labels (which change between releases).
 */}}
 {{- define "karta.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "karta.name" . }}
+app.kubernetes.io/name: {{ .Chart.Name }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 

--- a/charts/karta/templates/_helpers.tpl
+++ b/charts/karta/templates/_helpers.tpl
@@ -1,16 +1,13 @@
 # Copyright 2025 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-{{/*
-Base name for resources. Defaults to the chart name, overridable via nameOverride.
-*/}}
 {{- define "karta.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- .Chart.Name -}}
 {{- end -}}
 
 {{/*
-Fully qualified resource name. Defaults to "<name>-operator" (e.g. "karta-operator"),
-overridable wholesale via fullnameOverride. Truncated to 63 chars for the DNS label limit.
+Fully qualified resource name: "<chart-name>-operator" (e.g. "karta-operator").
+Override wholesale via fullnameOverride.
 */}}
 {{- define "karta.fullname" -}}
 {{- if .Values.fullnameOverride -}}

--- a/charts/karta/templates/_helpers.tpl
+++ b/charts/karta/templates/_helpers.tpl
@@ -1,5 +1,7 @@
-# Copyright 2025 NVIDIA CORPORATION
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+Copyright 2025 NVIDIA CORPORATION
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{/*
 Fully qualified resource name: "<chart-name>-operator" (e.g. "karta-operator").

--- a/charts/karta/templates/_helpers.tpl
+++ b/charts/karta/templates/_helpers.tpl
@@ -42,13 +42,13 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{/*
-Name of the ServiceAccount to use. Honors serviceAccount.name when set,
-otherwise derives from the fullname.
+Name of the ServiceAccount to use. When create=true the chart owns the name
+(karta.fullname). When create=false the caller must supply serviceAccount.name.
 */}}
 {{- define "karta.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}
-{{- default (include "karta.fullname" .) .Values.serviceAccount.name -}}
+{{- include "karta.fullname" . -}}
 {{- else -}}
-+{{- required "serviceAccount.name must be set when serviceAccount.create=false" .Values.serviceAccount.name -}}
+{{- required "serviceAccount.name is required when serviceAccount.create is false" .Values.serviceAccount.name -}}
 {{- end -}}
 {{- end -}}

--- a/charts/karta/templates/clusterrole.yaml
+++ b/charts/karta/templates/clusterrole.yaml
@@ -20,7 +20,7 @@ rules:
     verbs: ["get", "list", "watch"]
 
   # Emit Kubernetes events (Warning/Normal) on the Karta objects
-  - apiGroups: [""]
+  - apiGroups: ["events.k8s.io/v1"]
     resources: ["events"]
-    verbs: ["create", "patch"]
+    verbs: ["create", "patch", "update"]
 {{- end -}}

--- a/charts/karta/templates/clusterrole.yaml
+++ b/charts/karta/templates/clusterrole.yaml
@@ -1,7 +1,5 @@
-{{- /*
-Copyright 2025 NVIDIA CORPORATION
-SPDX-License-Identifier: Apache-2.0
-*/ -}}
+# Copyright 2025 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/karta/templates/clusterrole.yaml
+++ b/charts/karta/templates/clusterrole.yaml
@@ -20,7 +20,10 @@ rules:
     verbs: ["get", "list", "watch"]
 
   # Emit Kubernetes events (Warning/Normal) on the Karta objects
-  - apiGroups: ["events.k8s.io/v1"]
-    resources: ["events"]
-    verbs: ["create", "patch", "update"]
+  - apiGroups: [ "" ]
+    resources: [ "events" ]
+    verbs: [ "create", "patch" ]
+  - apiGroups: [ "events.k8s.io" ]
+    resources: [ "events" ]
+    verbs: [ "create", "patch", "update" ]
 {{- end -}}

--- a/charts/karta/templates/clusterrole.yaml
+++ b/charts/karta/templates/clusterrole.yaml
@@ -1,3 +1,7 @@
+{{- /*
+Copyright 2025 NVIDIA CORPORATION
+SPDX-License-Identifier: Apache-2.0
+*/ -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/karta/templates/clusterrole.yaml
+++ b/charts/karta/templates/clusterrole.yaml
@@ -1,5 +1,6 @@
 # Copyright 2025 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
+{{- if .Values.operator.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -24,3 +25,4 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
+{{- end -}}

--- a/charts/karta/templates/clusterrole.yaml
+++ b/charts/karta/templates/clusterrole.yaml
@@ -1,5 +1,7 @@
-# Copyright 2025 NVIDIA CORPORATION
-# SPDX-License-Identifier: Apache-2.0
+{{- /*
+Copyright 2025 NVIDIA CORPORATION
+SPDX-License-Identifier: Apache-2.0
+*/ -}}
 {{- if .Values.operator.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/karta/templates/clusterrole.yaml
+++ b/charts/karta/templates/clusterrole.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "karta.fullname" . }}
+  labels:
+    {{- include "karta.labels" . | nindent 4 }}
+rules:
+  # Reconcile Karta CRs and update their status
+  - apiGroups: ["run.ai"]
+    resources: ["kartas"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["run.ai"]
+    resources: ["kartas/status"]
+    verbs: ["get", "update", "patch"]
+
+  # Watch CRDs to trigger re-reconciliation when a referenced CRD appears or changes
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch"]
+
+  # Emit Kubernetes events (Warning/Normal) on the Karta objects
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]

--- a/charts/karta/templates/clusterrole.yaml
+++ b/charts/karta/templates/clusterrole.yaml
@@ -1,7 +1,3 @@
-{{- /*
-Copyright 2025 NVIDIA CORPORATION
-SPDX-License-Identifier: Apache-2.0
-*/ -}}
 {{- if .Values.operator.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/karta/templates/clusterrolebinding.yaml
+++ b/charts/karta/templates/clusterrolebinding.yaml
@@ -1,7 +1,3 @@
-{{- /*
-Copyright 2025 NVIDIA CORPORATION
-SPDX-License-Identifier: Apache-2.0
-*/ -}}
 {{- if .Values.operator.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/karta/templates/clusterrolebinding.yaml
+++ b/charts/karta/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "karta.fullname" . }}
+  labels:
+    {{- include "karta.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "karta.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "karta.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/karta/templates/clusterrolebinding.yaml
+++ b/charts/karta/templates/clusterrolebinding.yaml
@@ -1,3 +1,7 @@
+{{- /*
+Copyright 2025 NVIDIA CORPORATION
+SPDX-License-Identifier: Apache-2.0
+*/ -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/karta/templates/clusterrolebinding.yaml
+++ b/charts/karta/templates/clusterrolebinding.yaml
@@ -1,5 +1,7 @@
-# Copyright 2025 NVIDIA CORPORATION
-# SPDX-License-Identifier: Apache-2.0
+{{- /*
+Copyright 2025 NVIDIA CORPORATION
+SPDX-License-Identifier: Apache-2.0
+*/ -}}
 {{- if .Values.operator.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/karta/templates/clusterrolebinding.yaml
+++ b/charts/karta/templates/clusterrolebinding.yaml
@@ -1,7 +1,5 @@
-{{- /*
-Copyright 2025 NVIDIA CORPORATION
-SPDX-License-Identifier: Apache-2.0
-*/ -}}
+# Copyright 2025 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/karta/templates/clusterrolebinding.yaml
+++ b/charts/karta/templates/clusterrolebinding.yaml
@@ -1,5 +1,6 @@
 # Copyright 2025 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
+{{- if .Values.operator.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -14,3 +15,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "karta.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/karta/templates/deployment.yaml
+++ b/charts/karta/templates/deployment.yaml
@@ -1,7 +1,3 @@
-{{- /*
-Copyright 2025 NVIDIA CORPORATION
-SPDX-License-Identifier: Apache-2.0
-*/ -}}
 {{- if .Values.operator.enabled -}}
 {{- if and (gt (int .Values.replicaCount) 1) (not .Values.leaderElection.enabled) -}}
   {{- fail "replicaCount > 1 requires leaderElection.enabled=true; without leader election multiple replicas reconcile concurrently" -}}

--- a/charts/karta/templates/deployment.yaml
+++ b/charts/karta/templates/deployment.yaml
@@ -1,3 +1,10 @@
+{{- /*
+Copyright 2025 NVIDIA CORPORATION
+SPDX-License-Identifier: Apache-2.0
+*/ -}}
+{{- if and (gt (int .Values.replicaCount) 1) (not .Values.leaderElection.enabled) -}}
+  {{- fail "replicaCount > 1 requires leaderElection.enabled=true; without leader election multiple replicas reconcile concurrently" -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/karta/templates/deployment.yaml
+++ b/charts/karta/templates/deployment.yaml
@@ -38,10 +38,15 @@ spec:
           image: "{{ required "image.repository is required" .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            {{- toYaml .Values.args | nindent 12 }}
             {{- if .Values.leaderElection.enabled }}
             - --leader-elect
             - --leader-election-id={{ .Values.leaderElection.id }}
+            {{- end }}
+            - --metrics-bind-address=:{{ .Values.ports.metrics }}
+            - --health-probe-bind-address=:{{ .Values.ports.health }}
+            - --zap-log-level={{ .Values.logLevel }}
+            {{- with .Values.extraArgs }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           ports:
             - name: metrics

--- a/charts/karta/templates/deployment.yaml
+++ b/charts/karta/templates/deployment.yaml
@@ -1,5 +1,7 @@
-# Copyright 2025 NVIDIA CORPORATION
-# SPDX-License-Identifier: Apache-2.0
+{{- /*
+Copyright 2025 NVIDIA CORPORATION
+SPDX-License-Identifier: Apache-2.0
+*/ -}}
 {{- if .Values.operator.enabled -}}
 {{- if and (gt (int .Values.replicaCount) 1) (not .Values.leaderElection.enabled) -}}
   {{- fail "replicaCount > 1 requires leaderElection.enabled=true; without leader election multiple replicas reconcile concurrently" -}}

--- a/charts/karta/templates/deployment.yaml
+++ b/charts/karta/templates/deployment.yaml
@@ -1,7 +1,5 @@
-{{- /*
-Copyright 2025 NVIDIA CORPORATION
-SPDX-License-Identifier: Apache-2.0
-*/ -}}
+# Copyright 2025 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
 {{- if and (gt (int .Values.replicaCount) 1) (not .Values.leaderElection.enabled) -}}
   {{- fail "replicaCount > 1 requires leaderElection.enabled=true; without leader election multiple replicas reconcile concurrently" -}}
 {{- end -}}

--- a/charts/karta/templates/deployment.yaml
+++ b/charts/karta/templates/deployment.yaml
@@ -1,5 +1,6 @@
 # Copyright 2025 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
+{{- if .Values.operator.enabled -}}
 {{- if and (gt (int .Values.replicaCount) 1) (not .Values.leaderElection.enabled) -}}
   {{- fail "replicaCount > 1 requires leaderElection.enabled=true; without leader election multiple replicas reconcile concurrently" -}}
 {{- end -}}
@@ -79,3 +80,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end -}}

--- a/charts/karta/templates/deployment.yaml
+++ b/charts/karta/templates/deployment.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "karta.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "karta.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "karta.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "karta.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "karta.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ required "image.repository is required" .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            {{- toYaml .Values.args | nindent 12 }}
+            {{- if .Values.leaderElection.enabled }}
+            - --leader-elect
+            - --leader-election-id={{ .Values.leaderElection.id }}
+            {{- end }}
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.ports.metrics }}
+            - name: health
+              containerPort: {{ .Values.ports.health }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/karta/templates/leader-election-role.yaml
+++ b/charts/karta/templates/leader-election-role.yaml
@@ -1,7 +1,5 @@
-{{- /*
-Copyright 2025 NVIDIA CORPORATION
-SPDX-License-Identifier: Apache-2.0
-*/ -}}
+# Copyright 2025 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
 {{- if .Values.leaderElection.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/charts/karta/templates/leader-election-role.yaml
+++ b/charts/karta/templates/leader-election-role.yaml
@@ -1,5 +1,7 @@
-# Copyright 2025 NVIDIA CORPORATION
-# SPDX-License-Identifier: Apache-2.0
+{{- /*
+Copyright 2025 NVIDIA CORPORATION
+SPDX-License-Identifier: Apache-2.0
+*/ -}}
 {{- if and .Values.operator.enabled .Values.leaderElection.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/charts/karta/templates/leader-election-role.yaml
+++ b/charts/karta/templates/leader-election-role.yaml
@@ -1,3 +1,7 @@
+{{- /*
+Copyright 2025 NVIDIA CORPORATION
+SPDX-License-Identifier: Apache-2.0
+*/ -}}
 {{- if .Values.leaderElection.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/charts/karta/templates/leader-election-role.yaml
+++ b/charts/karta/templates/leader-election-role.yaml
@@ -1,6 +1,6 @@
 # Copyright 2025 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
-{{- if .Values.leaderElection.enabled -}}
+{{- if and .Values.operator.enabled .Values.leaderElection.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/karta/templates/leader-election-role.yaml
+++ b/charts/karta/templates/leader-election-role.yaml
@@ -1,7 +1,3 @@
-{{- /*
-Copyright 2025 NVIDIA CORPORATION
-SPDX-License-Identifier: Apache-2.0
-*/ -}}
 {{- if and .Values.operator.enabled .Values.leaderElection.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/charts/karta/templates/leader-election-role.yaml
+++ b/charts/karta/templates/leader-election-role.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.leaderElection.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "karta.fullname" . }}-leader-election
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "karta.labels" . | nindent 4 }}
+rules:
+  # Leader election coordinates active/passive replicas via a Lease object in
+  # the operator's own namespace. Event permissions are already granted by the
+  # ClusterRole, so they are not repeated here.
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+{{- end -}}

--- a/charts/karta/templates/leader-election-rolebinding.yaml
+++ b/charts/karta/templates/leader-election-rolebinding.yaml
@@ -1,7 +1,3 @@
-{{- /*
-Copyright 2025 NVIDIA CORPORATION
-SPDX-License-Identifier: Apache-2.0
-*/ -}}
 {{- if and .Values.operator.enabled .Values.leaderElection.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/karta/templates/leader-election-rolebinding.yaml
+++ b/charts/karta/templates/leader-election-rolebinding.yaml
@@ -1,6 +1,6 @@
 # Copyright 2025 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
-{{- if .Values.leaderElection.enabled -}}
+{{- if and .Values.operator.enabled .Values.leaderElection.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/karta/templates/leader-election-rolebinding.yaml
+++ b/charts/karta/templates/leader-election-rolebinding.yaml
@@ -1,3 +1,7 @@
+{{- /*
+Copyright 2025 NVIDIA CORPORATION
+SPDX-License-Identifier: Apache-2.0
+*/ -}}
 {{- if .Values.leaderElection.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/karta/templates/leader-election-rolebinding.yaml
+++ b/charts/karta/templates/leader-election-rolebinding.yaml
@@ -1,5 +1,7 @@
-# Copyright 2025 NVIDIA CORPORATION
-# SPDX-License-Identifier: Apache-2.0
+{{- /*
+Copyright 2025 NVIDIA CORPORATION
+SPDX-License-Identifier: Apache-2.0
+*/ -}}
 {{- if and .Values.operator.enabled .Values.leaderElection.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/karta/templates/leader-election-rolebinding.yaml
+++ b/charts/karta/templates/leader-election-rolebinding.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.leaderElection.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "karta.fullname" . }}-leader-election
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "karta.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "karta.fullname" . }}-leader-election
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "karta.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/karta/templates/leader-election-rolebinding.yaml
+++ b/charts/karta/templates/leader-election-rolebinding.yaml
@@ -1,7 +1,5 @@
-{{- /*
-Copyright 2025 NVIDIA CORPORATION
-SPDX-License-Identifier: Apache-2.0
-*/ -}}
+# Copyright 2025 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
 {{- if .Values.leaderElection.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/karta/templates/serviceaccount.yaml
+++ b/charts/karta/templates/serviceaccount.yaml
@@ -1,7 +1,3 @@
-{{- /*
-Copyright 2025 NVIDIA CORPORATION
-SPDX-License-Identifier: Apache-2.0
-*/ -}}
 {{- if and .Values.operator.enabled .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/karta/templates/serviceaccount.yaml
+++ b/charts/karta/templates/serviceaccount.yaml
@@ -1,7 +1,5 @@
-{{- /*
-Copyright 2025 NVIDIA CORPORATION
-SPDX-License-Identifier: Apache-2.0
-*/ -}}
+# Copyright 2025 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/karta/templates/serviceaccount.yaml
+++ b/charts/karta/templates/serviceaccount.yaml
@@ -1,3 +1,7 @@
+{{- /*
+Copyright 2025 NVIDIA CORPORATION
+SPDX-License-Identifier: Apache-2.0
+*/ -}}
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/karta/templates/serviceaccount.yaml
+++ b/charts/karta/templates/serviceaccount.yaml
@@ -1,5 +1,7 @@
-# Copyright 2025 NVIDIA CORPORATION
-# SPDX-License-Identifier: Apache-2.0
+{{- /*
+Copyright 2025 NVIDIA CORPORATION
+SPDX-License-Identifier: Apache-2.0
+*/ -}}
 {{- if and .Values.operator.enabled .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/karta/templates/serviceaccount.yaml
+++ b/charts/karta/templates/serviceaccount.yaml
@@ -1,6 +1,6 @@
 # Copyright 2025 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
-{{- if .Values.serviceAccount.create -}}
+{{- if and .Values.operator.enabled .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/karta/templates/serviceaccount.yaml
+++ b/charts/karta/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "karta.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "karta.labels" . | nindent 4 }}
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end -}}

--- a/charts/karta/values.yaml
+++ b/charts/karta/values.yaml
@@ -1,0 +1,83 @@
+# Copyright 2025 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+# Default values for the karta operator chart.
+# Override any of these with --set key=value or -f my-values.yaml.
+
+# Override the base name used for resources. Empty = use the chart name ("karta").
+nameOverride: ""
+# Override the full resource name outright. Empty = "<name>-operator".
+fullnameOverride: ""
+
+# Number of operator replicas. Keep this at 1 unless leaderElection.enabled is
+# true; without leader election multiple replicas would reconcile concurrently.
+replicaCount: 1
+
+# Leader election lets you run more than one replica safely (active/passive):
+# only the replica holding the lease reconciles. When enabled, the chart also
+# creates a namespaced Role/RoleBinding granting access to the lease object.
+leaderElection:
+  enabled: false
+  # Name of the Lease object used to coordinate leadership.
+  id: karta-operator.run.ai
+
+image:
+  # Container registry + image name. Defaults to the published OSS image.
+  repository: ghcr.io/run-ai/karta/karta-operator
+  # Image tag. When empty, the chart falls back to .Chart.AppVersion,
+  # so the chart version and image version stay in lockstep.
+  tag: ""
+  pullPolicy: IfNotPresent
+
+# Optional image pull secrets for private registries (list of {name: ...}).
+imagePullSecrets: []
+
+# Annotations applied to the operator pod template (e.g. Prometheus scrape hints).
+podAnnotations: {}
+
+serviceAccount:
+  # When true, the chart creates the ServiceAccount. Set false to use an
+  # externally managed one (then set the name below).
+  create: true
+  # Leave empty to use the chart's default name.
+  name: ""
+
+# Flags passed to the operator binary.
+args:
+  - --metrics-bind-address=:8080
+  - --health-probe-bind-address=:8081
+  - --zap-log-level=info
+
+# Container ports exposed by the operator.
+ports:
+  metrics: 8080
+  health: 8081
+
+# Pod-level security context.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 0
+  seccompProfile:
+    type: RuntimeDefault
+
+# Container-level security context.
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 200m
+    memory: 128Mi
+
+# Optional scheduling controls.
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/charts/karta/values.yaml
+++ b/charts/karta/values.yaml
@@ -4,6 +4,10 @@
 # Default values for the karta operator chart.
 # Override with --set key=value or -f my-values.yaml.
 
+# Set false to install only the CRD, without deploying the operator workload.
+operator:
+  enabled: true
+
 # Overrides for resource names. Rarely needed.
 fullnameOverride: ""
 

--- a/charts/karta/values.yaml
+++ b/charts/karta/values.yaml
@@ -2,58 +2,49 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Default values for the karta operator chart.
-# Override any of these with --set key=value or -f my-values.yaml.
+# Override with --set key=value or -f my-values.yaml.
 
-# Override the base name used for resources. Empty = use the chart name ("karta").
+# Overrides for resource names. Rarely needed.
 nameOverride: ""
-# Override the full resource name outright. Empty = "<name>-operator".
 fullnameOverride: ""
 
-# Number of operator replicas. Keep this at 1 unless leaderElection.enabled is
-# true; without leader election multiple replicas would reconcile concurrently.
+# Keep at 1 unless leaderElection.enabled is true; without leader election
+# multiple replicas would reconcile concurrently.
 replicaCount: 1
 
-# Leader election lets you run more than one replica safely (active/passive):
-# only the replica holding the lease reconciles. When enabled, the chart also
-# creates a namespaced Role/RoleBinding granting access to the lease object.
+# When enabled, only the replica holding the lease reconciles (active/passive).
+# The chart also creates a namespaced Role/RoleBinding for the lease object.
 leaderElection:
   enabled: false
-  # Name of the Lease object used to coordinate leadership.
   id: karta-operator.run.ai
 
 image:
-  # Container registry + image name. Defaults to the published OSS image.
   repository: ghcr.io/run-ai/karta/karta-operator
-  # Image tag. When empty, the chart falls back to .Chart.AppVersion,
-  # so the chart version and image version stay in lockstep.
+  # When empty, falls back to .Chart.AppVersion so chart and image versions
+  # stay in lockstep.
   tag: ""
   pullPolicy: IfNotPresent
 
-# Optional image pull secrets for private registries (list of {name: ...}).
+# Image pull secrets for private registries.
 imagePullSecrets: []
 
-# Annotations applied to the operator pod template (e.g. Prometheus scrape hints).
+# Pod annotations (e.g. Prometheus scrape hints).
 podAnnotations: {}
 
 serviceAccount:
-  # When true, the chart creates the ServiceAccount. Set false to use an
-  # externally managed one (then set the name below).
+  # Set false to use an externally managed ServiceAccount (set name below).
   create: true
-  # Leave empty to use the chart's default name.
   name: ""
 
-# Flags passed to the operator binary.
 args:
   - --metrics-bind-address=:8080
   - --health-probe-bind-address=:8081
   - --zap-log-level=info
 
-# Container ports exposed by the operator.
 ports:
   metrics: 8080
   health: 8081
 
-# Pod-level security context.
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 65532
@@ -61,7 +52,6 @@ podSecurityContext:
   seccompProfile:
     type: RuntimeDefault
 
-# Container-level security context.
 securityContext:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
@@ -77,7 +67,6 @@ resources:
     cpu: 200m
     memory: 128Mi
 
-# Optional scheduling controls.
 nodeSelector: {}
 tolerations: []
 affinity: {}

--- a/charts/karta/values.yaml
+++ b/charts/karta/values.yaml
@@ -5,7 +5,6 @@
 # Override with --set key=value or -f my-values.yaml.
 
 # Overrides for resource names. Rarely needed.
-nameOverride: ""
 fullnameOverride: ""
 
 # Keep at 1 unless leaderElection.enabled is true; without leader election
@@ -34,16 +33,18 @@ podAnnotations: {}
 serviceAccount:
   # Set false to use an externally managed ServiceAccount (set name below).
   create: true
+  # Only used when create: false — name of the externally managed SA.
   name: ""
-
-args:
-  - --metrics-bind-address=:8080
-  - --health-probe-bind-address=:8081
-  - --zap-log-level=info
 
 ports:
   metrics: 8080
   health: 8081
+
+logLevel: info
+
+# Extra flags appended after the chart's default args. Use this to add flags
+# without replacing the defaults entirely.
+extraArgs: []
 
 podSecurityContext:
   runAsNonRoot: true

--- a/charts/karta/values.yaml
+++ b/charts/karta/values.yaml
@@ -1,6 +1,3 @@
-# Copyright 2025 NVIDIA CORPORATION
-# SPDX-License-Identifier: Apache-2.0
-
 # Default values for the karta operator chart.
 # Override with --set key=value or -f my-values.yaml.
 


### PR DESCRIPTION
## What does this PR do?

The `charts/karta/` chart previously shipped only the CRD. This PR makes it possible to deploy the operator via Helm.


## Related issue(s)

<!-- Every PR must reference at least one open GitHub issue -->
Fixes #

## Checklist

- [ ] All commits are signed off with DCO (`git commit -s`)
- [ ] New/modified files have SPDX license and copyright headers
- [ ] Documentation updated (if applicable)
- [ ] Tests pass (`make check`)
- [ ] No proprietary or internal information included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a Helm chart for the karta operator with a Deployment, optional ServiceAccount, and supporting templates.
  * Added RBAC for managing Karta resources and emitting events, plus optional leader-election Role/RoleBinding.
  * Enabled metrics/health endpoints with liveness/readiness probes and configurable image, resources, security, and scheduling.
  * Introduced standard naming and labeling helpers for consistent manifests.

* **Behavior Changes**
  * If ServiceAccount creation is disabled, you must supply an existing ServiceAccount name.
  * If running more than one replica, leader election must be enabled (otherwise chart rendering fails).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->