### PR TITLE
docs: drop API group rename from roadmap and governance

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -38,8 +38,7 @@ vendor-owned one. To keep it neutral:
 - **Neutral, stable consumption surface.** Karta is consumed both as a CRD and as a
   Go library. The API group and the library follow a documented versioning and
   deprecation policy so that any downstream project — regardless of vendor — can
-  depend on Karta with predictable upgrade expectations. (This is why the roadmap
-  includes moving off a vendor-prefixed API group before the API stabilizes.)
+  depend on Karta with predictable upgrade expectations.
 - **Open contribution and review.** Contributors and adopters get a fair
   opportunity to reach consensus on features and PRs through the public review
   process, without one organization's priorities overriding the community's.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -88,10 +88,6 @@ vendor-neutral v1beta1.**
 
 *Later items are directional, not commitments — order and shape will change with community input.*
 
-- **Vendor-neutral API group.** Move the Karta API off the current
-  `run.ai`-prefixed group to a neutral group **before** the API stabilizes, so
-  adopters never have to migrate a vendor-prefixed group later. This is a
-  prerequisite for vendor-neutral governance (see [GOVERNANCE.md](GOVERNANCE.md)).
 - **Karta-aware tooling ecosystem.** Karta is most valuable when many tools read
   and act on the same description. Karta itself stays a thin, neutral contract;
   richer behavior lives in separate projects across the Karta ecosystem. Examples


### PR DESCRIPTION
## What does this PR do?

Removes the commitment to move Karta off the vendor-prefixed `run.ai` API group. Per feedback, the group-name question is deferred (not decided), so the docs should stop promising the move:

- ROADMAP.md: drop the "Vendor-neutral API group" item from the Later section.
- GOVERNANCE.md: remove the parenthetical that pointed at that roadmap item (it would otherwise dangle).

Broader vendor-neutral language is intentionally left intact (the project stays vendor-neutral; only the concrete group-rename commitment is removed). The group name itself remains an open question for a future decision.

## Related issue(s)

Fixes #112

## Checklist

- [x] All commits are signed off with DCO (`git commit -s`)
- [x] New/modified files have SPDX license and copyright headers (n/a, no new files)
- [x] Documentation updated (if applicable)
- [ ] Tests pass (`make check`) — docs-only change, no code affected
- [x] No proprietary or internal information included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated governance guidance to keep the vendor-neutrality note more general.
  * Removed a roadmap item about a specific API naming transition, leaving the remaining future priorities unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->