### PR TITLE
docs(samples): fix rayjob worker instanceIdPath nesting

### DIFF
--- a/docs/samples/rayjob.yaml
+++ b/docs/samples/rayjob.yaml
@@ -53,7 +53,7 @@ spec:
           podTemplateSpecPath: .spec.rayClusterSpec.workerGroupSpecs[].template
         scaleDefinition:
           replicasPath: .spec.rayClusterSpec.workerGroupSpecs[].replicas // 1
-        instanceIdPath: .spec.workerGroupSpecs[].groupName
+        instanceIdPath: .spec.rayClusterSpec.workerGroupSpecs[].groupName
         podSelector:
           componentTypeSelector:
             keyPath: .metadata.labels["ray.io/node-type"]


### PR DESCRIPTION
## What does this PR do?

Fixes the `worker` component's `instanceIdPath` in `docs/samples/rayjob.yaml`. On a `RayJob`, worker groups live under `.spec.rayClusterSpec.workerGroupSpecs`, which the component's `podTemplateSpecPath` and `replicasPath` already use. The `instanceIdPath` was missing the `.rayClusterSpec` segment (copied from `raycluster.yaml`, where the bare `.spec.workerGroupSpecs` path is correct), so it resolved to nothing and broke worker instance-id extraction.

```diff
-        instanceIdPath: .spec.workerGroupSpecs[].groupName
+        instanceIdPath: .spec.rayClusterSpec.workerGroupSpecs[].groupName
```

The path is syntactically valid jq, so the sample self-validation test passes either way; it is only wrong against the real RayJob CRD shape. The `pkg/api/runai/v1alpha1` package tests (which validate every sample) pass with the fix.

## Related issue(s)

Fixes #131

## Checklist

- [x] All commits are signed off with DCO (`git commit -s`)
- [x] New/modified files have SPDX license and copyright headers
- [x] Documentation updated (if applicable)
- [x] Tests pass (`go test ./pkg/api/runai/v1alpha1/`)
- [x] No proprietary or internal information included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the sample Ray job configuration to use the current worker group name path for deriving worker instance IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->