### PR TITLE
docs: harden OSS health docs (security policy, code of conduct, contributing)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,84 +1,82 @@
 # Contributor Covenant Code of Conduct
 
-## Overview
-
-Define the code of conduct followed and enforced for Karta.
-
-### Intended audience
-
-Community | Developers | Project Leads
-
 ## Our Pledge
 
-In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
-appearance, race, religion, or sexual identity and orientation.
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
 
 ## Our Standards
 
-Examples of behavior that contributes to creating a positive environment
-include:
+Examples of behavior that contributes to a positive environment for our
+community include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
 
-Examples of unacceptable behavior by participants include:
+Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
-  advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
 * Public or private harassment
-* Publishing others' private information, such as a physical or electronic
-  address, without explicit permission
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
 * Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
-## Our Responsibilities
+## Enforcement Responsibilities
 
-Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
 
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
 
 ## Scope
 
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
 
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting GitHub_Conduct@nvidia.com. All complaints will be reviewed and
-investigated and will result in a response that is deemed necessary and appropriate
-to the circumstances. The project team is obligated to maintain confidentiality with
-regard to the reporter of an incident. Further details of specific enforcement policies
-may be posted separately.
+reported to the community leaders responsible for enforcement at
+GitHub_Conduct@nvidia.com.
+All complaints will be reviewed and investigated promptly and fairly.
 
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
 
 [homepage]: https://www.contributor-covenant.org
-
-For answers to common questions about this code of conduct, see
-https://www.contributor-covenant.org/faq
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,32 @@ For more information about the DCO, please visit: https://developercertificate.o
 3. Every pull request must reference at least one open GitHub issue in its description. This ensures that all changes are tracked and linked to project requirements or bug reports.
 4. For major changes, please open an issue first to discuss the proposed changes
 
+### Development Environment Setup
 
+Karta is a Go project. To set up a local environment:
+
+```bash
+# 1. Clone your fork
+git clone https://github.com/<your-username>/karta.git
+cd karta
+
+# 2. Build the packages (uses the Go version pinned in go.mod)
+go build ./...
+
+# 3. Run the full check pipeline (codegen, manifests, licenses, and tests) -
+#    this is the same target CI runs
+make check
+
+# 4. Lint the Go code and the Helm chart
+make lint
+make helm-lint
+make helm-validate
+```
+
+CI runs `make check` along with `golangci-lint` and the Helm `lint`/`validate`
+steps on every pull request. Running `make check` and `make lint` locally first
+is the fastest way to catch issues before pushing. If you only need a quick test
+pass, `make test` runs the tests and mock generation on their own.
 
 ### Making Changes
 
@@ -99,6 +124,19 @@ For more information about the DCO, please visit: https://developercertificate.o
 2. Your pull request will be reviewed by maintainers
 3. Address any feedback or requested changes
 4. Once approved, your changes will be merged
+
+### Review Process
+
+- Who reviews: pull requests are reviewed by the project
+  [maintainers](MAINTAINERS.md). Relevant maintainers are added automatically;
+  you do not need to request reviewers manually.
+- Turnaround: maintainers aim to provide an initial response within 5
+  business days. Smaller, focused pull requests are reviewed faster.
+- Approvals: at least one maintainer approval is required before merging,
+  and all CI checks must pass.
+- Following up: if your pull request has not received a response within the
+  expected window, please leave a comment to nudge the maintainers, or mention
+  it in the related issue.
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 **A standard way to describe the structure of any Kubernetes workload type.**
 
-Karta lets you define a portable, declarative blueprint for any Kubernetes workload — whether it's a simple Deployment, a distributed PyTorchJob, or a custom CRD. Controllers and platforms can then use that blueprint to inspect, modify, and manage workloads without hard-coding knowledge of each type.
+Karta lets you define a portable, declarative blueprint for any Kubernetes workload - whether it's a simple Deployment, a distributed PyTorchJob, or a custom CRD. Controllers and platforms can then use that blueprint to inspect, modify, and manage workloads without hard-coding knowledge of each type.
 
 ## The Problem
 
-In Kubernetes, and especially in AI systems, a workload is not a standalone execution unit such as a single Pod. Instead, it is composed of multiple components organized in a complex hierarchy of resources, often exposed via custom resource definitions (CRDs) — for example: PyTorchJob, RayCluster, and MPIJob. Each of these CRDs structures the workload configuration differently, but they all share the same conceptual building blocks: pod specifications, scaling parameters, and status definitions.
+In Kubernetes, and especially in AI systems, a workload is not a standalone execution unit such as a single Pod. Instead, it is composed of multiple components organized in a complex hierarchy of resources, often exposed via custom resource definitions (CRDs) - for example: PyTorchJob, RayCluster, and MPIJob. Each of these CRDs structures the workload configuration differently, but they all share the same conceptual building blocks: pod specifications, scaling parameters, and status definitions.
 
 If you're building a controller, scheduler, or platform that needs to work with multiple workload types, you end up writing bespoke logic for each one:
 
@@ -15,7 +15,7 @@ If you're building a controller, scheduler, or platform that needs to work with 
 - Which status conditions mean "running" vs "failed"?
 - How do I modify the pod spec without breaking the workload?
 
-This doesn't scale. Every new workload type means new integration code — schedulers, controllers, and platforms all end up maintaining per-CRD adapters that implement the same patterns over and over.
+This doesn't scale. Every new workload type means new integration code - schedulers, controllers, and platforms all end up maintaining per-CRD adapters that implement the same patterns over and over.
 
 ## The Solution
 
@@ -56,7 +56,7 @@ go get github.com/run-ai/karta@latest
 
 ### Define a Karta
 
-Here's a Karta for a JobSet — a distributed training workload with master and worker groups:
+Here's a Karta for a JobSet - a distributed training workload with master and worker groups:
 
 ```yaml
 apiVersion: run.ai/v1alpha1
@@ -146,7 +146,7 @@ updates := map[string]resource.FragmentedPodSpec{
     },
 }
 
-// Apply updates — modifies the underlying unstructured object
+// Apply updates - modifies the underlying unstructured object
 err := component.UpdateFragmentedPodSpec(ctx, updates)
 
 // Get the updated object to apply back to the cluster
@@ -193,12 +193,13 @@ Karta was created at [Run:ai](https://run.ai) (NVIDIA) to power workload managem
 - [Technical Guide](docs/Technical%20Guide.md) - Full Karta spec, path syntax (jq), validation rules
 - [Karta definitions](docs/samples/) - Real-world Karta definitions for common workload types
 - [Runnable examples](docs/examples/) - Offline quickstart and an installable controller-runtime example
-- [API Reference](https://pkg.go.dev/github.com/run-ai/karta) — Go package documentation
-- [CONTRIBUTING.md](CONTRIBUTING.md) — How to contribute (DCO required)
+- [API Reference](https://pkg.go.dev/github.com/run-ai/karta) - Go package documentation
+- [CONTRIBUTING.md](CONTRIBUTING.md) - How to contribute (DCO required)
+- [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) - Community standards and expectations
 
 ## Status
 
-Karta is in active development (pre-1.0). The API may change between minor versions. We welcome feedback and contributions — please open an issue or start a discussion.
+Karta is in active development (pre-1.0). The API may change between minor versions. We welcome feedback and contributions - please open an issue or start a discussion.
 
 ## Third-Party Software
 
@@ -206,6 +207,6 @@ This project includes third-party software components. See the [NOTICE](NOTICE) 
 
 ## License
 
-Apache License 2.0 — see [LICENSE](LICENSE) for the full text.
+Apache License 2.0 - see [LICENSE](LICENSE) for the full text.
 
 Copyright (c) 2026 NVIDIA Corporation.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,6 +3,16 @@
 The Karta maintainers take security seriously. We appreciate your efforts to
 responsibly disclose any security vulnerabilities you find.
 
+## Supported Versions
+
+Security fixes are applied to the latest released minor version. While Karta is
+pre-1.0, only the most recent release receives security updates.
+
+| Version | Supported |
+|---|---|
+| Latest release | :white_check_mark: |
+| Older releases | :x: |
+
 ## Reporting a Vulnerability
 
 **Please do not report security vulnerabilities through public GitHub issues.**
@@ -13,4 +23,24 @@ Instead, please report them via
 Please include a description of the vulnerability, steps to reproduce, affected versions,
 and any potential impact.
 
+### What to expect
+
+We aim to acknowledge and investigate reports in a timely manner, share an
+initial assessment of severity and next steps, and keep you informed of progress.
+We will coordinate a disclosure timeline with you before any public announcement.
+
 We kindly ask reporters to allow a reasonable timeframe for a fix before any public disclosure.
+
+### Out of scope
+
+The following are generally **not** considered reportable vulnerabilities:
+
+- Issues caused by misconfiguration of a self-hosted deployment.
+- Vulnerabilities in third-party dependencies that do not affect Karta directly
+  (please report those to the upstream project).
+- Reports from automated scanners without a demonstrated, exploitable impact.
+
+### Credit
+
+We are happy to credit reporters in the release notes for the fix unless you
+prefer to remain anonymous. Please let us know your preference when you report.


### PR DESCRIPTION
## What

Strengthens the project's community and security documentation:

- **SECURITY.md** — adds a Supported Versions table, an out-of-scope list, and a reporter credit policy; clarifies what reporters can expect. Keeps the existing GitHub Security Advisories reporting path and "timely response" language (consistent with KAI-Scheduler).
- **CODE_OF_CONDUCT.md** — updates Contributor Covenant from v1.4 to v2.1 (modernized Pledge, Standards, and Scope wording). Existing `GitHub_Conduct@nvidia.com` reporting contact is preserved.
- **CONTRIBUTING.md** — adds a Development Environment Setup section with the actual `make` targets (`make test`, `make lint`, `make check`), and a Review Process section (who reviews, turnaround expectations, how to follow up).
- **README.md** — links `CODE_OF_CONDUCT.md` from the Documentation section.

## Why

These close documentation gaps surfaced by an OSS health review. No code changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation & Policies**
  * Updated the Code of Conduct to the Contributor Covenant v2.1 structure with refreshed pledges, standards, enforcement responsibilities, and clearer reporting/privacy guidance.
  * Expanded CONTRIBUTING with development environment setup steps and clearer review/merge expectations.
  * Improved README navigation by normalizing formatting and adding direct links to key documentation (API Reference, CONTRIBUTING, Code of Conduct).
* **Security**
  * Added supported-version scope for security fixes and expanded “what to expect” for vulnerability reports, including out-of-scope items and credit/acknowledgement options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->