### PR TITLE
docs: add KAI Scheduler to who uses Karta section

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ Two runnable examples live under [`docs/examples/`](docs/examples/):
 
 Karta was created at [Run:ai](https://run.ai) (NVIDIA) to power workload management across diverse Kubernetes workload types. It is used internally by multiple services including the workload controllers, scheduler integrations, and platform components.
 
+[KAI Scheduler](https://github.com/kai-scheduler/KAI-Scheduler), an open source Kubernetes scheduler for AI and GPU workloads, uses Karta as the generic fallback plugin in its pod grouper ([kai-scheduler/KAI-Scheduler#1527](https://github.com/kai-scheduler/KAI-Scheduler/issues/1527)). A Karta definition gives any CRD correct pod grouping and gang scheduling in KAI, with no scheduler plugin to write and no KAI release to wait for. Native in-tree plugins keep precedence; Karta handles the long tail.
+
 ## Documentation
 
 - [Technical Guide](docs/Technical%20Guide.md) - Full Karta spec, path syntax (jq), validation rules

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Two runnable examples live under [`docs/examples/`](docs/examples/):
 
 Karta was created at [Run:ai](https://run.ai) (NVIDIA) to power workload management across diverse Kubernetes workload types. It is used internally by multiple services including the workload controllers, scheduler integrations, and platform components.
 
-[KAI Scheduler](https://github.com/kai-scheduler/KAI-Scheduler), an open source Kubernetes scheduler for AI and GPU workloads, uses Karta as the generic fallback plugin in its pod grouper ([kai-scheduler/KAI-Scheduler#1527](https://github.com/kai-scheduler/KAI-Scheduler/issues/1527)). A Karta definition gives any CRD correct pod grouping and gang scheduling in KAI, with no scheduler plugin to write and no KAI release to wait for. Native in-tree plugins keep precedence; Karta handles the long tail.
+[KAI Scheduler](https://github.com/kai-scheduler/KAI-Scheduler),a CNCF sandbox open source Kubernetes scheduler for AI and GPU workloads, uses Karta as the generic fallback plugin in its pod grouper ([kai-scheduler/KAI-Scheduler#1527](https://github.com/kai-scheduler/KAI-Scheduler/issues/1527)). A Karta definition gives any CRD correct pod grouping and gang scheduling in KAI, with no scheduler plugin to write and no KAI release to wait for. Native in-tree plugins keep precedence; Karta handles the long tail.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Two runnable examples live under [`docs/examples/`](docs/examples/):
 
 Karta was created at [Run:ai](https://run.ai) (NVIDIA) to power workload management across diverse Kubernetes workload types. It is used internally by multiple services including the workload controllers, scheduler integrations, and platform components.
 
-[KAI Scheduler](https://github.com/kai-scheduler/KAI-Scheduler),a CNCF sandbox open source Kubernetes scheduler for AI and GPU workloads, uses Karta as the generic fallback plugin in its pod grouper ([kai-scheduler/KAI-Scheduler#1527](https://github.com/kai-scheduler/KAI-Scheduler/issues/1527)). A Karta definition gives any CRD correct pod grouping and gang scheduling in KAI, with no scheduler plugin to write and no KAI release to wait for. Native in-tree plugins keep precedence; Karta handles the long tail.
+[KAI Scheduler](https://github.com/kai-scheduler/KAI-Scheduler), a CNCF sandbox open-source Kubernetes scheduler for AI and GPU workloads, uses Karta as the generic fallback plugin in its pod grouper ([kai-scheduler/KAI-Scheduler#1527](https://github.com/kai-scheduler/KAI-Scheduler/issues/1527)). A Karta definition gives any CRD correct pod grouping and gang scheduling in KAI, with no scheduler plugin to write and no KAI release to wait for. Native in-tree plugins keep precedence; Karta handles the long tail.
 
 ## Documentation
 


### PR DESCRIPTION
## Description

Adds KAI Scheduler to the Who Uses Karta section of the README. KAI merged a Karta-based generic fallback plugin for its pod grouper (kai-scheduler/KAI-Scheduler#1877, closing kai-scheduler/KAI-Scheduler#1527), making it the first public OSS consumer worth naming in the README.

## Related Issues

Docs-only change; no karta tracking issue. References the KAI-side integration: kai-scheduler/KAI-Scheduler#1527.

## Checklist

- [x] Self-reviewed
- [ ] Added/updated tests (docs-only, none needed)
- [x] Updated documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the “Who Uses Karta?” section to add a note that **KAI Scheduler** uses Karta as a generic fallback plugin.
  * Added/updated the related linked reference for additional details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->