### PR TITLE
docs: add maintainer ladder/emeritus to governance, add RELEASE.md

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -27,6 +27,41 @@ pull request. Where consensus cannot be reached, maintainers resolve the matter 
 a simple majority. No single organization is the deciding authority for the
 project.
 
+## Becoming a maintainer
+
+Maintainership is earned through sustained, high-quality contribution, and the
+ladder is open to contributors from any organization.
+
+- **Contributor** - anyone who opens issues or pull requests. No prior status is
+  required; see [CONTRIBUTING.md](CONTRIBUTING.md) to get started.
+- **Reviewer** - a contributor with a track record of quality contributions and
+  review feedback in an area of the project. Reviewers are expected to help triage
+  issues and review pull requests in their area.
+- **Maintainer** - a reviewer who has demonstrated sustained ownership and sound
+  technical judgment. Maintainers carry merge rights and share responsibility for
+  direction, reviews, and releases.
+
+A contributor is nominated for reviewer or maintainer by an existing maintainer,
+typically after a consistent history of merged contributions. The nomination is
+made in a public pull request that adds the person to [MAINTAINERS.md](MAINTAINERS.md)
+(and `OWNERS` where applicable), and is confirmed by lazy consensus of the current
+maintainers. Promotion is based on contribution and judgment, not affiliation; the
+project actively wants maintainers from more than one organization.
+
+## Stepping down and emeritus
+
+Maintainers may step down at any time by opening a pull request that removes them
+from [MAINTAINERS.md](MAINTAINERS.md) and `OWNERS`. Maintainers who are no longer
+active may be moved to emeritus status: they are recognized for their past
+contributions and are welcome to return, but they no longer carry active
+maintainer responsibilities or merge rights.
+
+A maintainer who is inactive for an extended period, or who is unable to uphold
+these responsibilities, may be moved to emeritus by lazy consensus of the
+remaining maintainers via a public pull request. The intent is to keep the active
+maintainer list an accurate reflection of who is currently stewarding the project,
+not to penalize anyone.
+
 ## Vendor neutrality
 
 Karta originated at Run:ai (NVIDIA) but is intended as a community standard, not a

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,44 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright (c) 2026 NVIDIA Corporation -->
+
+# Release Process
+
+This document describes how Karta is versioned and released. The mechanics of
+cutting a release are documented in [CONTRIBUTING.md](CONTRIBUTING.md#versioning);
+this document covers the policy around them.
+
+## Versioning
+
+Karta follows [Semantic Versioning](https://semver.org/). Releases are tagged
+`vMAJOR.MINOR.PATCH`.
+
+While Karta is pre-1.0 (`0.y.z`), the API (`run.ai/v1alpha1`) and the Go library
+surface may change between minor versions. Breaking changes are called out in the
+release notes. Consumers should pin to a specific released version.
+
+## Cadence
+
+Karta releases on an as-needed basis rather than a fixed calendar. A release is
+cut when a meaningful set of changes has accumulated on `main`, or when a fix needs
+to ship. There is no separate release branch while the project is pre-1.0; releases
+are tagged from `main`.
+
+## Who can cut a release
+
+Releases are cut by project [maintainers](MAINTAINERS.md). Release artifacts are
+built by CI from the pushed tag, never from a local machine.
+
+## How a release is cut
+
+The full steps live in [CONTRIBUTING.md](CONTRIBUTING.md#versioning). In short, a
+maintainer pushes a `vX.Y.Z` tag, which triggers the `push-artifacts` workflow to
+publish the Helm chart to GHCR and create the corresponding GitHub Release. No
+release-prep pull request or `Chart.yaml` bump is required; the tag is the source
+of truth.
+
+## Release notes and breaking changes
+
+Each GitHub Release includes notes describing what changed. Every breaking change
+(API field changes, removed or renamed library surface, behavioral changes that
+require consumer action) must be documented in the release notes with migration
+guidance so that downstream consumers can upgrade predictably.


### PR DESCRIPTION
## What

Two governance/release documentation additions:

- **GOVERNANCE.md** — adds a "Becoming a maintainer" section (contributor -> reviewer -> maintainer ladder, nomination by public PR, confirmed by lazy consensus, open to any organization) and a "Stepping down and emeritus" section (how maintainers step down or are moved to emeritus).
- **RELEASE.md** (new) — documents versioning policy (SemVer, pre-1.0 caveats), release cadence, who can cut a release, and the requirement to document breaking changes with migration guidance. The mechanics already live in CONTRIBUTING.md; this covers the policy around them.

## Why

Continues the OSS health hardening (after #111 and #125). A documented maintainer ladder and emeritus path are credibility steps toward vendor-neutral, foundation-track governance; a RELEASE.md documents the release contract for downstream consumers. No code changes.

## Note for maintainers

`OWNERS` lists a fourth approver (`Ronkahn21`) who is not in `MAINTAINERS.md`. This PR does not resolve that drift, since whether that person is a maintainer is a call for the team. Worth reconciling in a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented contributor, reviewer, maintainer, and emeritus roles, including nomination and transition processes.
  * Added release policies covering versioning, compatibility expectations, release timing, artifact publishing, and breaking-change guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->