### PR TITLE
feat(e2e): kind-based e2e cluster provisioner (hack/e2e)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,3 +51,6 @@ jobs:
       - name: Run operator checks
         working-directory: operator
         run: make check
+
+      - name: Lint shell scripts
+        run: make lint-shell

--- a/Makefile
+++ b/Makefile
@@ -139,30 +139,10 @@ CLUSTER_NAME ?= karta-e2e
 
 # Pick which operators to install:
 #   make e2e-up                          # everything
-#   make e2e-up WORKLOADS="jobset lws"   # a couple - one provision, deps resolved once
-#   make e2e-up-jobset                   # a single operator (tab-completes: make e2e-up-<TAB>)
-#   make e2e-up-all                      # everything, explicit
+#   make e2e-up WORKLOADS="jobset lws"   # a subset - one provision, deps resolved once
 .PHONY: e2e-up
 e2e-up: ## Provision a kind cluster + operators (WORKLOADS="jobset kuberay" for a subset, or "all"; CLUSTER_NAME=<name> for an isolated parallel cluster)
 	CLUSTER_NAME=$(CLUSTER_NAME) ./hack/e2e/up.sh $(WORKLOADS)
-
-# Per-operator convenience targets, spelled out one rule each so shell completion
-# lists them individually: make e2e-up-<TAB> -> e2e-up-jobset, e2e-up-kserve, ...
-# Keep this list in sync with ALL_WORKLOADS in hack/e2e/up.sh. Use WORKLOADS on
-# e2e-up to compose several; e2e-up-all (or bare e2e-up) installs everything.
-.PHONY: e2e-up-all e2e-up-lws e2e-up-jobset e2e-up-kuberay e2e-up-kubeflow e2e-up-knative e2e-up-kserve e2e-up-milvus e2e-up-grove e2e-up-dynamo e2e-up-nim
-e2e-up-all: ## Provision a kind cluster + all operators
-	@$(MAKE) e2e-up WORKLOADS=all
-e2e-up-lws:      ; @$(MAKE) e2e-up WORKLOADS=lws
-e2e-up-jobset:   ; @$(MAKE) e2e-up WORKLOADS=jobset
-e2e-up-kuberay:  ; @$(MAKE) e2e-up WORKLOADS=kuberay
-e2e-up-kubeflow: ; @$(MAKE) e2e-up WORKLOADS=kubeflow
-e2e-up-knative:  ; @$(MAKE) e2e-up WORKLOADS=knative
-e2e-up-kserve:   ; @$(MAKE) e2e-up WORKLOADS=kserve
-e2e-up-milvus:   ; @$(MAKE) e2e-up WORKLOADS=milvus
-e2e-up-grove:    ; @$(MAKE) e2e-up WORKLOADS=grove
-e2e-up-dynamo:   ; @$(MAKE) e2e-up WORKLOADS=dynamo
-e2e-up-nim:      ; @$(MAKE) e2e-up WORKLOADS=nim
 
 .PHONY: e2e-down
 e2e-down: ## Tear down the e2e cluster (set CLUSTER_NAME for a named one)

--- a/Makefile
+++ b/Makefile
@@ -130,3 +130,51 @@ helm-lint: ## Lint the helm chart
 .PHONY: helm-validate
 helm-validate: ## Validate the helm chart renders
 	helm template $(KARTA_CHART_DIR)
+
+##@ E2E
+
+# Cluster name for the e2e targets. Override to run isolated clusters in parallel,
+# e.g. make e2e-up CLUSTER_NAME=shard-a WORKLOADS="jobset kuberay"
+CLUSTER_NAME ?= karta-e2e
+
+# Pick which operators to install:
+#   make e2e-up                          # everything
+#   make e2e-up WORKLOADS="jobset lws"   # a couple - one provision, deps resolved once
+#   make e2e-up-jobset                   # a single operator (tab-completes: make e2e-up-<TAB>)
+#   make e2e-up-all                      # everything, explicit
+.PHONY: e2e-up
+e2e-up: ## Provision a kind cluster + operators (WORKLOADS="jobset kuberay" for a subset, or "all"; CLUSTER_NAME=<name> for an isolated parallel cluster)
+	CLUSTER_NAME=$(CLUSTER_NAME) ./hack/e2e/up.sh $(WORKLOADS)
+
+# Per-operator convenience targets, spelled out one rule each so shell completion
+# lists them individually: make e2e-up-<TAB> -> e2e-up-jobset, e2e-up-kserve, ...
+# Keep this list in sync with ALL_WORKLOADS in hack/e2e/up.sh. Use WORKLOADS on
+# e2e-up to compose several; e2e-up-all (or bare e2e-up) installs everything.
+.PHONY: e2e-up-all e2e-up-lws e2e-up-jobset e2e-up-kuberay e2e-up-kubeflow e2e-up-knative e2e-up-kserve e2e-up-milvus e2e-up-grove e2e-up-dynamo e2e-up-nim
+e2e-up-all: ## Provision a kind cluster + all operators
+	@$(MAKE) e2e-up WORKLOADS=all
+e2e-up-lws:      ; @$(MAKE) e2e-up WORKLOADS=lws
+e2e-up-jobset:   ; @$(MAKE) e2e-up WORKLOADS=jobset
+e2e-up-kuberay:  ; @$(MAKE) e2e-up WORKLOADS=kuberay
+e2e-up-kubeflow: ; @$(MAKE) e2e-up WORKLOADS=kubeflow
+e2e-up-knative:  ; @$(MAKE) e2e-up WORKLOADS=knative
+e2e-up-kserve:   ; @$(MAKE) e2e-up WORKLOADS=kserve
+e2e-up-milvus:   ; @$(MAKE) e2e-up WORKLOADS=milvus
+e2e-up-grove:    ; @$(MAKE) e2e-up WORKLOADS=grove
+e2e-up-dynamo:   ; @$(MAKE) e2e-up WORKLOADS=dynamo
+e2e-up-nim:      ; @$(MAKE) e2e-up WORKLOADS=nim
+
+.PHONY: e2e-down
+e2e-down: ## Tear down the e2e cluster (set CLUSTER_NAME for a named one)
+	CLUSTER_NAME=$(CLUSTER_NAME) ./hack/e2e/down.sh
+
+# The e2e shell scripts to shellcheck: the provisioner, teardown, the shared
+# helpers, and every per-operator install.sh/verify.sh.
+E2E_SHELL := hack/e2e/up.sh hack/e2e/down.sh \
+	hack/e2e/operators/_common.sh \
+	$(wildcard hack/e2e/operators/*/install.sh) \
+	$(wildcard hack/e2e/operators/*/verify.sh)
+
+.PHONY: lint-shell
+lint-shell: ## shellcheck the e2e shell scripts (-x follows sourced files)
+	shellcheck -x $(E2E_SHELL)

--- a/hack/e2e/README.md
+++ b/hack/e2e/README.md
@@ -30,7 +30,7 @@ hack/e2e/
 ```sh
 make e2e-up                          # base + all operators
 make e2e-up WORKLOADS="jobset lws"   # base + a subset (one provision, deps resolved once)
-make e2e-up-jobset                   # base + a single operator (tab-completes: make e2e-up-<TAB>)
+make e2e-up WORKLOADS="jobset"       # base + a single operator
 make e2e-down                        # tear down
 ./hack/e2e/up.sh --list dynamo       # print the resolved plan and exit (dynamo pulls grove)
 ```
@@ -106,8 +106,6 @@ Install side (this directory):
    the operator shows in the install summary.
 4. Add `<name>` to `ALL_WORKLOADS` in `up.sh` (in install order), and a `deps_of`
    entry only if it depends on another operator.
-5. Add an `e2e-up-<name>` line to the `Makefile` (next to the others) so
-   `make e2e-up-<name>` works and tab-completes.
 
 Before pushing: `make lint-shell` (shellcheck), then provision just that operator to
-confirm it installs and smoke-tests clean, for example `make e2e-up-<name>`.
+confirm it installs and smoke-tests clean, for example `make e2e-up WORKLOADS=<name>`.

--- a/hack/e2e/README.md
+++ b/hack/e2e/README.md
@@ -1,0 +1,112 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright (c) 2026 NVIDIA Corporation -->
+
+# Karta e2e cluster provisioner
+
+This directory provisions a local kind cluster for the Karta e2e suite: it builds
+and deploys the Karta operator, installs the dependencies the suite needs, and
+installs the upstream workload operators it exercises. Each operator is smoke-tested
+as it installs, so a broken install fails provisioning rather than a later run.
+
+## Layout
+
+```
+hack/e2e/
+  up.sh                 orchestrator: base + selected operators (install then verify)
+  down.sh               tear the cluster down (and its kubeconfig for named clusters)
+  global.env            single source of truth for versions and runtime defaults
+  kind-config.yaml      kind cluster shape (1 control-plane + 1 worker)
+  operators/
+    _common.sh          shared helpers + GitHub Actions logging, sourced by every script
+    <name>/
+      install.sh        standalone: installs the operator (run as a subprocess)
+      verify.sh         standalone: smoke-tests it via run_smoke
+      smoke.yaml        the throwaway workload the smoke test applies
+      <config>.yaml     optional co-located config (e.g. grove/values.yaml)
+```
+
+## Usage
+
+```sh
+make e2e-up                          # base + all operators
+make e2e-up WORKLOADS="jobset lws"   # base + a subset (one provision, deps resolved once)
+make e2e-up-jobset                   # base + a single operator (tab-completes: make e2e-up-<TAB>)
+make e2e-down                        # tear down
+./hack/e2e/up.sh --list dynamo       # print the resolved plan and exit (dynamo pulls grove)
+```
+
+The always-on base is the kind cluster, cert-manager, the fake-gpu-operator, and
+the Karta operator. Selecting a subset keeps a run light. Dependencies are added
+automatically: kserve pulls knative, dynamo pulls grove.
+
+## How up.sh runs an operator
+
+For each selected operator, up.sh runs `operators/<name>/install.sh` then
+`operators/<name>/verify.sh` as subprocesses. It groups each operator in the CI
+log (`::group::`) and writes an install summary table to the run's Summary page
+(operator, version, install time, smoke time). A failing install or smoke fails
+provisioning fast, rather than partway through the suite.
+
+## Shared helpers (`operators/_common.sh`)
+
+Sourcing `_common.sh` also loads `global.env`, so any script gets the version
+pins in one step. Available helpers:
+
+- `rollout_wait <ns> <resource> [timeout]` - wait for a rollout; resource includes
+  the kind, e.g. `deploy/foo` or `statefulset/foo`.
+- `apply_with_retry <file|url> [tries] [sleep] [kubectl args...]` - kubectl apply,
+  retried past a warming webhook.
+- `retry <tries> <sleep> <command...>` - run a command, retried past a transient.
+- `run_smoke <manifest> <target> <wait-expr> [timeout] [ns]` - apply a throwaway
+  resource, wait for the state, delete it. Used by every verify.sh.
+- `preload_image <src-ref> <local-tag>` - pull an image and load it into kind.
+- `build_and_load_image <context-dir> <local-tag>` - build an image and load it.
+- `ensure_secret <ns> <name> <k=v>...` - idempotently create/update a secret.
+- Logging: `group`/`endgroup`, `notice`/`warn`/`fail`, `summary`. When to use each
+  is documented at the top of `_common.sh`.
+
+## Adding an operator
+
+Install side (this directory):
+
+1. Create `operators/<name>/install.sh` as a standalone script:
+
+   ```sh
+   #!/usr/bin/env bash
+   # SPDX-License-Identifier: Apache-2.0
+   # Copyright (c) 2026 NVIDIA Corporation
+   set -euo pipefail
+   MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+   # shellcheck source=/dev/null
+   source "${MODULE_DIR}/../_common.sh"
+
+   main() {
+     echo "==> <name> ${<NAME>_VERSION}"
+     # install with helm/kubectl; wait with rollout_wait; use the shared helpers;
+     # reference co-located config via "${MODULE_DIR}/...".
+   }
+
+   main "$@"
+   ```
+
+2. Create `operators/<name>/smoke.yaml` (a throwaway workload) and
+   `operators/<name>/verify.sh`:
+
+   ```sh
+   #!/usr/bin/env bash
+   # SPDX + copyright, set -euo pipefail, MODULE_DIR, source ../_common.sh
+   run_smoke "${MODULE_DIR}/smoke.yaml" "<kind>/<name>-smoke" "<wait-expr>" "<timeout>" default
+   ```
+
+   `<wait-expr>` is passed to `kubectl wait --for=`, so both `condition=Ready` and
+   `jsonpath={.status.state}=ready` work.
+
+3. Pin the version(s) in `global.env`, and add a `version_of` case in `up.sh` so
+   the operator shows in the install summary.
+4. Add `<name>` to `ALL_WORKLOADS` in `up.sh` (in install order), and a `deps_of`
+   entry only if it depends on another operator.
+5. Add an `e2e-up-<name>` line to the `Makefile` (next to the others) so
+   `make e2e-up-<name>` works and tab-completes.
+
+Before pushing: `make lint-shell` (shellcheck), then provision just that operator to
+confirm it installs and smoke-tests clean, for example `make e2e-up-<name>`.

--- a/hack/e2e/README.md
+++ b/hack/e2e/README.md
@@ -15,7 +15,7 @@ hack/e2e/
   up.sh                 orchestrator: base + selected operators (install then verify)
   down.sh               tear the cluster down (and its kubeconfig for named clusters)
   global.env            single source of truth for versions and runtime defaults
-  kind-config.yaml      kind cluster shape (1 control-plane + 1 worker)
+  kind-config.yaml      kind cluster shape (1 control-plane + 2 workers)
   operators/
     _common.sh          shared helpers + GitHub Actions logging, sourced by every script
     <name>/
@@ -42,10 +42,11 @@ automatically: kserve pulls knative, dynamo pulls grove.
 ## How up.sh runs an operator
 
 For each selected operator, up.sh runs `operators/<name>/install.sh` then
-`operators/<name>/verify.sh` as subprocesses. It groups each operator in the CI
-log (`::group::`) and writes an install summary table to the run's Summary page
-(operator, version, install time, smoke time). A failing install or smoke fails
-provisioning fast, rather than partway through the suite.
+`operators/<name>/verify.sh` as `bash <script>` subprocesses. The only contract is
+the exit code: any non-zero exit is a failed install/smoke and fails provisioning
+fast (the `main()` wrapper in the scripts is just convention). up.sh groups each
+operator in the CI log (`::group::`) and writes an install summary table to the run's
+Summary page (operator, version, install time, smoke time).
 
 ## Shared helpers (`operators/_common.sh`)
 

--- a/hack/e2e/down.sh
+++ b/hack/e2e/down.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# Tear down the local Karta e2e cluster.
+set -euo pipefail
+DEFAULT_CLUSTER="karta-e2e"
+CLUSTER_NAME="${CLUSTER_NAME:-${DEFAULT_CLUSTER}}"
+# Mirror up.sh: a non-default cluster has its own kubeconfig; remove it too.
+derived=""
+if [ -z "${KUBECONFIG:-}" ] && [ "${CLUSTER_NAME}" != "${DEFAULT_CLUSTER}" ]; then
+  KUBECONFIG="${HOME}/.kube/kind-${CLUSTER_NAME}.kubeconfig"
+  export KUBECONFIG
+  derived=1
+fi
+kind delete cluster --name "${CLUSTER_NAME}"
+if [ -n "${derived}" ]; then rm -f "${KUBECONFIG}"; fi

--- a/hack/e2e/global.env
+++ b/hack/e2e/global.env
@@ -40,6 +40,10 @@ JOBSET_VERSION="${JOBSET_VERSION:-v0.10.1}"
 KUBERAY_VERSION="${KUBERAY_VERSION:-1.6.2}"
 RAY_VERSION="${RAY_VERSION:-2.40.0}"
 KUBEFLOW_VERSION="${KUBEFLOW_VERSION:-v1.9.0}"
+# Standalone kubeflow mpi-operator for kubeflow.org/v2beta1 MPIJob (the newer MPI
+# path, matching run:ai self-hosted, which drops the training-operator's bundled v1
+# MPIJob and installs this instead).
+MPI_OPERATOR_VERSION="${MPI_OPERATOR_VERSION:-v0.8.2}"
 KNATIVE_VERSION="${KNATIVE_VERSION:-knative-v1.15.2}"
 KOURIER_VERSION="${KOURIER_VERSION:-knative-v1.15.0}"
 KSERVE_VERSION="${KSERVE_VERSION:-v0.13.1}"

--- a/hack/e2e/global.env
+++ b/hack/e2e/global.env
@@ -40,9 +40,8 @@ JOBSET_VERSION="${JOBSET_VERSION:-v0.10.1}"
 KUBERAY_VERSION="${KUBERAY_VERSION:-1.6.2}"
 RAY_VERSION="${RAY_VERSION:-2.40.0}"
 KUBEFLOW_VERSION="${KUBEFLOW_VERSION:-v1.9.0}"
-# Standalone kubeflow mpi-operator for kubeflow.org/v2beta1 MPIJob (the newer MPI
-# path, matching run:ai self-hosted, which drops the training-operator's bundled v1
-# MPIJob and installs this instead).
+# Standalone kubeflow mpi-operator serving kubeflow.org/v2beta1 MPIJob (the newer
+# MPI path; replaces the training-operator's bundled v1 MPIJob).
 MPI_OPERATOR_VERSION="${MPI_OPERATOR_VERSION:-v0.8.2}"
 KNATIVE_VERSION="${KNATIVE_VERSION:-knative-v1.15.2}"
 KOURIER_VERSION="${KOURIER_VERSION:-knative-v1.15.0}"

--- a/hack/e2e/global.env
+++ b/hack/e2e/global.env
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# Single source of truth for the e2e config and version pins. Sourced by
+# hack/e2e/operators/_common.sh, so up.sh and every operator script (install.sh
+# and verify.sh) see the same values. This is the one place a value changes; each
+# stays overridable from the environment, e.g. KUBERAY_VERSION=1.7.0 ./hack/e2e/up.sh
+
+# Runtime defaults (overridable from the environment). up.sh exports these so the
+# operator subprocesses inherit them.
+CLUSTER_NAME="${CLUSTER_NAME:-karta-e2e}"
+IMAGE="${IMAGE:-karta-operator:e2e}"
+# Memory limit for the Karta operator, raised from the chart default: crdExistsForGVK
+# can OOM listing all CustomResourceDefinitions when large upstream CRDs are installed.
+KARTA_OPERATOR_MEMORY="${KARTA_OPERATOR_MEMORY:-512Mi}"
+
+# Go toolchain used to build the Karta operator image.
+GO_VERSION="${GO_VERSION:-1.26.3}"
+
+# kind node image (pins the Kubernetes version so it does not float with the
+# local kind binary). For full immutability append @sha256:<digest> (cert-manager
+# style; the digest is in the kind release notes for the kind version in use).
+# Override to test another Kubernetes version.
+KIND_NODE_IMAGE="${KIND_NODE_IMAGE:-kindest/node:v1.34.0}"
+
+# CI toolchain: the e2e workflow (.github/workflows/e2e.yaml) installs these
+# pinned prebuilt binaries rather than compiling kind from source. kubectl tracks
+# the cluster Kubernetes version (KIND_NODE_IMAGE above). Overridable like the rest.
+KIND_VERSION="${KIND_VERSION:-v0.30.0}"
+KUBECTL_VERSION="${KUBECTL_VERSION:-v1.34.0}"
+HELM_VERSION="${HELM_VERSION:-v3.16.4}"
+
+# Cluster dependencies.
+CERT_MANAGER_VERSION="${CERT_MANAGER_VERSION:-v1.14.4}"
+FAKE_GPU_VERSION="${FAKE_GPU_VERSION:-0.0.72}"
+
+# Workload operators exercised by the suite.
+LWS_VERSION="${LWS_VERSION:-v0.7.0}"
+JOBSET_VERSION="${JOBSET_VERSION:-v0.10.1}"
+KUBERAY_VERSION="${KUBERAY_VERSION:-1.6.2}"
+RAY_VERSION="${RAY_VERSION:-2.40.0}"
+KUBEFLOW_VERSION="${KUBEFLOW_VERSION:-v1.9.0}"
+KNATIVE_VERSION="${KNATIVE_VERSION:-knative-v1.15.2}"
+KOURIER_VERSION="${KOURIER_VERSION:-knative-v1.15.0}"
+KSERVE_VERSION="${KSERVE_VERSION:-v0.13.1}"
+# KServe repoints its rbac-proxy sidecar off the unserved upstream gcr.io tag to this
+# maintained image (see operators/kserve/install.sh).
+KUBE_RBAC_PROXY_VERSION="${KUBE_RBAC_PROXY_VERSION:-v0.18.0}"
+MILVUS_OPERATOR_VERSION="${MILVUS_OPERATOR_VERSION:-1.3.7}"
+KAI_SCHEDULER_VERSION="${KAI_SCHEDULER_VERSION:-v0.15.2}"
+GROVE_VERSION="${GROVE_VERSION:-v0.1.0-alpha.10-rc1}"
+DYNAMO_VERSION="${DYNAMO_VERSION:-1.2.1}"
+# k8s-nim-operator has no published Helm/OCI chart; the nim module fetches the
+# chart from this upstream git tag at install time (see operators/nim/install.sh)
+# instead of vendoring it.
+NIM_OPERATOR_VERSION="${NIM_OPERATOR_VERSION:-v3.0.2}"

--- a/hack/e2e/global.env
+++ b/hack/e2e/global.env
@@ -23,9 +23,8 @@ GO_VERSION="${GO_VERSION:-1.26.3}"
 # Override to test another Kubernetes version.
 KIND_NODE_IMAGE="${KIND_NODE_IMAGE:-kindest/node:v1.34.0}"
 
-# CI toolchain: the e2e workflow (.github/workflows/e2e.yaml) installs these
-# pinned prebuilt binaries rather than compiling kind from source. kubectl tracks
-# the cluster Kubernetes version (KIND_NODE_IMAGE above). Overridable like the rest.
+# CLI tooling: kind, kubectl, helm. kubectl tracks the cluster Kubernetes version
+# (KIND_NODE_IMAGE above).
 KIND_VERSION="${KIND_VERSION:-v0.30.0}"
 KUBECTL_VERSION="${KUBECTL_VERSION:-v1.34.0}"
 HELM_VERSION="${HELM_VERSION:-v3.16.4}"

--- a/hack/e2e/kind-config.yaml
+++ b/hack/e2e/kind-config.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+  - role: worker

--- a/hack/e2e/kind-config.yaml
+++ b/hack/e2e/kind-config.yaml
@@ -1,7 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 NVIDIA Corporation
+#
+# The control-plane stays tainted (kube default) so workloads never compete with the
+# API server; two workers give the suite enough room without untainting it.
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
+  - role: worker
   - role: worker

--- a/hack/e2e/operators/_common.sh
+++ b/hack/e2e/operators/_common.sh
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# Shared helpers for the per-operator e2e scripts under hack/e2e/operators/.
+# Each operator ships a standalone install.sh (and, if it has a smoke.yaml, a
+# verify.sh). Every such script sources this file once at its top:
+#
+#   MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#   source "${MODULE_DIR}/../_common.sh"
+#
+# Sourcing this file also loads hack/e2e/global.env, so the version pins and
+# runtime defaults are available without a second source. Reference co-located
+# files via "${MODULE_DIR}/...". All helpers are bash 3.2 safe (no associative
+# arrays, no mapfile).
+# shellcheck shell=bash
+
+# Global config + version pins in one place (resolved relative to this file).
+_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${_COMMON_DIR}/../global.env"
+
+# --- GitHub Actions logging --------------------------------------------------
+# Where output should go, so a run reads as a scannable report and not a wall of
+# gray logs:
+#   group/endgroup  wrap a phase's verbose command output; the run log collapses
+#                   it, leaving the group title as the scannable line.
+#   notice          a key milestone (blue annotation at the top of the run and on
+#                   the PR); use rarely, one per run at most.
+#   warn            a non-fatal problem worth surfacing (yellow annotation).
+#   fail            a failure (red annotation, top of run + PR); pair with a
+#                   non-zero exit.
+#   summary         the run's report card: a markdown table written to the run's
+#                   Summary page. This is the primary place to read results - the
+#                   logs are only for drilling into detail.
+# Under $GITHUB_ACTIONS these emit workflow commands; run locally they fall back
+# to plain output so the same scripts read well in a terminal.
+# See https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions
+
+group() {
+  if [ -n "${GITHUB_ACTIONS:-}" ]; then echo "::group::$*"; else echo "==> $*"; fi
+}
+endgroup() {
+  if [ -n "${GITHUB_ACTIONS:-}" ]; then echo "::endgroup::"; fi
+}
+notice() {
+  if [ -n "${GITHUB_ACTIONS:-}" ]; then echo "::notice::$*"; else echo "    $*"; fi
+}
+warn() {
+  if [ -n "${GITHUB_ACTIONS:-}" ]; then echo "::warning::$*"; else echo "    warning: $*" >&2; fi
+}
+fail() {
+  if [ -n "${GITHUB_ACTIONS:-}" ]; then echo "::error::$*"; else echo "    error: $*" >&2; fi
+}
+
+# summary <markdown-line>
+# Append a line to the GitHub Actions job summary (rendered on the run page).
+# A no-op when not running in Actions.
+summary() {
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then printf '%s\n' "$*" >>"${GITHUB_STEP_SUMMARY}"; fi
+}
+
+# --- cluster helpers ---------------------------------------------------------
+
+# rollout_wait <namespace> <resource> [timeout]
+# Wait for a rollout to finish. <resource> includes the kind, e.g. deploy/foo or
+# statefulset/foo, so this is not limited to Deployments. Default timeout 180s.
+rollout_wait() {
+  local ns="$1" resource="$2" timeout="${3:-180s}"
+  kubectl -n "${ns}" rollout status "${resource}" --timeout="${timeout}"
+}
+
+# apply_with_retry <file-or-url> [tries] [sleep_secs] [extra kubectl apply args...]
+# kubectl apply, retried while a validating webhook is still warming up. The apply
+# runs inside an if so set -e does not abort on an expected transient failure.
+apply_with_retry() {
+  local target="$1"; shift
+  local tries="${1:-5}"; if [ "$#" -gt 0 ]; then shift; fi
+  local sleep_secs="${1:-10}"; if [ "$#" -gt 0 ]; then shift; fi
+  local i
+  for i in $(seq 1 "${tries}"); do
+    if kubectl apply "$@" -f "${target}"; then
+      return 0
+    fi
+    echo "    apply failed (webhook warming up?); retry ${i}/${tries}" >&2
+    sleep "${sleep_secs}"
+  done
+  return 1
+}
+
+# retry <tries> <sleep_secs> <command...>
+# Run a command, retrying on failure past a transient (a webhook still warming up,
+# an endpoint not yet reachable). The command runs inside an if so set -e does not
+# abort on an expected transient failure.
+retry() {
+  local tries="$1" sleep_secs="$2"; shift 2
+  local i
+  for i in $(seq 1 "${tries}"); do
+    if "$@"; then return 0; fi
+    echo "    retry ${i}/${tries}: $*" >&2
+    sleep "${sleep_secs}"
+  done
+  return 1
+}
+
+# run_smoke <manifest> <target> <wait-expr> [timeout] [namespace]
+# Uniform smoke test: apply the throwaway resource (retried past webhook warmup),
+# wait for the stable state, then delete. <wait-expr> is passed to kubectl wait
+# --for=, so it handles both "condition=Ready" and "jsonpath={.status.x}=y".
+run_smoke() {
+  local manifest="$1" target="$2" wait_expr="$3" timeout="${4:-300s}" ns="${5:-default}"
+  apply_with_retry "${manifest}" 6 10
+  # Capture the wait result so the throwaway resource is always cleaned up, and so
+  # a failed smoke propagates regardless of how run_smoke is called (a bare call
+  # under set -e, or in an if condition where set -e would not fire).
+  local rc=0
+  kubectl wait --for="${wait_expr}" "${target}" -n "${ns}" --timeout="${timeout}" || rc=$?
+  kubectl delete -f "${manifest}" --wait=false || true
+  return "${rc}"
+}
+
+# preload_image <source-ref> <local-tag>
+# Pull an upstream image and load it into kind under a local tag, so the workload
+# does not pull it mid-test.
+preload_image() {
+  local src="$1" tag="$2"
+  docker pull "${src}"
+  docker tag "${src}" "${tag}"
+  kind load docker-image "${tag}" --name "${CLUSTER_NAME}"
+}
+
+# build_and_load_image <context-dir> <local-tag>
+# Build a local image from a build context and load it into kind.
+build_and_load_image() {
+  local ctx="$1" tag="$2"
+  docker build -t "${tag}" "${ctx}"
+  kind load docker-image "${tag}" --name "${CLUSTER_NAME}"
+}
+
+# ensure_secret <namespace> <name> <literal k=v> [more k=v...]
+# Idempotently create/update an opaque secret via apply.
+ensure_secret() {
+  local ns="$1" name="$2"; shift 2
+  local args=() kv
+  for kv in "$@"; do args+=(--from-literal="${kv}"); done
+  kubectl create secret generic "${name}" -n "${ns}" "${args[@]}" \
+    --dry-run=client -o yaml | kubectl apply -f -
+}

--- a/hack/e2e/operators/_common.sh
+++ b/hack/e2e/operators/_common.sh
@@ -74,8 +74,11 @@ rollout_wait() {
 # runs inside an if so set -e does not abort on an expected transient failure.
 apply_with_retry() {
   local target="$1"; shift
-  local tries="${1:-5}"; if [ "$#" -gt 0 ]; then shift; fi
-  local sleep_secs="${1:-10}"; if [ "$#" -gt 0 ]; then shift; fi
+  # tries and sleep_secs are optional; consume a leading arg only if it is numeric,
+  # so a caller can pass kubectl flags directly (apply_with_retry <url> --server-side).
+  local tries=5 sleep_secs=10
+  case "${1:-}" in '' | *[!0-9]*) ;; *) tries="$1"; shift ;; esac
+  case "${1:-}" in '' | *[!0-9]*) ;; *) sleep_secs="$1"; shift ;; esac
   local i
   for i in $(seq 1 "${tries}"); do
     if kubectl apply "$@" -f "${target}"; then
@@ -108,13 +111,14 @@ retry() {
 # --for=, so it handles both "condition=Ready" and "jsonpath={.status.x}=y".
 run_smoke() {
   local manifest="$1" target="$2" wait_expr="$3" timeout="${4:-300s}" ns="${5:-default}"
-  apply_with_retry "${manifest}" 6 10
-  # Capture the wait result so the throwaway resource is always cleaned up, and so
-  # a failed smoke propagates regardless of how run_smoke is called (a bare call
-  # under set -e, or in an if condition where set -e would not fire).
+  # Capture each step's result so the resource is always deleted (even if the apply
+  # exhausts its retries) and the failure still propagates under set -e.
   local rc=0
-  kubectl wait --for="${wait_expr}" "${target}" -n "${ns}" --timeout="${timeout}" || rc=$?
-  kubectl delete -f "${manifest}" --wait=false || true
+  apply_with_retry "${manifest}" 6 10 || rc=$?
+  if [ "${rc}" -eq 0 ]; then
+    kubectl wait --for="${wait_expr}" "${target}" -n "${ns}" --timeout="${timeout}" || rc=$?
+  fi
+  kubectl delete -f "${manifest}" --wait=false --ignore-not-found || true
   return "${rc}"
 }
 

--- a/hack/e2e/operators/dynamo/install.sh
+++ b/hack/e2e/operators/dynamo/install.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# dynamo-platform (mocker DGD). Depends on grove (see deps_of in up.sh).
+# shellcheck disable=SC2154  # DYNAMO_VERSION comes from global.env via _common.sh
+set -euo pipefail
+MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${MODULE_DIR}/../_common.sh"
+
+main() {
+  echo "==> dynamo-platform ${DYNAMO_VERSION} (mocker DGD)"
+  # The platform chart is published on NGC as an https .tgz (anonymous). etcd is
+  # off by default; the mocker workers need it for the distributed runtime. The
+  # operator and dynamo-planner images are public and multi-arch. Fetch into a temp
+  # dir cleaned up on exit rather than leaving an artifact in /tmp. tmp is not local
+  # so the EXIT trap (which fires after main returns) can still resolve it under set -u.
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "${tmp}"' EXIT
+  curl -fsSL -o "${tmp}/dynamo-platform.tgz" \
+    "https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-platform-${DYNAMO_VERSION}.tgz"
+  helm upgrade -i dynamo-platform "${tmp}/dynamo-platform.tgz" -n dynamo-system --create-namespace \
+    --set global.etcd.install=true --wait --timeout 8m >/dev/null
+  # Dummy HF token: the mocker references the secret but downloads no model.
+  ensure_secret default hf-token-secret HF_TOKEN=dummy
+}
+
+main "$@"

--- a/hack/e2e/operators/dynamo/smoke.yaml
+++ b/hack/e2e/operators/dynamo/smoke.yaml
@@ -5,6 +5,7 @@
 # DynamoGraphDeployment and waits for the operator to drive it to
 # state=successful (Frontend + a mocker decode worker, CPU-only) before the e2e
 # suite relies on Dynamo. Fails fast here if the operator is broken.
+# verify.sh substitutes ${DYNAMO_VERSION} (global.env) into the image tag before apply.
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:
@@ -17,7 +18,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
+          image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:${DYNAMO_VERSION}"
           imagePullPolicy: IfNotPresent
     decode:
       envFromSecret: hf-token-secret
@@ -26,7 +27,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
+          image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:${DYNAMO_VERSION}"
           imagePullPolicy: IfNotPresent
           workingDir: /workspace
           command: ["python3", "-m", "dynamo.mocker"]

--- a/hack/e2e/operators/dynamo/smoke.yaml
+++ b/hack/e2e/operators/dynamo/smoke.yaml
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# Smoke test for the dynamo-platform install: up.sh creates this mocker-backend
+# DynamoGraphDeployment and waits for the operator to drive it to
+# state=successful (Frontend + a mocker decode worker, CPU-only) before the e2e
+# suite relies on Dynamo. Fails fast here if the operator is broken.
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: dynamo-smoke
+  namespace: default
+spec:
+  services:
+    Frontend:
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
+          imagePullPolicy: IfNotPresent
+    decode:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      subComponentType: decode
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
+          imagePullPolicy: IfNotPresent
+          workingDir: /workspace
+          command: ["python3", "-m", "dynamo.mocker"]
+          args:
+            - --model-path
+            - nvidia/Llama-3.1-8B-Instruct-FP8
+            - --model-name
+            - nvidia/Llama-3.1-8B-Instruct-FP8
+            - --speedup-ratio
+            - "1.0"
+            - --planner-profile-data
+            - /workspace/components/src/dynamo/planner/tests/data/profiling_results/H200_TP1P_TP1D

--- a/hack/e2e/operators/dynamo/verify.sh
+++ b/hack/e2e/operators/dynamo/verify.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# Smoke test for dynamo-platform: a throwaway DynamoGraphDeployment must reach
+# state=successful. run_smoke retries the apply past the DGD webhook warmup.
+set -euo pipefail
+MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${MODULE_DIR}/../_common.sh"
+
+echo "==> smoke: dynamographdeployment/dynamo-smoke"
+run_smoke "${MODULE_DIR}/smoke.yaml" "dynamographdeployment/dynamo-smoke" "jsonpath={.status.state}=successful" "300s" default

--- a/hack/e2e/operators/dynamo/verify.sh
+++ b/hack/e2e/operators/dynamo/verify.sh
@@ -4,10 +4,16 @@
 #
 # Smoke test for dynamo-platform: a throwaway DynamoGraphDeployment must reach
 # state=successful. run_smoke retries the apply past the DGD webhook warmup.
+# shellcheck disable=SC2154  # DYNAMO_VERSION comes from global.env via _common.sh
 set -euo pipefail
 MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=/dev/null
 source "${MODULE_DIR}/../_common.sh"
 
 echo "==> smoke: dynamographdeployment/dynamo-smoke"
-run_smoke "${MODULE_DIR}/smoke.yaml" "dynamographdeployment/dynamo-smoke" "jsonpath={.status.state}=successful" "300s" default
+# Render DYNAMO_VERSION (global.env) into the smoke image tag so it tracks the
+# installed platform version.
+rendered="$(mktemp)"
+trap 'rm -f "${rendered}"' EXIT
+sed "s|\${DYNAMO_VERSION}|${DYNAMO_VERSION}|g" "${MODULE_DIR}/smoke.yaml" >"${rendered}"
+run_smoke "${rendered}" "dynamographdeployment/dynamo-smoke" "jsonpath={.status.state}=successful" "300s" default

--- a/hack/e2e/operators/grove/install.sh
+++ b/hack/e2e/operators/grove/install.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# kai-scheduler + Grove. Installed together: kai-scheduler is Grove's gang-scheduler
+# backend. dynamo depends on this module (see deps_of in up.sh). Ships a values.yaml.
+# shellcheck disable=SC2154  # KAI_SCHEDULER_VERSION/GROVE_VERSION come from global.env via _common.sh
+set -euo pipefail
+MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${MODULE_DIR}/../_common.sh"
+
+main() {
+  echo "==> kai-scheduler ${KAI_SCHEDULER_VERSION} + Grove ${GROVE_VERSION}"
+  # Grove is Dynamo's multinode orchestrator; it publishes a multi-arch chart and
+  # images (no source build needed). kai-scheduler is Grove's gang-scheduler backend.
+  helm upgrade -i kai-scheduler oci://ghcr.io/kai-scheduler/kai-scheduler/kai-scheduler \
+    --version "${KAI_SCHEDULER_VERSION}" -n kai-scheduler --create-namespace --wait --timeout 5m >/dev/null
+  # Trim scheduler profiles to the backends actually installed (default-scheduler +
+  # kai); the chart default also lists volcano/lpx, whose absent CRDs crash the
+  # operator at startup. The chart installs the Grove CRDs itself.
+  helm upgrade -i grove-operator oci://ghcr.io/ai-dynamo/grove/grove-charts \
+    --version "${GROVE_VERSION}" -n grove-system --create-namespace \
+    -f "${MODULE_DIR}/values.yaml" --wait --timeout 5m >/dev/null
+  rollout_wait grove-system deploy/grove-operator
+  # Health probes are enabled in values.yaml, so the rollout above only completes
+  # once the webhook is serving - the smoke apply will not race it.
+}
+
+main "$@"

--- a/hack/e2e/operators/grove/smoke.yaml
+++ b/hack/e2e/operators/grove/smoke.yaml
@@ -20,7 +20,7 @@ spec:
           podSpec:
             containers:
               - name: worker
-                image: busybox:latest
+                image: busybox:1.36
                 command: ["/bin/sh", "-c", "echo grove-ok && sleep infinity"]
                 resources:
                   requests:

--- a/hack/e2e/operators/grove/smoke.yaml
+++ b/hack/e2e/operators/grove/smoke.yaml
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# Smoke test for the Grove install: up.sh creates this PodCliqueSet and waits for
+# the operator to bring its pods up (availableReplicas) before the e2e suite
+# relies on Grove. Fails fast here if the operator is broken rather than mid-suite.
+apiVersion: grove.io/v1alpha1
+kind: PodCliqueSet
+metadata:
+  name: grove-smoke
+  namespace: default
+spec:
+  replicas: 1
+  template:
+    cliques:
+      - name: worker
+        spec:
+          roleName: worker
+          replicas: 2
+          podSpec:
+            containers:
+              - name: worker
+                image: busybox:latest
+                command: ["/bin/sh", "-c", "echo grove-ok && sleep infinity"]
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi

--- a/hack/e2e/operators/grove/values.yaml
+++ b/hack/e2e/operators/grove/values.yaml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# Grove operator values for the e2e cluster: enable only the scheduler backends
+# actually installed (the built-in default-scheduler and kai-scheduler). The
+# chart default also lists volcano and lpx, whose CRDs are absent here, which
+# crashes the operator at startup while initializing those backends.
+config:
+  server:
+    # Enable the operator health probes (off by default in the chart). Its /readyz
+    # gates on the webhook server being started and its certs being ready, so
+    # `helm --wait` blocks until the validating/defaulting webhook actually serves;
+    # without this the smoke PodCliqueSet races a not-yet-ready webhook.
+    healthProbes:
+      enable: true
+  scheduler:
+    profiles:
+      - name: default-scheduler
+      - name: kai-scheduler
+    defaultProfileName: default-scheduler

--- a/hack/e2e/operators/grove/verify.sh
+++ b/hack/e2e/operators/grove/verify.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# Smoke test for Grove: a throwaway PodCliqueSet must reach availableReplicas=1.
+set -euo pipefail
+MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${MODULE_DIR}/../_common.sh"
+
+echo "==> smoke: podcliqueset/grove-smoke"
+run_smoke "${MODULE_DIR}/smoke.yaml" "podcliqueset/grove-smoke" "jsonpath={.status.availableReplicas}=1" "180s" default

--- a/hack/e2e/operators/jobset/install.sh
+++ b/hack/e2e/operators/jobset/install.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# JobSet operator (sigs.k8s.io/jobset).
+# shellcheck disable=SC2154  # JOBSET_VERSION comes from global.env via _common.sh
+set -euo pipefail
+MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${MODULE_DIR}/../_common.sh"
+
+main() {
+  echo "==> JobSet ${JOBSET_VERSION}"
+  kubectl apply --server-side -f "https://github.com/kubernetes-sigs/jobset/releases/download/${JOBSET_VERSION}/manifests.yaml"
+  rollout_wait jobset-system deploy/jobset-controller-manager
+}
+
+main "$@"

--- a/hack/e2e/operators/jobset/smoke.yaml
+++ b/hack/e2e/operators/jobset/smoke.yaml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# Smoke test for the JobSet install: up.sh creates this JobSet whose single Job
+# runs `true` and completes, so the operator drives it to a Completed condition
+# before the e2e suite relies on it. Fails fast here if the operator is broken.
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  name: jobset-smoke
+  namespace: default
+spec:
+  replicatedJobs:
+    - name: workers
+      replicas: 1
+      template:
+        spec:
+          parallelism: 1
+          completions: 1
+          backoffLimit: 0
+          template:
+            spec:
+              restartPolicy: Never
+              containers:
+                - name: worker
+                  image: busybox:1.36
+                  command: ["true"]
+                  resources:
+                    requests: {cpu: 50m, memory: 32Mi}

--- a/hack/e2e/operators/jobset/verify.sh
+++ b/hack/e2e/operators/jobset/verify.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# Smoke test for JobSet: a throwaway JobSet must reach Completed.
+set -euo pipefail
+MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${MODULE_DIR}/../_common.sh"
+
+echo "==> smoke: jobset/jobset-smoke"
+run_smoke "${MODULE_DIR}/smoke.yaml" "jobset/jobset-smoke" "condition=Completed" "120s" default

--- a/hack/e2e/operators/knative/install.sh
+++ b/hack/e2e/operators/knative/install.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# Knative Serving + Kourier.
+# shellcheck disable=SC2154  # KNATIVE_VERSION/KOURIER_VERSION come from global.env via _common.sh
+set -euo pipefail
+MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${MODULE_DIR}/../_common.sh"
+
+main() {
+  echo "==> Knative Serving ${KNATIVE_VERSION} + Kourier ${KOURIER_VERSION}"
+  # --server-side (+ --force-conflicts) so a reused cluster does not fail on field
+  # ownership, matching the other operators' apply style.
+  kubectl apply --server-side --force-conflicts -f "https://github.com/knative/serving/releases/download/${KNATIVE_VERSION}/serving-crds.yaml"
+  kubectl apply --server-side --force-conflicts -f "https://github.com/knative/serving/releases/download/${KNATIVE_VERSION}/serving-core.yaml"
+  for d in activator autoscaler controller webhook; do
+    rollout_wait knative-serving "deploy/$d"
+  done
+  # Kourier is the networking layer; net-kourier tags lag serving patch releases.
+  kubectl apply --server-side --force-conflicts -f "https://github.com/knative/net-kourier/releases/download/${KOURIER_VERSION}/kourier.yaml"
+  # The Serving config-validation webhook may refuse connections for a moment after
+  # its Deployment reports Available (endpoint/cert still wiring up), so retry these
+  # configmap patches past that warmup.
+  retry 10 6 kubectl patch configmap/config-network -n knative-serving --type merge \
+    -p '{"data":{"ingress-class":"kourier.ingress.networking.knative.dev"}}'
+  retry 10 6 kubectl patch configmap/config-domain -n knative-serving --type merge \
+    -p '{"data":{"127.0.0.1.sslip.io":""}}'
+  rollout_wait knative-serving deploy/net-kourier-controller
+  rollout_wait kourier-system deploy/3scale-kourier-gateway
+}
+
+main "$@"

--- a/hack/e2e/operators/knative/smoke.yaml
+++ b/hack/e2e/operators/knative/smoke.yaml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# Smoke test for the Knative Serving install: up.sh creates this Service and
+# waits for the controller to mark it Ready before the e2e suite relies on
+# Knative. If the operator is broken, up.sh fails here rather than mid-suite.
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: knative-smoke
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+        - image: ghcr.io/knative/helloworld-go:latest
+          ports:
+            - containerPort: 8080
+          env:
+            - name: TARGET
+              value: smoke
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi

--- a/hack/e2e/operators/knative/smoke.yaml
+++ b/hack/e2e/operators/knative/smoke.yaml
@@ -13,7 +13,9 @@ spec:
   template:
     spec:
       containers:
-        - image: ghcr.io/knative/helloworld-go:latest
+        # Pinned by digest: this image publishes only :latest (no version tag), so
+        # a digest is the only reproducible pin.
+        - image: ghcr.io/knative/helloworld-go@sha256:c2b7412fbea6f1ef24a0cac60698e88df7ae3c4278e42d0cb34fe7d4b2641bba
           ports:
             - containerPort: 8080
           env:

--- a/hack/e2e/operators/knative/verify.sh
+++ b/hack/e2e/operators/knative/verify.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# Smoke test for Knative Serving: a throwaway Knative Service must reach Ready, so
+# a broken Serving install fails fast at provision time.
+set -euo pipefail
+MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${MODULE_DIR}/../_common.sh"
+
+echo "==> smoke: ksvc/knative-smoke"
+run_smoke "${MODULE_DIR}/smoke.yaml" "ksvc/knative-smoke" "condition=Ready" "180s" default

--- a/hack/e2e/operators/kserve/disable-istio-vh.yaml
+++ b/hack/e2e/operators/kserve/disable-istio-vh.yaml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# Merge patch for KServe's inferenceservice-config: run Serverless KServe without
+# Istio by disabling the Istio VirtualHost so routing goes through Knative/Kourier.
+data:
+  ingress: |-
+    {
+        "ingressGateway" : "knative-serving/knative-ingress-gateway",
+        "ingressService" : "istio-ingressgateway.istio-system.svc.cluster.local",
+        "localGateway" : "knative-serving/knative-local-gateway",
+        "localGatewayService" : "knative-local-gateway.istio-system.svc.cluster.local",
+        "ingressDomain"  : "example.com",
+        "ingressClassName" : "istio",
+        "domainTemplate": "{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}",
+        "urlScheme": "http",
+        "disableIstioVirtualHost": true,
+        "disableIngressCreation": false
+    }

--- a/hack/e2e/operators/kserve/install.sh
+++ b/hack/e2e/operators/kserve/install.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# KServe, Serverless on Knative + Kourier. Depends on knative (see deps_of in
+# up.sh). Ships a config patch (disable-istio-vh.yaml).
+# shellcheck disable=SC2154  # KSERVE_VERSION/KUBE_RBAC_PROXY_VERSION come from global.env via _common.sh
+set -euo pipefail
+MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${MODULE_DIR}/../_common.sh"
+
+main() {
+  echo "==> KServe ${KSERVE_VERSION} (Serverless on Knative + Kourier)"
+  # --force-conflicts: cert-manager-cainjector owns the webhook caBundle fields,
+  # and on a reused cluster our own set-image/patch steps below already own the
+  # rbac-proxy image and inferenceservice-config ingress. Reclaim them here; the
+  # set-image and patch steps that follow re-assert those overrides.
+  kubectl apply --server-side --force-conflicts -f "https://github.com/kserve/kserve/releases/download/${KSERVE_VERSION}/kserve.yaml"
+  # Upstream pins gcr.io/kubebuilder/kube-rbac-proxy:${KSERVE_VERSION}, a tag that
+  # registry no longer serves; the sidecar only guards metrics, so repoint it to a
+  # maintained image, otherwise the pod never goes Ready and the webhook has no
+  # endpoints.
+  kubectl set image deployment/kserve-controller-manager -n kserve \
+    kube-rbac-proxy="quay.io/brancz/kube-rbac-proxy:${KUBE_RBAC_PROXY_VERSION}"
+  # Serverless KServe defaults to creating Istio VirtualServices; without Istio the
+  # reconcile errors and PredictorReady/RoutesReady never go True. Route through
+  # Knative/Kourier instead.
+  kubectl patch cm inferenceservice-config -n kserve --type merge \
+    --patch-file "${MODULE_DIR}/disable-istio-vh.yaml"
+  rollout_wait kserve deploy/kserve-controller-manager 240s
+  # ClusterServingRuntimes are validated by the webhook, so apply them only after
+  # the controller pod is Ready; retry briefly in case the webhook is still warming.
+  apply_with_retry "https://github.com/kserve/kserve/releases/download/${KSERVE_VERSION}/kserve-cluster-resources.yaml" \
+    5 10 --server-side --force-conflicts
+}
+
+main "$@"

--- a/hack/e2e/operators/kserve/smoke.yaml
+++ b/hack/e2e/operators/kserve/smoke.yaml
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# Smoke test for the KServe install: up.sh creates this InferenceService and
+# waits for the controller to drive it Ready (sklearn CPU model, no GPU, no
+# credentials) before the e2e suite relies on KServe. If the operator is broken,
+# up.sh fails here rather than mid-suite.
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: kserve-smoke
+  namespace: default
+spec:
+  predictor:
+    model:
+      modelFormat:
+        name: sklearn
+      storageUri: gs://kfserving-examples/models/sklearn/1.0/model
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi

--- a/hack/e2e/operators/kserve/verify.sh
+++ b/hack/e2e/operators/kserve/verify.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# Smoke test for KServe: a throwaway InferenceService must reach Ready.
+set -euo pipefail
+MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${MODULE_DIR}/../_common.sh"
+
+echo "==> smoke: isvc/kserve-smoke"
+run_smoke "${MODULE_DIR}/smoke.yaml" "isvc/kserve-smoke" "condition=Ready" "300s" default

--- a/hack/e2e/operators/kubeflow/install.sh
+++ b/hack/e2e/operators/kubeflow/install.sh
@@ -15,14 +15,14 @@ main() {
   # mpi-operator (v2beta1) below. Drop the bundled MPIJob CRD before each apply:
   # kube will not re-point it to v2beta1 in place while v1 is still a stored version.
   echo "==> Kubeflow training-operator ${KUBEFLOW_VERSION}"
-  kubectl delete crd mpijobs.kubeflow.org --ignore-not-found
+  kubectl delete crd mpijobs.kubeflow.org --ignore-not-found --timeout=60s
   kubectl apply --server-side --force-conflicts -k "github.com/kubeflow/trainer/manifests/overlays/standalone?ref=${KUBEFLOW_VERSION}"
   kubectl patch deployment training-operator -n kubeflow \
     -p '{"spec":{"template":{"spec":{"containers":[{"name":"training-operator","args":["--enable-scheme=pytorchjob"]}]}}}}'
   rollout_wait kubeflow deploy/training-operator
 
   echo "==> mpi-operator ${MPI_OPERATOR_VERSION} (kubeflow.org/v2beta1 MPIJob)"
-  kubectl delete crd mpijobs.kubeflow.org --ignore-not-found
+  kubectl delete crd mpijobs.kubeflow.org --ignore-not-found --timeout=60s
   apply_with_retry "https://raw.githubusercontent.com/kubeflow/mpi-operator/${MPI_OPERATOR_VERSION}/deploy/v2beta1/mpi-operator.yaml" \
     5 10 --server-side --force-conflicts
   rollout_wait mpi-operator deploy/mpi-operator

--- a/hack/e2e/operators/kubeflow/install.sh
+++ b/hack/e2e/operators/kubeflow/install.sh
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 NVIDIA Corporation
 #
-# Kubeflow training-operator (PyTorchJob) + the standalone kubeflow mpi-operator for
-# kubeflow.org/v2beta1 MPIJob (the newer MPI path, matching run:ai self-hosted).
+# Kubeflow training-operator (PyTorchJob) and the standalone kubeflow mpi-operator
+# (kubeflow.org/v2beta1 MPIJob).
 # shellcheck disable=SC2154  # KUBEFLOW_VERSION/MPI_OPERATOR_VERSION from global.env via _common.sh
 set -euo pipefail
 MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -11,22 +11,16 @@ MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${MODULE_DIR}/../_common.sh"
 
 main() {
+  # Restrict the training-operator to PyTorchJob and hand MPIJob to the standalone
+  # mpi-operator (v2beta1) below. Drop the bundled MPIJob CRD before each apply:
+  # kube will not re-point it to v2beta1 in place while v1 is still a stored version.
   echo "==> Kubeflow training-operator ${KUBEFLOW_VERSION}"
-  # Start from a clean MPIJob CRD so neither apply below hits a stored-version
-  # conflict on a reused cluster (we end on the mpi-operator's v2beta1 anyway).
   kubectl delete crd mpijobs.kubeflow.org --ignore-not-found
-  # --force-conflicts: a reused cluster can hit field-ownership conflicts on rerun
-  # (matches the other operators' applies).
-  kubectl apply --server-side --force-conflicts -k "github.com/kubeflow/training-operator/manifests/overlays/standalone?ref=${KUBEFLOW_VERSION}"
-  # Limit the training-operator to the job types we use and leave MPIJob to the
-  # standalone mpi-operator below (matches run:ai self-hosted's --enable-scheme).
-  # Without this it keeps trying to watch the v1 MPIJob CRD we drop and log-spams.
+  kubectl apply --server-side --force-conflicts -k "github.com/kubeflow/trainer/manifests/overlays/standalone?ref=${KUBEFLOW_VERSION}"
   kubectl patch deployment training-operator -n kubeflow \
-    -p '{"spec":{"template":{"spec":{"containers":[{"name":"training-operator","args":["--enable-scheme=tfjob","--enable-scheme=pytorchjob","--enable-scheme=xgboostjob","--enable-scheme=jaxjob"]}]}}}}'
+    -p '{"spec":{"template":{"spec":{"containers":[{"name":"training-operator","args":["--enable-scheme=pytorchjob"]}]}}}}'
   rollout_wait kubeflow deploy/training-operator
-  # Swap MPIJob from the training-operator's bundled v1 to the standalone
-  # mpi-operator's v2beta1 (matches run:ai self-hosted). Drop the bundled v1 CRD
-  # first - kube refuses to replace it in place while v1 is a stored version.
+
   echo "==> mpi-operator ${MPI_OPERATOR_VERSION} (kubeflow.org/v2beta1 MPIJob)"
   kubectl delete crd mpijobs.kubeflow.org --ignore-not-found
   apply_with_retry "https://raw.githubusercontent.com/kubeflow/mpi-operator/${MPI_OPERATOR_VERSION}/deploy/v2beta1/mpi-operator.yaml" \

--- a/hack/e2e/operators/kubeflow/install.sh
+++ b/hack/e2e/operators/kubeflow/install.sh
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 NVIDIA Corporation
 #
-# Kubeflow training-operator (github.com/kubeflow/training-operator; also serves
-# kubeflow.org/v1 MPIJob).
-# shellcheck disable=SC2154  # KUBEFLOW_VERSION comes from global.env via _common.sh
+# Kubeflow training-operator (PyTorchJob) + the standalone kubeflow mpi-operator for
+# kubeflow.org/v2beta1 MPIJob (the newer MPI path, matching run:ai self-hosted).
+# shellcheck disable=SC2154  # KUBEFLOW_VERSION/MPI_OPERATOR_VERSION from global.env via _common.sh
 set -euo pipefail
 MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=/dev/null
@@ -12,10 +12,26 @@ source "${MODULE_DIR}/../_common.sh"
 
 main() {
   echo "==> Kubeflow training-operator ${KUBEFLOW_VERSION}"
+  # Start from a clean MPIJob CRD so neither apply below hits a stored-version
+  # conflict on a reused cluster (we end on the mpi-operator's v2beta1 anyway).
+  kubectl delete crd mpijobs.kubeflow.org --ignore-not-found
   # --force-conflicts: a reused cluster can hit field-ownership conflicts on rerun
   # (matches the other operators' applies).
   kubectl apply --server-side --force-conflicts -k "github.com/kubeflow/training-operator/manifests/overlays/standalone?ref=${KUBEFLOW_VERSION}"
+  # Limit the training-operator to the job types we use and leave MPIJob to the
+  # standalone mpi-operator below (matches run:ai self-hosted's --enable-scheme).
+  # Without this it keeps trying to watch the v1 MPIJob CRD we drop and log-spams.
+  kubectl patch deployment training-operator -n kubeflow \
+    -p '{"spec":{"template":{"spec":{"containers":[{"name":"training-operator","args":["--enable-scheme=tfjob","--enable-scheme=pytorchjob","--enable-scheme=xgboostjob","--enable-scheme=jaxjob"]}]}}}}'
   rollout_wait kubeflow deploy/training-operator
+  # Swap MPIJob from the training-operator's bundled v1 to the standalone
+  # mpi-operator's v2beta1 (matches run:ai self-hosted). Drop the bundled v1 CRD
+  # first - kube refuses to replace it in place while v1 is a stored version.
+  echo "==> mpi-operator ${MPI_OPERATOR_VERSION} (kubeflow.org/v2beta1 MPIJob)"
+  kubectl delete crd mpijobs.kubeflow.org --ignore-not-found
+  apply_with_retry "https://raw.githubusercontent.com/kubeflow/mpi-operator/${MPI_OPERATOR_VERSION}/deploy/v2beta1/mpi-operator.yaml" \
+    5 10 --server-side --force-conflicts
+  rollout_wait mpi-operator deploy/mpi-operator
 }
 
 main "$@"

--- a/hack/e2e/operators/kubeflow/install.sh
+++ b/hack/e2e/operators/kubeflow/install.sh
@@ -12,7 +12,9 @@ source "${MODULE_DIR}/../_common.sh"
 
 main() {
   echo "==> Kubeflow training-operator ${KUBEFLOW_VERSION}"
-  kubectl apply --server-side -k "github.com/kubeflow/training-operator/manifests/overlays/standalone?ref=${KUBEFLOW_VERSION}"
+  # --force-conflicts: a reused cluster can hit field-ownership conflicts on rerun
+  # (matches the other operators' applies).
+  kubectl apply --server-side --force-conflicts -k "github.com/kubeflow/training-operator/manifests/overlays/standalone?ref=${KUBEFLOW_VERSION}"
   rollout_wait kubeflow deploy/training-operator
 }
 

--- a/hack/e2e/operators/kubeflow/install.sh
+++ b/hack/e2e/operators/kubeflow/install.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# Kubeflow training-operator (github.com/kubeflow/training-operator; also serves
+# kubeflow.org/v1 MPIJob).
+# shellcheck disable=SC2154  # KUBEFLOW_VERSION comes from global.env via _common.sh
+set -euo pipefail
+MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${MODULE_DIR}/../_common.sh"
+
+main() {
+  echo "==> Kubeflow training-operator ${KUBEFLOW_VERSION}"
+  kubectl apply --server-side -k "github.com/kubeflow/training-operator/manifests/overlays/standalone?ref=${KUBEFLOW_VERSION}"
+  rollout_wait kubeflow deploy/training-operator
+}
+
+main "$@"

--- a/hack/e2e/operators/kubeflow/mpi-smoke.yaml
+++ b/hack/e2e/operators/kubeflow/mpi-smoke.yaml
@@ -12,7 +12,9 @@ metadata:
 spec:
   slotsPerWorker: 1
   runPolicy:
-    cleanPodPolicy: None
+    # All so the operator deletes the worker pods when the launcher finishes; it
+    # does not garbage-collect them on MPIJob deletion, and the worker sleeps.
+    cleanPodPolicy: All
   mpiReplicaSpecs:
     Launcher:
       replicas: 1
@@ -24,6 +26,7 @@ spec:
               command: ["true"]
               resources:
                 requests: {cpu: 50m, memory: 64Mi}
+                limits: {cpu: 100m, memory: 64Mi}
     Worker:
       replicas: 1
       template:
@@ -34,3 +37,4 @@ spec:
               command: ["sleep", "infinity"]
               resources:
                 requests: {cpu: 50m, memory: 64Mi}
+                limits: {cpu: 100m, memory: 64Mi}

--- a/hack/e2e/operators/kubeflow/mpi-smoke.yaml
+++ b/hack/e2e/operators/kubeflow/mpi-smoke.yaml
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# Smoke test for the standalone mpi-operator: up.sh creates this v2beta1 MPIJob
+# whose launcher runs `true` and reaches Succeeded, so a broken mpi-operator fails
+# provisioning rather than a later run.
+apiVersion: kubeflow.org/v2beta1
+kind: MPIJob
+metadata:
+  name: mpi-smoke
+  namespace: default
+spec:
+  slotsPerWorker: 1
+  runPolicy:
+    cleanPodPolicy: None
+  mpiReplicaSpecs:
+    Launcher:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: mpi-launcher
+              image: busybox:1.36
+              command: ["true"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}
+    Worker:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: mpi-worker
+              image: busybox:1.36
+              command: ["sleep", "infinity"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}

--- a/hack/e2e/operators/kubeflow/smoke.yaml
+++ b/hack/e2e/operators/kubeflow/smoke.yaml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# Smoke test for the Kubeflow training-operator install: up.sh creates this
+# PyTorchJob (single master, sleeping) and waits for the operator to mark it
+# Running before the e2e suite relies on it. The container must be named
+# "pytorch" for the training-operator to manage it.
+apiVersion: kubeflow.org/v1
+kind: PyTorchJob
+metadata:
+  name: pytorch-smoke
+  namespace: default
+spec:
+  pytorchReplicaSpecs:
+    Master:
+      replicas: 1
+      restartPolicy: Never
+      template:
+        spec:
+          containers:
+            - name: pytorch
+              image: busybox:1.36
+              command: ["sleep", "infinity"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}

--- a/hack/e2e/operators/kubeflow/verify.sh
+++ b/hack/e2e/operators/kubeflow/verify.sh
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 NVIDIA Corporation
 #
-# Smoke test for Kubeflow training-operator: a throwaway PyTorchJob must reach Running.
+# Smoke tests: a throwaway PyTorchJob (training-operator) must reach Running and a
+# throwaway v2beta1 MPIJob (mpi-operator) must reach Succeeded.
 set -euo pipefail
 MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=/dev/null
@@ -10,3 +11,6 @@ source "${MODULE_DIR}/../_common.sh"
 
 echo "==> smoke: pytorchjob/pytorch-smoke"
 run_smoke "${MODULE_DIR}/smoke.yaml" "pytorchjob/pytorch-smoke" "condition=Running" "240s" default
+
+echo "==> smoke: mpijob/mpi-smoke"
+run_smoke "${MODULE_DIR}/mpi-smoke.yaml" "mpijob/mpi-smoke" "condition=Succeeded" "240s" default

--- a/hack/e2e/operators/kubeflow/verify.sh
+++ b/hack/e2e/operators/kubeflow/verify.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# Smoke test for Kubeflow training-operator: a throwaway PyTorchJob must reach Running.
+set -euo pipefail
+MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${MODULE_DIR}/../_common.sh"
+
+echo "==> smoke: pytorchjob/pytorch-smoke"
+run_smoke "${MODULE_DIR}/smoke.yaml" "pytorchjob/pytorch-smoke" "condition=Running" "240s" default

--- a/hack/e2e/operators/kuberay/install.sh
+++ b/hack/e2e/operators/kuberay/install.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# KubeRay operator (github.com/ray-project/kuberay).
+# shellcheck disable=SC2154  # KUBERAY_VERSION/RAY_VERSION come from global.env via _common.sh
+set -euo pipefail
+MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${MODULE_DIR}/../_common.sh"
+
+# arch_ray_ref <ray-version>: the arch-native rayproject/ray image ref (the amd64
+# image under qemu emulation crash-loops when a RayJob runs real work). Only
+# kuberay needs the Ray image, so it lives here rather than in _common.sh.
+arch_ray_ref() {
+  case "$(uname -m)" in
+    arm64 | aarch64) echo "rayproject/ray:${1}-aarch64" ;;
+    *) echo "rayproject/ray:${1}" ;;
+  esac
+}
+
+main() {
+  echo "==> KubeRay ${KUBERAY_VERSION}"
+  helm repo add kuberay https://ray-project.github.io/kuberay-helm/ >/dev/null 2>&1 || true
+  helm repo update kuberay >/dev/null
+  helm upgrade -i kuberay-operator kuberay/kuberay-operator --version "${KUBERAY_VERSION}" \
+    -n ray --create-namespace >/dev/null
+  rollout_wait ray deploy/kuberay-operator 120s
+  # Pre-load the Ray image into kind as ray-e2e:local so the RayCluster and RayJob
+  # cases do not pull ~3GB from Docker Hub mid-test. arch_ray_ref picks the
+  # arch-native variant (the amd64 image under qemu crash-loops running a RayJob).
+  preload_image "$(arch_ray_ref "${RAY_VERSION}")" ray-e2e:local
+}
+
+main "$@"

--- a/hack/e2e/operators/kuberay/smoke.yaml
+++ b/hack/e2e/operators/kuberay/smoke.yaml
@@ -5,13 +5,14 @@
 # waits for KubeRay to drive it to .status.state=ready before the e2e suite relies
 # on it. Uses the ray-e2e:local image the module preloads. The head probes are a
 # permissive tcpSocket on the GCS port so the head goes Ready on a CPU-only node.
+# verify.sh substitutes ${RAY_VERSION} (global.env) into rayVersion before apply.
 apiVersion: ray.io/v1
 kind: RayCluster
 metadata:
   name: ray-smoke
   namespace: default
 spec:
-  rayVersion: "2.40.0"
+  rayVersion: "${RAY_VERSION}"
   headGroupSpec:
     rayStartParams: {}
     template:

--- a/hack/e2e/operators/kuberay/smoke.yaml
+++ b/hack/e2e/operators/kuberay/smoke.yaml
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# Smoke test for the KubeRay install: up.sh creates this head-only RayCluster and
+# waits for KubeRay to drive it to .status.state=ready before the e2e suite relies
+# on it. Uses the ray-e2e:local image the module preloads. The head probes are a
+# permissive tcpSocket on the GCS port so the head goes Ready on a CPU-only node.
+apiVersion: ray.io/v1
+kind: RayCluster
+metadata:
+  name: ray-smoke
+  namespace: default
+spec:
+  rayVersion: "2.40.0"
+  headGroupSpec:
+    rayStartParams: {}
+    template:
+      spec:
+        containers:
+          - name: ray-head
+            image: ray-e2e:local
+            imagePullPolicy: IfNotPresent
+            resources:
+              requests: {cpu: 250m, memory: 1Gi}
+              limits: {cpu: "1", memory: 2Gi}
+            readinessProbe:
+              tcpSocket: {port: 6379}
+              initialDelaySeconds: 10
+              periodSeconds: 5
+              failureThreshold: 30
+            livenessProbe:
+              tcpSocket: {port: 6379}
+              initialDelaySeconds: 30
+              periodSeconds: 10
+              failureThreshold: 30

--- a/hack/e2e/operators/kuberay/verify.sh
+++ b/hack/e2e/operators/kuberay/verify.sh
@@ -3,10 +3,15 @@
 # Copyright (c) 2026 NVIDIA Corporation
 #
 # Smoke test for KubeRay: a throwaway RayCluster must reach state=ready.
+# shellcheck disable=SC2154  # RAY_VERSION comes from global.env via _common.sh
 set -euo pipefail
 MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=/dev/null
 source "${MODULE_DIR}/../_common.sh"
 
 echo "==> smoke: raycluster/ray-smoke"
-run_smoke "${MODULE_DIR}/smoke.yaml" "raycluster/ray-smoke" "jsonpath={.status.state}=ready" "480s" default
+# Render RAY_VERSION (global.env) into rayVersion so it matches the preloaded image.
+rendered="$(mktemp)"
+trap 'rm -f "${rendered}"' EXIT
+sed "s|\${RAY_VERSION}|${RAY_VERSION}|g" "${MODULE_DIR}/smoke.yaml" >"${rendered}"
+run_smoke "${rendered}" "raycluster/ray-smoke" "jsonpath={.status.state}=ready" "480s" default

--- a/hack/e2e/operators/kuberay/verify.sh
+++ b/hack/e2e/operators/kuberay/verify.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# Smoke test for KubeRay: a throwaway RayCluster must reach state=ready.
+set -euo pipefail
+MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${MODULE_DIR}/../_common.sh"
+
+echo "==> smoke: raycluster/ray-smoke"
+run_smoke "${MODULE_DIR}/smoke.yaml" "raycluster/ray-smoke" "jsonpath={.status.state}=ready" "480s" default

--- a/hack/e2e/operators/lws/install.sh
+++ b/hack/e2e/operators/lws/install.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# LeaderWorkerSet operator (sigs.k8s.io/lws).
+# shellcheck disable=SC2154  # LWS_VERSION comes from global.env via _common.sh
+set -euo pipefail
+MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${MODULE_DIR}/../_common.sh"
+
+main() {
+  echo "==> LeaderWorkerSet ${LWS_VERSION}"
+  kubectl apply --server-side -f "https://github.com/kubernetes-sigs/lws/releases/download/${LWS_VERSION}/manifests.yaml"
+  rollout_wait lws-system deploy/lws-controller-manager
+}
+
+main "$@"

--- a/hack/e2e/operators/lws/smoke.yaml
+++ b/hack/e2e/operators/lws/smoke.yaml
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# Smoke test for the LeaderWorkerSet install: up.sh creates this LeaderWorkerSet
+# and waits for the operator to bring it Available before the e2e suite relies on
+# it. The containers only sleep, so it reaches a stable state on a CPU-only node.
+apiVersion: leaderworkerset.x-k8s.io/v1
+kind: LeaderWorkerSet
+metadata:
+  name: lws-smoke
+  namespace: default
+spec:
+  replicas: 1
+  leaderWorkerTemplate:
+    size: 2
+    leaderTemplate:
+      spec:
+        containers:
+          - name: leader
+            image: busybox:1.36
+            command: ["sleep", "infinity"]
+            resources:
+              requests: {cpu: 50m, memory: 32Mi}
+    workerTemplate:
+      spec:
+        containers:
+          - name: worker
+            image: busybox:1.36
+            command: ["sleep", "infinity"]
+            resources:
+              requests: {cpu: 50m, memory: 32Mi}

--- a/hack/e2e/operators/lws/verify.sh
+++ b/hack/e2e/operators/lws/verify.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# Smoke test for LeaderWorkerSet: a throwaway LWS must reach Available.
+set -euo pipefail
+MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${MODULE_DIR}/../_common.sh"
+
+echo "==> smoke: leaderworkerset/lws-smoke"
+run_smoke "${MODULE_DIR}/smoke.yaml" "leaderworkerset/lws-smoke" "condition=Available" "120s" default

--- a/hack/e2e/operators/milvus/install.sh
+++ b/hack/e2e/operators/milvus/install.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# milvus-operator (standalone Milvus).
+# shellcheck disable=SC2154  # MILVUS_OPERATOR_VERSION comes from global.env via _common.sh
+set -euo pipefail
+MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${MODULE_DIR}/../_common.sh"
+
+main() {
+  echo "==> milvus-operator ${MILVUS_OPERATOR_VERSION}"
+  helm repo add milvus-operator https://zilliztech.github.io/milvus-operator/ >/dev/null 2>&1 || true
+  helm repo update milvus-operator >/dev/null
+  helm upgrade -i milvus-operator milvus-operator/milvus-operator \
+    --version "${MILVUS_OPERATOR_VERSION}" -n milvus-operator --create-namespace --wait --timeout 5m >/dev/null
+}
+
+main "$@"

--- a/hack/e2e/operators/milvus/smoke.yaml
+++ b/hack/e2e/operators/milvus/smoke.yaml
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# Smoke test for the milvus-operator install: up.sh creates this standalone
+# Milvus and waits for the operator to drive it to MilvusReady (etcd + MinIO +
+# the standalone pod) before the e2e suite relies on it. Fails fast here if the
+# operator is broken rather than mid-suite.
+apiVersion: milvus.io/v1beta1
+kind: Milvus
+metadata:
+  name: milvus-smoke
+  namespace: default
+spec:
+  mode: standalone
+  dependencies:
+    etcd:
+      inCluster:
+        values:
+          replicaCount: 1
+    storage:
+      inCluster:
+        values:
+          mode: standalone
+          resources:
+            requests:
+              memory: 256Mi
+  components:
+    standalone:
+      replicas: 1
+      resources:
+        requests:
+          cpu: 250m
+          memory: 1Gi

--- a/hack/e2e/operators/milvus/verify.sh
+++ b/hack/e2e/operators/milvus/verify.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# Smoke test for milvus-operator: a throwaway standalone Milvus must reach MilvusReady.
+set -euo pipefail
+MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${MODULE_DIR}/../_common.sh"
+
+echo "==> smoke: milvus/milvus-smoke"
+run_smoke "${MODULE_DIR}/smoke.yaml" "milvus/milvus-smoke" "condition=MilvusReady" "480s" default

--- a/hack/e2e/operators/nim/image/Dockerfile
+++ b/hack/e2e/operators/nim/image/Dockerfile
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# Fictive CPU NIM stand-in: a static Go binary on a distroless base. The final
+# image has no shell, package manager, Python runtime, or third-party packages,
+# so it carries effectively no CVEs. The build uses the standard library only,
+# so it needs no module downloads.
+FROM golang:1.23-bookworm AS build
+WORKDIR /src
+COPY go.mod .
+COPY main.go .
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /nim .
+
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY --from=build /nim /nim
+EXPOSE 8000
+ENTRYPOINT ["/nim"]

--- a/hack/e2e/operators/nim/image/README.md
+++ b/hack/e2e/operators/nim/image/README.md
@@ -1,0 +1,55 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright (c) 2026 NVIDIA Corporation -->
+
+# Fictive CPU NIM image
+
+A small stand-in for an NVIDIA NIM container, used by the Karta e2e cluster so the
+k8s-nim-operator can drive a NIMService to Ready without a GPU or a real NGC token.
+It is a Go HTTP server (see `main.go`) answering the endpoints the operator probes,
+in particular `GET /v1/health/ready`, so the operator drives the NIMService to
+`state=Ready`. It serves dummy responses only; it loads no model and performs no
+inference.
+
+The server uses the Go standard library only and ships as a static binary on a
+distroless base (see `Dockerfile`), so the image carries no Python runtime or
+third-party package CVEs.
+
+## What Karta uses
+
+The operator only needs the readiness endpoint to mark the NIMService ready:
+
+- HTTP on port 8000.
+- `GET /v1/health/ready` and `GET /v1/health/live` for health probing.
+- `GET /v1/models`, `POST /v1/chat/completions`, `GET /v1/metrics` for
+  completeness; the Karta suite does not exercise these.
+
+## How the suite builds it
+
+`hack/e2e/up.sh` builds and loads the image into the kind cluster:
+
+```sh
+docker build -t nim-cpu:e2e hack/e2e/operators/nim/image
+kind load docker-image nim-cpu:e2e --name karta-e2e
+```
+
+The NIMService smoke test (`hack/e2e/operators/nim/smoke.yaml`) references
+`nim-cpu:e2e`, and `up.sh` creates a dummy `ngc-secret` (`NGC_API_KEY`) that the
+operator requires but the image ignores.
+
+## Run standalone
+
+```sh
+docker build -t nim-cpu:e2e hack/e2e/operators/nim/image
+docker run -p 8000:8000 nim-cpu:e2e
+curl http://localhost:8000/v1/health/ready
+```
+
+`NIM_REQUEST_LATENCY` (float seconds, default 0) adds a delay to
+`/v1/chat/completions`, simulating processing time. `NIM_HTTP_PORT` overrides the
+listen port (default 8000).
+
+## Files
+
+- `main.go` - the HTTP server (standard library only).
+- `go.mod` - module definition; no third-party dependencies.
+- `Dockerfile` - multi-stage build to a static binary on `distroless/static`.

--- a/hack/e2e/operators/nim/image/go.mod
+++ b/hack/e2e/operators/nim/image/go.mod
@@ -1,0 +1,3 @@
+module nim-cpu
+
+go 1.23

--- a/hack/e2e/operators/nim/image/main.go
+++ b/hack/e2e/operators/nim/image/main.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+//
+// Fictive CPU stand-in for an NVIDIA NIM container, used by the Karta e2e suite.
+// It answers the HTTP endpoints the k8s-nim-operator probes (in particular
+// GET /v1/health/ready) so the operator drives the NIMService to state=Ready.
+// It loads no model and performs no inference.
+//
+// Standard library only: the image is a static binary on a distroless base, so
+// it carries no Python runtime or third-party package CVEs.
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+)
+
+const modelName = "meta/llama-3.2-1b-instruct"
+
+// requestLatency is applied to the chat endpoint to imitate processing time
+// (NIM_REQUEST_LATENCY, seconds). Readiness is always immediate.
+var requestLatency = latencyFromEnv()
+
+func main() {
+	port := getenv("NIM_HTTP_PORT", "8000")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/health/ready", status("ready"))
+	mux.HandleFunc("/v1/health/live", status("alive"))
+	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, map[string]string{"status": "healthy"})
+	})
+	mux.HandleFunc("/v1/models", listModels)
+	mux.HandleFunc("/v1/chat/completions", chatCompletions)
+	mux.HandleFunc("/v1/metrics", metrics)
+	mux.HandleFunc("/", root)
+
+	addr := ":" + port
+	log.Printf("fictive NIM listening on %s (model %s, latency %s)", addr, modelName, requestLatency)
+	srv := &http.Server{Addr: addr, Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+	log.Fatal(srv.ListenAndServe())
+}
+
+func status(state string) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, map[string]string{
+			"status":    state,
+			"model":     modelName,
+			"timestamp": time.Now().UTC().Format(time.RFC3339),
+		})
+	}
+}
+
+func listModels(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, map[string]any{
+		"object": "list",
+		"data": []any{map[string]any{
+			"id":       modelName,
+			"object":   "model",
+			"created":  time.Now().Unix(),
+			"owned_by": "nim-service",
+		}},
+	})
+}
+
+func chatCompletions(w http.ResponseWriter, _ *http.Request) {
+	time.Sleep(requestLatency)
+	writeJSON(w, map[string]any{
+		"id":      "chatcmpl-fictive",
+		"object":  "chat.completion",
+		"created": time.Now().Unix(),
+		"model":   modelName,
+		"choices": []any{map[string]any{
+			"index":         0,
+			"finish_reason": "stop",
+			"message":       map[string]string{"role": "assistant", "content": "This is a simulated NIM response."},
+		}},
+		"usage": map[string]int{"prompt_tokens": 50, "completion_tokens": 25, "total_tokens": 75},
+	})
+}
+
+func metrics(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+	_, _ = w.Write([]byte("# HELP num_requests_running Number of requests currently running\n" +
+		"# TYPE num_requests_running gauge\n" +
+		"num_requests_running 0\n" +
+		"# HELP gpu_cache_usage_perc GPU cache usage percentage\n" +
+		"# TYPE gpu_cache_usage_perc gauge\n" +
+		"gpu_cache_usage_perc 0\n"))
+}
+
+func root(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, map[string]any{
+		"message":   "fictive NVIDIA NIM is running",
+		"model":     modelName,
+		"endpoints": []string{"/v1/models", "/v1/chat/completions", "/v1/health/ready", "/v1/health/live", "/v1/metrics"},
+	})
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func getenv(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func latencyFromEnv() time.Duration {
+	if v := os.Getenv("NIM_REQUEST_LATENCY"); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil && f > 0 {
+			return time.Duration(f * float64(time.Second))
+		}
+	}
+	return 0
+}

--- a/hack/e2e/operators/nim/image/main.go
+++ b/hack/e2e/operators/nim/image/main.go
@@ -41,7 +41,15 @@ func main() {
 
 	addr := ":" + port
 	log.Printf("fictive NIM listening on %s (model %s, latency %s)", addr, modelName, requestLatency)
-	srv := &http.Server{Addr: addr, Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		// WriteTimeout must exceed NIM_REQUEST_LATENCY (the chat handler sleeps).
+		WriteTimeout: 30 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
 	log.Fatal(srv.ListenAndServe())
 }
 

--- a/hack/e2e/operators/nim/install.sh
+++ b/hack/e2e/operators/nim/install.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# k8s-nim-operator with a fictive CPU NIM image (no GPU or NGC token needed). Ships
+# an image build context (image/). The operator chart is not published to a Helm/OCI
+# registry, so it is fetched at install time from the pinned upstream git tag
+# (NIM_OPERATOR_VERSION) rather than vendored in-repo.
+# shellcheck disable=SC2154  # NIM_OPERATOR_VERSION comes from global.env via _common.sh
+set -euo pipefail
+MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${MODULE_DIR}/../_common.sh"
+
+main() {
+  echo "==> fake NIM image + k8s-nim-operator"
+  build_and_load_image "${MODULE_DIR}/image" nim-cpu:e2e
+  # The dev chart ships incomplete RBAC (cannot list computedomains/ingress/hpa/lws ->
+  # cache-sync crashloop), so grant the operator broad access on this throwaway cluster.
+  kubectl create clusterrolebinding k8s-nim-operator-admin \
+    --clusterrole=cluster-admin --serviceaccount=nim-operator:k8s-nim-operator \
+    --dry-run=client -o yaml | kubectl apply -f -
+  # Install only when absent: the chart's pre-upgrade CRD-migration hook Job
+  # crashloops when re-run, so plain "helm upgrade -i" is not idempotent here.
+  if helm status k8s-nim-operator -n nim-operator >/dev/null 2>&1; then
+    echo "    k8s-nim-operator release already present; skipping reinstall"
+  else
+    # The operator chart is not published to a Helm/OCI registry, only in-repo,
+    # so fetch it from the pinned upstream tag at install time instead of
+    # vendoring it. The tag tarball extracts to k8s-nim-operator-<version>/.
+    local src chart
+    src="$(mktemp -d)"
+    curl -fsSL "https://github.com/NVIDIA/k8s-nim-operator/archive/refs/tags/${NIM_OPERATOR_VERSION}.tar.gz" \
+      | tar -xz -C "${src}"
+    chart="$(ls -d "${src}"/k8s-nim-operator-*/deployments/helm/k8s-nim-operator)"
+    helm install k8s-nim-operator "${chart}" -n nim-operator --create-namespace >/dev/null
+    rm -rf "${src}"
+  fi
+  rollout_wait nim-operator deploy/k8s-nim-operator
+  # Dummy NGC secret: the operator injects NGC_API_KEY from it; the fictive image ignores it.
+  ensure_secret default ngc-secret NGC_API_KEY=dummy-not-a-real-token
+}
+
+main "$@"

--- a/hack/e2e/operators/nim/install.sh
+++ b/hack/e2e/operators/nim/install.sh
@@ -28,13 +28,21 @@ main() {
     # The operator chart is not published to a Helm/OCI registry, only in-repo,
     # so fetch it from the pinned upstream tag at install time instead of
     # vendoring it. The tag tarball extracts to k8s-nim-operator-<version>/.
-    local src chart
+    # src is not local so the EXIT trap can resolve it under set -u (cleans up even
+    # if a step below fails).
+    local chart="" d
     src="$(mktemp -d)"
+    trap 'rm -rf "${src}"' EXIT
     curl -fsSL "https://github.com/NVIDIA/k8s-nim-operator/archive/refs/tags/${NIM_OPERATOR_VERSION}.tar.gz" \
       | tar -xz -C "${src}"
-    chart="$(ls -d "${src}"/k8s-nim-operator-*/deployments/helm/k8s-nim-operator)"
+    for d in "${src}"/k8s-nim-operator-*/deployments/helm/k8s-nim-operator; do
+      [ -d "${d}" ] && chart="${d}"
+    done
+    if [ -z "${chart}" ]; then
+      echo "error: k8s-nim-operator Helm chart not found in the ${NIM_OPERATOR_VERSION} tarball (upstream layout changed?)" >&2
+      exit 1
+    fi
     helm install k8s-nim-operator "${chart}" -n nim-operator --create-namespace >/dev/null
-    rm -rf "${src}"
   fi
   rollout_wait nim-operator deploy/k8s-nim-operator
   # Dummy NGC secret: the operator injects NGC_API_KEY from it; the fictive image ignores it.

--- a/hack/e2e/operators/nim/smoke.yaml
+++ b/hack/e2e/operators/nim/smoke.yaml
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# Smoke test for the k8s-nim-operator install: up.sh creates this NIMService
+# backed by the fictive CPU image (nim-cpu:e2e) the module builds, and waits for
+# the operator to drive it to state=Ready before the e2e suite relies on it. Uses
+# the dummy ngc-secret the module creates. Fails fast here if the operator is broken.
+apiVersion: apps.nvidia.com/v1alpha1
+kind: NIMService
+metadata:
+  name: nim-smoke
+  namespace: default
+spec:
+  image:
+    repository: nim-cpu
+    tag: e2e
+    pullPolicy: IfNotPresent
+  authSecret: ngc-secret
+  storage:
+    pvc:
+      create: true
+      size: 1Gi
+      volumeAccessMode: ReadWriteOnce
+  replicas: 1
+  expose:
+    service:
+      type: ClusterIP
+      port: 8000
+  env:
+    - name: NIM_REQUEST_LATENCY
+      value: "2"

--- a/hack/e2e/operators/nim/verify.sh
+++ b/hack/e2e/operators/nim/verify.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# Smoke test for k8s-nim-operator: a throwaway NIMService (fictive CPU image) must
+# reach state=Ready.
+set -euo pipefail
+MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${MODULE_DIR}/../_common.sh"
+
+echo "==> smoke: nimservice/nim-smoke"
+run_smoke "${MODULE_DIR}/smoke.yaml" "nimservice/nim-smoke" "jsonpath={.status.state}=Ready" "300s" default

--- a/hack/e2e/up.sh
+++ b/hack/e2e/up.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# Provision a local kind cluster for the Karta e2e suite: builds and deploys the
+# Karta operator, then installs the dependencies the suite needs (cert-manager,
+# the fake-gpu-operator) and the upstream workload operators it exercises. Each
+# operator is smoke-tested as it installs, so a broken install fails provisioning.
+#
+# Usage:
+#   ./hack/e2e/up.sh                 # install everything (default)
+#   ./hack/e2e/up.sh jobset kuberay  # install only the named workload operators
+#   ./hack/e2e/up.sh --list jobset   # print the resolved install plan and exit
+#   ./hack/e2e/up.sh --help
+#
+# Each workload operator is a standalone script under hack/e2e/operators/<name>/:
+# install.sh does the install, verify.sh smoke-tests it. up.sh runs them as
+# subprocesses (install then verify), so the two concerns stay decoupled and each
+# script is runnable on its own. The always-on base (kind cluster, cert-manager,
+# fake-gpu-operator, the Karta operator) is installed regardless of selection.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OPERATORS_DIR="${REPO_ROOT}/hack/e2e/operators"
+# Shared helpers + GitHub Actions logging. Sourcing this also loads
+# hack/e2e/global.env (version pins and the CLUSTER_NAME/IMAGE runtime defaults).
+# shellcheck source=/dev/null
+source "${OPERATORS_DIR}/_common.sh"
+
+DEFAULT_CLUSTER="karta-e2e"
+# CLUSTER_NAME and IMAGE come from global.env (overridable from the environment).
+# Each non-default cluster gets its own kubeconfig, so several clusters (for
+# example two CI shards installing different operators) can be provisioned in
+# parallel without racing on the shared current-context. The default cluster keeps
+# the standard kubeconfig so plain kubectl works after e2e-up.
+if [ -z "${KUBECONFIG:-}" ] && [ "${CLUSTER_NAME}" != "${DEFAULT_CLUSTER}" ]; then
+  KUBECONFIG="${HOME}/.kube/kind-${CLUSTER_NAME}.kubeconfig"
+  mkdir -p "$(dirname "${KUBECONFIG}")"
+  export KUBECONFIG
+fi
+# The per-operator install.sh/verify.sh run as subprocesses; export the context
+# they need so they inherit it (version pins come from global.env via _common.sh).
+export CLUSTER_NAME IMAGE REPO_ROOT
+
+# Workload operators selectable on the command line, in canonical install order:
+# a dependency always appears before its dependents (knative before kserve,
+# grove before dynamo).
+ALL_WORKLOADS=(lws jobset kuberay kubeflow knative kserve milvus grove dynamo nim)
+
+# deps_of <workload> prints the workload operators that must be installed first.
+deps_of() {
+  case "$1" in
+    kserve) echo "knative" ;; # KServe Serverless routes through Knative + Kourier
+    dynamo) echo "grove" ;;   # Grove is Dynamo's multinode orchestrator
+  esac
+}
+
+# version_of <workload> prints its pinned version, for the job-summary table.
+version_of() {
+  case "$1" in
+    lws) echo "${LWS_VERSION}" ;;
+    jobset) echo "${JOBSET_VERSION}" ;;
+    kuberay) echo "${KUBERAY_VERSION}" ;;
+    kubeflow) echo "${KUBEFLOW_VERSION}" ;;
+    knative) echo "${KNATIVE_VERSION}" ;;
+    kserve) echo "${KSERVE_VERSION}" ;;
+    milvus) echo "${MILVUS_OPERATOR_VERSION}" ;;
+    grove) echo "${GROVE_VERSION}" ;;
+    dynamo) echo "${DYNAMO_VERSION}" ;;
+    nim) echo "${NIM_OPERATOR_VERSION}" ;;
+    *) echo "?" ;;
+  esac
+}
+
+usage() {
+  cat >&2 <<EOF
+Usage: $0 [--list] [workload...]
+  No workload args (or "all") installs everything. Named args install the base
+  plus only those workload operators (and their dependencies).
+  Workloads: ${ALL_WORKLOADS[*]}
+  --list    print the resolved install plan and exit
+EOF
+}
+
+# --- base (always installed) -------------------------------------------------
+
+# require_tools fails fast with a clear message if a needed binary is missing,
+# rather than erroring cryptically partway through provisioning.
+require_tools() {
+  local missing=()
+  for t in docker kind kubectl helm curl; do
+    command -v "$t" >/dev/null 2>&1 || missing+=("$t")
+  done
+  if [ "${#missing[@]}" -gt 0 ]; then
+    echo "error: missing required tools: ${missing[*]}" >&2
+    echo "install them and re-run." >&2
+    exit 1
+  fi
+}
+
+setup_cluster() {
+  echo "==> build operator image (${IMAGE})"
+  # Build output is left visible: a failing image build is the first thing to debug.
+  docker build --build-arg "GO_VERSION=${GO_VERSION}" \
+    -f "${REPO_ROOT}/operator/Dockerfile" -t "${IMAGE}" "${REPO_ROOT}"
+
+  if kind get clusters 2>/dev/null | grep -qx "${CLUSTER_NAME}"; then
+    echo "==> reusing existing kind cluster (${CLUSTER_NAME})"
+    # Re-export the kubeconfig: the cluster can outlive its context (a reset or
+    # overwritten ~/.kube/config), and "kind create" is skipped on this path.
+    kind export kubeconfig --name "${CLUSTER_NAME}" >/dev/null
+  else
+    echo "==> create kind cluster (${CLUSTER_NAME}, ${KIND_NODE_IMAGE})"
+    kind create cluster --name "${CLUSTER_NAME}" --image "${KIND_NODE_IMAGE}" \
+      --config "${REPO_ROOT}/hack/e2e/kind-config.yaml"
+  fi
+  # Pin kubectl to this cluster so every step below targets it, not a stale context.
+  kubectl config use-context "kind-${CLUSTER_NAME}" >/dev/null
+  echo "==> load operator image"
+  kind load docker-image "${IMAGE}" --name "${CLUSTER_NAME}"
+  kubectl wait --for=condition=Ready nodes --all --timeout=120s
+  # Untaint the control-plane so its capacity is schedulable: the single worker
+  # cannot hold every operator plus a real Milvus/Knative/KServe workload at once.
+  kubectl taint nodes "${CLUSTER_NAME}-control-plane" \
+    node-role.kubernetes.io/control-plane:NoSchedule- 2>/dev/null || true
+}
+
+install_cert_manager() {
+  kubectl apply -f "https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml"
+  for d in cert-manager cert-manager-webhook cert-manager-cainjector; do
+    rollout_wait cert-manager "deploy/${d}"
+  done
+}
+
+install_fake_gpu() {
+  kubectl label node "${CLUSTER_NAME}-worker" run.ai/simulated-gpu-node-pool=default --overwrite
+  helm upgrade -i fake-gpu-operator oci://ghcr.io/run-ai/fake-gpu-operator/fake-gpu-operator \
+    -n gpu-operator --create-namespace --version "${FAKE_GPU_VERSION}" \
+    --set computeDomainDraPlugin.enabled=true >/dev/null
+}
+
+install_karta() {
+  kubectl apply --server-side -f "${REPO_ROOT}/charts/karta/crds/"
+  helm upgrade -i karta "${REPO_ROOT}/charts/karta" -n karta-system --create-namespace \
+    --set image.repository="${IMAGE%%:*}" --set image.tag="${IMAGE##*:}" \
+    --set resources.limits.memory="${KARTA_OPERATOR_MEMORY}" >/dev/null
+  rollout_wait karta-system deploy/karta-operator 120s
+}
+
+# --- selectable workload operators -------------------------------------------
+
+# run_operator <name>: run the operator's standalone install.sh then verify.sh,
+# each as a subprocess, grouped in the CI log and recording a job-summary row.
+# Exits non-zero on the first failure so a broken operator fails provisioning fast
+# rather than partway through the e2e suite.
+run_operator() {
+  local name="$1" dir="${OPERATORS_DIR}/$1" ver
+  ver="$(version_of "${name}")"
+  [ -f "${dir}/install.sh" ] || { fail "no install.sh for operator ${name}"; exit 1; }
+  group "operator: ${name} (${ver})"
+  # SECONDS is a bash builtin counting elapsed seconds; diff it to time each phase.
+  local t0=$SECONDS irc=0
+  bash "${dir}/install.sh" || irc=$?
+  local idur=$((SECONDS - t0))
+  if [ "${irc}" -ne 0 ]; then
+    endgroup
+    echo "==> ${name}: install FAILED after ${idur}s"
+    # :x: renders as a red X in the GitHub summary; ASCII in the source.
+    summary "| :x: | ${name} | ${ver} | fail (${idur}s) | - |"
+    fail "install ${name} failed (exit ${irc}, ${idur}s)"
+    exit 1
+  fi
+  local smoke="n/a" vdur=0
+  if [ -f "${dir}/verify.sh" ]; then
+    local t1=$SECONDS src=0
+    bash "${dir}/verify.sh" || src=$?
+    vdur=$((SECONDS - t1))
+    if [ "${src}" -ne 0 ]; then
+      endgroup
+      echo "==> ${name}: smoke FAILED after ${vdur}s"
+      summary "| :x: | ${name} | ${ver} | ${idur}s | fail (${vdur}s) |"
+      fail "smoke ${name} failed (exit ${src}, ${vdur}s)"
+      exit 1
+    fi
+    smoke="${vdur}s"
+  fi
+  endgroup
+  # Ungrouped, so the outcome is visible without expanding the group above.
+  echo "==> ${name}: ready (install ${idur}s, smoke ${smoke})"
+  summary "| :white_check_mark: | ${name} | ${ver} | ${idur}s | ${smoke} |"
+}
+
+main() {
+  local plan_only=false
+  local requested=()
+  for arg in "$@"; do
+    case "$arg" in
+      -h | --help) usage; exit 0 ;;
+      --list | --plan) plan_only=true ;;
+      -*) echo "unknown flag: $arg" >&2; usage; exit 2 ;;
+      *) requested+=("$arg") ;;
+    esac
+  done
+
+  # Resolve the selection: no names means every workload.
+  # "all" is a convenience alias for every workload (same as passing no args).
+  for w in "${requested[@]}"; do
+    [ "$w" = "all" ] && { requested=("${ALL_WORKLOADS[@]}"); break; }
+  done
+
+  local selected=()
+  if [ "${#requested[@]}" -eq 0 ]; then
+    selected=("${ALL_WORKLOADS[@]}")
+  else
+    for w in "${requested[@]}"; do
+      printf '%s\n' "${ALL_WORKLOADS[@]}" | grep -qxF "$w" ||
+        { echo "unknown workload: $w" >&2; usage; exit 2; }
+    done
+    selected=("${requested[@]}")
+    for w in "${requested[@]}"; do
+      for d in $(deps_of "$w"); do selected+=("$d"); done
+    done
+  fi
+
+  # Build the ordered plan by walking the canonical order and keeping selected ones.
+  local plan=()
+  for w in "${ALL_WORKLOADS[@]}"; do
+    if printf '%s\n' "${selected[@]}" | grep -qxF "$w"; then plan+=("$w"); fi
+  done
+
+  if [ "$plan_only" = true ]; then
+    echo "base: kind cluster, cert-manager, fake-gpu-operator, karta"
+    if [ "${#plan[@]}" -gt 0 ]; then echo "workloads: ${plan[*]}"; else echo "workloads: (none)"; fi
+    exit 0
+  fi
+
+  require_tools
+  group "build image + kind cluster"; setup_cluster; endgroup
+  group "cert-manager ${CERT_MANAGER_VERSION}"; install_cert_manager; endgroup
+  group "fake-gpu-operator ${FAKE_GPU_VERSION}"; install_fake_gpu; endgroup
+  if [ "${#plan[@]}" -gt 0 ]; then
+    summary "## E2E install: ${CLUSTER_NAME}"
+    summary ""
+    summary "|  | Operator | Version | Install | Smoke |"
+    summary "|---|---|---|---|---|"
+    for w in "${plan[@]}"; do run_operator "$w"; done
+  fi
+  group "karta operator"; install_karta; endgroup
+
+  echo "==> environment ready (cluster: ${CLUSTER_NAME})."
+  if [ "${CLUSTER_NAME}" != "${DEFAULT_CLUSTER}" ]; then
+    echo "    this cluster has its own kubeconfig: ${KUBECONFIG}"
+    echo "    export KUBECONFIG=${KUBECONFIG} to use kubectl against it"
+  fi
+}
+
+main "$@"

--- a/hack/e2e/up.sh
+++ b/hack/e2e/up.sh
@@ -88,7 +88,7 @@ EOF
 # rather than erroring cryptically partway through provisioning.
 require_tools() {
   local missing=()
-  for t in docker kind kubectl helm curl; do
+  for t in docker kind kubectl helm curl tar; do
     command -v "$t" >/dev/null 2>&1 || missing+=("$t")
   done
   if [ "${#missing[@]}" -gt 0 ]; then
@@ -133,16 +133,20 @@ install_cert_manager() {
 }
 
 install_fake_gpu() {
-  kubectl label node "${CLUSTER_NAME}-worker" run.ai/simulated-gpu-node-pool=default --overwrite
+  # Label every worker (by role selector, not a hardcoded node name) so this still
+  # works if kind-config.yaml grows more workers.
+  kubectl label nodes -l '!node-role.kubernetes.io/control-plane' \
+    run.ai/simulated-gpu-node-pool=default --overwrite
+  # --wait so later steps do not race a not-yet-ready operator.
   helm upgrade -i fake-gpu-operator oci://ghcr.io/run-ai/fake-gpu-operator/fake-gpu-operator \
     -n gpu-operator --create-namespace --version "${FAKE_GPU_VERSION}" \
-    --set computeDomainDraPlugin.enabled=true >/dev/null
+    --set computeDomainDraPlugin.enabled=true --wait --timeout 3m >/dev/null
 }
 
 install_karta() {
   kubectl apply --server-side -f "${REPO_ROOT}/charts/karta/crds/"
   helm upgrade -i karta "${REPO_ROOT}/charts/karta" -n karta-system --create-namespace \
-    --set image.repository="${IMAGE%%:*}" --set image.tag="${IMAGE##*:}" \
+    --set image.repository="${IMAGE%:*}" --set image.tag="${IMAGE##*:}" \
     --set resources.limits.memory="${KARTA_OPERATOR_MEMORY}" >/dev/null
   rollout_wait karta-system deploy/karta-operator 120s
 }

--- a/hack/e2e/up.sh
+++ b/hack/e2e/up.sh
@@ -3,21 +3,9 @@
 # Copyright (c) 2026 NVIDIA Corporation
 #
 # Provision a local kind cluster for the Karta e2e suite: builds and deploys the
-# Karta operator, then installs the dependencies the suite needs (cert-manager,
-# the fake-gpu-operator) and the upstream workload operators it exercises. Each
-# operator is smoke-tested as it installs, so a broken install fails provisioning.
-#
-# Usage:
-#   ./hack/e2e/up.sh                 # install everything (default)
-#   ./hack/e2e/up.sh jobset kuberay  # install only the named workload operators
-#   ./hack/e2e/up.sh --list jobset   # print the resolved install plan and exit
-#   ./hack/e2e/up.sh --help
-#
-# Each workload operator is a standalone script under hack/e2e/operators/<name>/:
-# install.sh does the install, verify.sh smoke-tests it. up.sh runs them as
-# subprocesses (install then verify), so the two concerns stay decoupled and each
-# script is runnable on its own. The always-on base (kind cluster, cert-manager,
-# fake-gpu-operator, the Karta operator) is installed regardless of selection.
+# Karta operator, installs the base dependencies (cert-manager, fake-gpu-operator),
+# and installs the selected upstream workload operators, smoke-testing each one as
+# it installs. Run with --help for usage; see hack/e2e/README.md for the details.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -50,8 +38,8 @@ ALL_WORKLOADS=(lws jobset kuberay kubeflow knative kserve milvus grove dynamo ni
 # deps_of <workload> prints the workload operators that must be installed first.
 deps_of() {
   case "$1" in
-    kserve) echo "knative" ;; # KServe Serverless routes through Knative + Kourier
-    dynamo) echo "grove" ;;   # Grove is Dynamo's multinode orchestrator
+    kserve) echo "knative" ;;
+    dynamo) echo "grove" ;;
   esac
 }
 
@@ -119,10 +107,6 @@ setup_cluster() {
   echo "==> load operator image"
   kind load docker-image "${IMAGE}" --name "${CLUSTER_NAME}"
   kubectl wait --for=condition=Ready nodes --all --timeout=120s
-  # Untaint the control-plane so its capacity is schedulable: the single worker
-  # cannot hold every operator plus a real Milvus/Knative/KServe workload at once.
-  kubectl taint nodes "${CLUSTER_NAME}-control-plane" \
-    node-role.kubernetes.io/control-plane:NoSchedule- 2>/dev/null || true
 }
 
 install_cert_manager() {
@@ -158,7 +142,8 @@ install_karta() {
 # Exits non-zero on the first failure so a broken operator fails provisioning fast
 # rather than partway through the e2e suite.
 run_operator() {
-  local name="$1" dir="${OPERATORS_DIR}/$1" ver
+  local name="$1" dir="${OPERATORS_DIR}/$1"
+  local ver
   ver="$(version_of "${name}")"
   [ -f "${dir}/install.sh" ] || { fail "no install.sh for operator ${name}"; exit 1; }
   group "operator: ${name} (${ver})"
@@ -200,17 +185,19 @@ main() {
   for arg in "$@"; do
     case "$arg" in
       -h | --help) usage; exit 0 ;;
-      --list | --plan) plan_only=true ;;
+      --list) plan_only=true ;;
       -*) echo "unknown flag: $arg" >&2; usage; exit 2 ;;
       *) requested+=("$arg") ;;
     esac
   done
 
-  # Resolve the selection: no names means every workload.
-  # "all" is a convenience alias for every workload (same as passing no args).
-  for w in "${requested[@]}"; do
-    [ "$w" = "all" ] && { requested=("${ALL_WORKLOADS[@]}"); break; }
-  done
+  # "all" is an alias for every workload (same as passing no args). Guard the
+  # expansion so bare "up.sh" does not trip set -u on the empty array (bash 3.2).
+  if [ "${#requested[@]}" -gt 0 ]; then
+    for w in "${requested[@]}"; do
+      [ "$w" = "all" ] && { requested=("${ALL_WORKLOADS[@]}"); break; }
+    done
+  fi
 
   local selected=()
   if [ "${#requested[@]}" -eq 0 ]; then

--- a/hack/e2e/up.sh
+++ b/hack/e2e/up.sh
@@ -49,7 +49,7 @@ version_of() {
     lws) echo "${LWS_VERSION}" ;;
     jobset) echo "${JOBSET_VERSION}" ;;
     kuberay) echo "${KUBERAY_VERSION}" ;;
-    kubeflow) echo "${KUBEFLOW_VERSION}" ;;
+    kubeflow) echo "${KUBEFLOW_VERSION}+mpi${MPI_OPERATOR_VERSION}" ;;
     knative) echo "${KNATIVE_VERSION}" ;;
     kserve) echo "${KSERVE_VERSION}" ;;
     milvus) echo "${MILVUS_OPERATOR_VERSION}" ;;


### PR DESCRIPTION
## What does this PR do?

Adds `hack/e2e`: a standalone provisioner that stands up a local kind cluster, builds and deploys the Karta operator, and installs the upstream workload operators the e2e suite exercises (cert-manager, fake-gpu-operator, LeaderWorkerSet, JobSet, KubeRay, Kubeflow training-operator, Knative + Kourier, KServe, milvus, Grove + kai-scheduler, dynamo, k8s-nim-operator).

Each operator is its own standalone `install.sh` + `verify.sh` smoke test; versions are pinned in `global.env`; `up.sh` resolves dependencies (kserve pulls knative, dynamo pulls grove) and prints a per-operator install summary. Adds the Makefile `e2e-up` / `e2e-up-<op>` / `e2e-down` / `lint-shell` targets and a README.

`up.sh` builds the operator image from `operator/Dockerfile` and installs `charts/karta`, both already on `main`, so the provisioner runs end to end today: `make e2e-up` (or a subset, e.g. `make e2e-up-jobset`).

Provisioner only. The e2e test suite (`test/e2e`) and the GitHub Actions workflow land in a follow-up PR.

## Related issue(s)

Relates to #138

## Checklist

- [x] All commits are signed off with DCO (`git commit -s`)
- [x] New/modified files have SPDX license and copyright headers
- [x] Documentation updated (`hack/e2e/README.md`)
- [ ] Tests pass (`make check`) - provisioner only; validated with `make lint-shell` and `./hack/e2e/up.sh --list`
- [x] No proprietary or internal information included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local end-to-end cluster setup/teardown with operator smoke-test orchestration, including per-operator install shortcuts and an `e2e-up-all` option.
  * Added a deterministic CPU-based NIM test image and NIM operator e2e install + smoke verification.
* **Documentation**
  * Documented the e2e workflow, operator selection, and per-operator onboarding steps.
* **Bug Fixes**
  * Improved reliability via rollout readiness waits, retry handling for transient apply/warmup issues, and fail-fast smoke tests.
* **Chores**
  * Added shell linting support for e2e scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->