### PR TITLE
docs: add README badges, community section, and CoC link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,7 +164,7 @@ No release-prep PR or `Chart.yaml` bump is needed - the tag is the source of tru
 
 ## Code of Conduct
 
-Please be respectful and professional in all interactions. We are committed to providing a welcoming and inclusive environment for all contributors.
+Please be respectful and professional in all interactions. We are committed to providing a welcoming and inclusive environment for all contributors. See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for the full code of conduct and how to report conduct concerns.
 
 ## Questions?
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 **A standard way to describe the structure of any Kubernetes workload type.**
 
+[![CI](https://github.com/run-ai/karta/actions/workflows/ci.yaml/badge.svg)](https://github.com/run-ai/karta/actions/workflows/ci.yaml)
+[![Go Reference](https://pkg.go.dev/badge/github.com/run-ai/karta.svg)](https://pkg.go.dev/github.com/run-ai/karta)
+[![Go Report Card](https://goreportcard.com/badge/github.com/run-ai/karta)](https://goreportcard.com/report/github.com/run-ai/karta)
+[![Latest release](https://img.shields.io/github/v/release/run-ai/karta)](https://github.com/run-ai/karta/releases)
+[![License](https://img.shields.io/github/license/run-ai/karta)](LICENSE)
+
 Karta lets you define a portable, declarative blueprint for any Kubernetes workload - whether it's a simple Deployment, a distributed PyTorchJob, or a custom CRD. Controllers and platforms can then use that blueprint to inspect, modify, and manage workloads without hard-coding knowledge of each type.
 
 ## The Problem
@@ -197,9 +203,13 @@ Karta was created at [Run:ai](https://run.ai) (NVIDIA) to power workload managem
 - [CONTRIBUTING.md](CONTRIBUTING.md) - How to contribute (DCO required)
 - [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) - Community standards and expectations
 
+## Community
+
+Have a question, an idea, or want to show what you built with Karta? Join the conversation in [GitHub Discussions](https://github.com/run-ai/karta/discussions). For bugs and feature requests, [open an issue](https://github.com/run-ai/karta/issues).
+
 ## Status
 
-Karta is in active development (pre-1.0). The API may change between minor versions. We welcome feedback and contributions - please open an issue or start a discussion.
+Karta is in active development (pre-1.0). The API may change between minor versions. We welcome feedback and contributions - please [open an issue](https://github.com/run-ai/karta/issues) or [start a discussion](https://github.com/run-ai/karta/discussions).
 
 ## Third-Party Software
 


### PR DESCRIPTION
## What

Three small documentation additions:

- **README badges** — CI status, Go Reference, Go Report Card, latest release, and license, placed under the tagline.
- **Community section** — points contributors to [GitHub Discussions](https://github.com/run-ai/karta/discussions) (already enabled on the repo) and hyperlinks the existing "open an issue / start a discussion" mentions.
- **CONTRIBUTING.md** — the Code of Conduct section now links to `CODE_OF_CONDUCT.md`.

## Why

Continues the OSS health hardening from #111. Badges + a community channel and the CoC link are standard signals for a public project. No code changes.

## Notes

- The Go Report Card badge renders after the report is generated on first visit to goreportcard.com for this repo.
- The release badge auto-reads the latest tag, so it needs no maintenance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidance to direct contributors to the full code of conduct and issue-reporting instructions.
  * Enhanced the README with additional badges and clearer status/feedback links.
  * Added a Community section with direct links to discussions, issues, feedback, and contributions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->