### PR TITLE
fix: avoid append aliasing of caller-owned component slices

### DIFF
--- a/pkg/api/runai/v1alpha1/validation.go
+++ b/pkg/api/runai/v1alpha1/validation.go
@@ -57,7 +57,10 @@ func (v *KartaValidator) initialize() []error {
 	v.rootComponent = v.karta.Spec.StructureDefinition.RootComponent
 
 	v.allComponents = make(map[string]ComponentDefinition)
-	for _, component := range append(v.karta.Spec.StructureDefinition.ChildComponents, v.karta.Spec.StructureDefinition.RootComponent) {
+	allComponents := make([]ComponentDefinition, 0, len(v.karta.Spec.StructureDefinition.ChildComponents)+1)
+	allComponents = append(allComponents, v.karta.Spec.StructureDefinition.ChildComponents...)
+	allComponents = append(allComponents, v.karta.Spec.StructureDefinition.RootComponent)
+	for _, component := range allComponents {
 		if _, ok := v.allComponents[component.Name]; ok {
 			errs = append(errs, fmt.Errorf("component name %s is not unique", component.Name))
 		}

--- a/pkg/resource/component_factory.go
+++ b/pkg/resource/component_factory.go
@@ -53,7 +53,9 @@ func NewComponentFactory(karta *v1alpha1.Karta, accessor ComponentAccessor) *Com
 	definitionsByName := make(map[string]v1alpha1.ComponentDefinition)
 
 	// Create single slice with all components (root + children)
-	allDefinitions := append(karta.Spec.StructureDefinition.ChildComponents, karta.Spec.StructureDefinition.RootComponent)
+	allDefinitions := make([]v1alpha1.ComponentDefinition, 0, len(karta.Spec.StructureDefinition.ChildComponents)+1)
+	allDefinitions = append(allDefinitions, karta.Spec.StructureDefinition.ChildComponents...)
+	allDefinitions = append(allDefinitions, karta.Spec.StructureDefinition.RootComponent)
 	for _, componentDefinition := range allDefinitions {
 		definitionsByName[componentDefinition.Name] = componentDefinition
 	}


### PR DESCRIPTION
## What does this PR do?

Fixes an append-aliasing footgun in two spots that assemble a combined "children + root" component list:

- `pkg/resource/component_factory.go` (`NewComponentFactory`)
- `pkg/api/runai/v1alpha1/validation.go` (`KartaValidator.initialize`)

Both did:

```go
allDefinitions := append(karta.Spec.StructureDefinition.ChildComponents, karta.Spec.StructureDefinition.RootComponent)
```

`append(s, x)` reuses `s`'s backing array whenever `cap(s) > len(s)`. `ChildComponents` is owned by the caller's `Karta`, so when that slice has spare capacity the append writes `RootComponent` into caller-owned memory instead of allocating fresh. A freshly unmarshalled `Karta` (JSON/YAML decoders over-allocate slice capacity) can hit this; a DeepCopy (`make([]T, len(...))`) cannot.

The fix allocates a dedicated slice sized `len(ChildComponents)+1` and copies into it, so the caller's slice is never touched. Iteration contents are unchanged.

## Related issue(s)

N/A

## Checklist

- [x] All commits are signed off with DCO (`git commit -s`)
- [x] New/modified files have SPDX license and copyright headers
- [ ] Documentation updated (if applicable) - N/A
- [x] Tests pass (`make check`)
- [x] No proprietary or internal information included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of component lists to avoid unintended sharing of internal slice data.
  * Made validator and component setup more reliable when combining child components with the root component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->