### PR TITLE
ci: create verified dependabot codegen commits via GitHub API

### DIFF
--- a/.github/workflows/dependabot-codegen.yaml
+++ b/.github/workflows/dependabot-codegen.yaml
@@ -42,17 +42,28 @@ jobs:
       - name: Regenerate generated files
         run: make generate manifests generate-mocks generate-licenses
 
-      - name: Commit and push if changed
-        env:
-          GH_TOKEN: ${{ github.token }}
-          HEAD_REF: ${{ github.head_ref }}
+      - name: Check for drift
+        id: drift
         run: |
           git add -A
           if git diff --cached --quiet; then
-            echo "No drift"
-            exit 0
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit -s -m "build: regenerate files for dependency bump"
-          git push "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}" "HEAD:${HEAD_REF}"
+
+      # A plain `git push` commit is unsigned and blocked by the
+      # required-signatures rule on main. Committing through the GitHub API
+      # (GraphQL createCommitOnBranch) makes GitHub sign the commit, so it
+      # is marked verified. The Signed-off-by trailer replaces `commit -s`.
+      - name: Commit and push if changed
+        if: steps.drift.outputs.changed == 'true'
+        uses: planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465 # v0.2.22
+        with:
+          commit_message: |-
+            build: regenerate files for dependency bump
+            Signed-off-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          repo: ${{ github.repository }}
+          branch: ${{ github.head_ref }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## What does this PR do?

Replaces the plain `git push` in the dependabot-codegen workflow with [planetscale/ghcommit-action](https://github.com/planetscale/ghcommit-action), which creates the regeneration commit through the GitHub GraphQL `createCommitOnBranch` mutation. GitHub signs API-created commits automatically, so the commit is marked verified and no longer blocks dependabot PRs under the required-signatures rule on main (see #147, blocked on an unsigned bot commit).

Notes for discussion per AGENTS.md:
- Workflow change: same trigger, permissions, and token as before; `persist-credentials: false` is kept and the token is exposed only to the commit step. The commit step now runs via a Docker action instead of shell, removing the `${{ }}` interpolation from the push URL.
- New third-party action: planetscale/ghcommit-action v0.2.22, Apache-2.0, pinned by commit SHA (its Docker image is pinned by sha256 digest). Alternatives considered: bot GPG key + git-auto-commit (requires managing a signing secret), inline `gh api graphql` call (reimplements file enumeration/encoding/deletions the action already handles), GitHub App token (not needed since manual approval of the triggered CI run is acceptable).
- The DCO `Signed-off-by` trailer is embedded in the commit message since the commit is no longer created by `git commit -s`.
- Known limitation: CI runs triggered by the GITHUB_TOKEN-authored commit still require manual approval before running; accepted for now.

## Related issue(s)

Fixes #152

## Checklist

- [x] All commits are signed off with DCO (`git commit -s`)
- [x] New/modified files have SPDX license and copyright headers
- [ ] Documentation updated (if applicable)
- [x] Tests pass (`make check`)
- [x] No proprietary or internal information included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated generated-file updates by detecting file drift more reliably.
  * Updated the workflow to create signed, verified commits that meet repository requirements.
  * Simplified automated push handling while preserving existing update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->