### PR TITLE
docs(design): add resource references high-level design

### DIFF
--- a/docs/design/references/high-level-design.md
+++ b/docs/design/references/high-level-design.md
@@ -47,7 +47,7 @@ We want to enrich a Karta definition by letting it draw on other cluster resourc
 ## Concept
 A reference is a definition's way of reaching another resource in the cluster. A reference lets it name another resource - or a set of them - and use that resource's values too.
 
-Concretely, a reference is a named pointer to another cluster resource, or set of resources, that Karta exposes to a definition's JQ expressions as the variable `$<Name>`. In this proposal, a Karta definition declares its references at the structure level. Each reference could be resolved against the workload object itself (the root custom resource the definition describes, for example the `TrainJob`) - the expressions that pick the name, namespace, and labels run with that object as their input - and then fetched once from the cluster. Its value can then be used anywhere in the Karta definition - in the JQ expressions of any component. To the author it is just another input: where `.spec...` reads the workload object, `$trainingRuntime.spec...` reads a referenced one.
+Concretely, a reference is a named pointer to another cluster resource, or set of resources, that Karta exposes to a definition's JQ expressions as the variable `$<Name>`. In this proposal, a Karta definition declares its references at the structure level. Each reference could be resolved against the workload object itself (the root custom resource the definition describes, for example the `TrainJob`) - the expressions that pick the name and labels run with that object as their input - and then fetched once from the cluster. Its value can then be used anywhere in the Karta definition - in the JQ expressions of any component. To the author it is just another input: where `.spec...` reads the workload object, `$trainingRuntime.spec...` reads a referenced one.
 
 Karta stays declarative: it still fetches nothing itself. Resolving references is the consumer's job, and it adds one more input - the fetched values - to what the consumer passes when it evaluates a Karta definition.
 
@@ -62,7 +62,9 @@ Naming the two cases after what they return - one object versus many - keeps the
 ## API
 References are declared on the structure definition, as a list, alongside the root component, child components, and additional child kinds. Each entry names the variable, the GVK to fetch, and one of `lookup` or `list`. The list is keyed by the unique `name`.
 
-A `lookup` names the single object to fetch: its `nameExpression` is a JQ expression against the root object that resolves the resource's name, and the consumer `Get`s that object (in the namespace from `namespaceExpression`, or the workload's own namespace).
+A `lookup` names the single object to fetch: its `nameExpression` is a JQ expression against the root object that resolves the resource's name, and the consumer `Get`s that object.
+
+There is no namespace field, deliberately. A namespaced reference always resolves in the workload's own namespace; a cluster-scoped GVK (such as `ClusterTrainingRuntime`) has none. A definition can never reach into another namespace, which keeps references inside the workload's isolation boundary by construction.
 
 A `list` selects its set with a structured selector in the shape of a Kubernetes `LabelSelector` (`matchLabels` plus `matchExpressions`), so it converts directly into a real selector for the `List` call. The one addition over a plain Kubernetes selector is that a value can be sourced from the root object (using JQ) rather than being a constant: most values are literals, but the workload's own name (for "pods of this workload") only exists at runtime. A value is therefore either a literal or a JQ expression evaluated against the root.
 
@@ -83,11 +85,6 @@ type StructureDefinition struct {
 type ResourceReference struct {
     Name string           // variable name exposed to JQ as $<Name>
     GVK  GroupVersionKind // group/version/kind of the referenced resource(s)
-
-    // NamespaceExpression is a JQ expression against the root object resolving the
-    // namespace to fetch from. If empty, a namespaced GVK defaults to the root
-    // object's namespace.
-    NamespaceExpression *string
 
     Lookup *LookupReference
     List   *ListReference
@@ -139,10 +136,9 @@ spec:
         lookup:
           nameExpression: .spec.runtimeRef.name
 
-      # set of objects: $pods
+      # set of objects: $pods (listed in the workload's namespace)
       - name: pods
         gvk: { group: "", version: v1, kind: Pod }
-        namespaceExpression: .metadata.namespace
         list:
           matchLabels:
             training.kubeflow.org/job-name: { expression: .metadata.name }  # value from the root
@@ -262,3 +258,5 @@ A few points are worth calling out because they change the contract or carry rea
 - A label value resolves to exactly one scalar. There is no fan-out from one expression into a variable-length set of values; authors enumerate the values they want. Sourcing a whole value set from the root (for example, every replica type a workload declares) is intentionally out of scope for the first version and can be added later without breaking the API.
   
 - The reference uses `gvk` for its group/version/kind, while the existing `ComponentDefinition` names the same type `kind`. This inconsistency is deliberate for now - `kind.kind` reads poorly and `gvk` is accurate - but it should be resolved before the API stabilizes, either by renaming the existing field or accepting the divergence.
+
+- Merging a referenced base with the workload's overrides has no vocabulary yet. The Kubeflow case is the sharpest instance: the effective container env is the runtime's env merged with `.spec.trainer.env` by `name`, and no path expression can express that read, let alone write through it. This is a general Karta gap, not a references one - the read path and the write path need to be separated - and is tracked in #183.

--- a/docs/design/references/high-level-design.md
+++ b/docs/design/references/high-level-design.md
@@ -167,8 +167,14 @@ Any component's paths then read each variable by its shape - the variable is in 
 fragmentedPodSpecDefinition:
   imagePath: '.spec.trainer.image // $trainingRuntime.spec.template.spec.replicatedJobs[0].template.spec.template.spec.containers[0].image'
   resourcesPath: '.spec.trainer.resourcesPerNode // $trainingRuntime.spec.template.spec.replicatedJobs[0].template.spec.template.spec.containers[0].resources'
-# an aggregate over the matched pods:
-runningPodsPath: '[ $pods[] | select(.status.phase == "Running") ] | length'
+# an aggregate over the matched pods, feeding the status mapping - the workload is
+# Running when at least one of its pods is:
+statusDefinition:
+  statusMappings:
+    running:
+      - byExpression:
+          expression: '[ $pods[] | select(.status.phase == "Running") ] | length > 0'
+          expectedResult: "true"
 ```
 
 The one-of rules - one of `lookup`/`list`, one of `value`/`expression`, and unique reference names - are enforced by Karta's existing validation function, alongside the JQ validation that already checks every expression field.

--- a/docs/design/references/high-level-design.md
+++ b/docs/design/references/high-level-design.md
@@ -1,10 +1,7 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <!-- Copyright (c) 2026 NVIDIA Corporation -->
-# Karta Resource References - High-Level Design
-## Background
-A Karta definition describes a workload by reading its manifest. Every value Karta extracts - pod spec, scale, status, pod selectors - is a JQ expression evaluated against a single root object: the workload CR itself. This works as long as everything Karta needs lives inside that one object.
-
+# Karta Resource References - High-Level Design ## Background A Karta definition describes a workload by reading its manifest. Every value Karta extracts - pod spec, scale, status, pod selectors - is a JQ expression evaluated against a single root object: the workload CR itself. This works as long as everything Karta needs lives inside that one object.
 It often does not.
 
 Kubeflow Trainer v2 is the clearest example. A `TrainJob` points at a `ClusterTrainingRuntime` through `spec.runtimeRef`, and the runtime holds the base pod template - the containers and resources a job runs with. For example:
@@ -48,7 +45,7 @@ There is a second, related gap. Sometimes a value cannot be read from any single
 
 We want to enrich a Karta definition by letting it draw on other cluster resources - a specific object or a set of them - in the same JQ expressions, in a generic way.
 ## Concept
-A reference is a named pointer to another cluster resource, or set of resources, that Karta exposes to a definition's JQ expressions as the variable `$<Name>`. In this proposal, a Karta definition declares its references at the structure level. Each reference is resolved and fetched once against the workload object itself (the root custom resource the definition describes, for example the `TrainJob`), and its result is in scope for the JQ expressions of every component. To the author it is just another input: where `.spec...` reads the workload object, `$trainingRuntime.spec...` reads a referenced one.
+A reference is a named pointer to another cluster resource, or set of resources, that Karta exposes to a definition's JQ expressions as the variable `$<Name>`. In this proposal, a Karta definition declares its references at the structure level. Each reference is resolved against the workload object itself (the root custom resource the definition describes, for example the `TrainJob`) - the expressions that pick the name, namespace, and labels run with that object as their input - and then fetched once from the cluster. Its result is in scope for the JQ expressions of every component. To the author it is just another input: where `.spec...` reads the workload object, `$trainingRuntime.spec...` reads a referenced one.
 
 Declaring references once, for the whole workload, means the same value - the runtime, or the pod set - can be read by any number of components without being fetched again.
 

--- a/docs/design/references/high-level-design.md
+++ b/docs/design/references/high-level-design.md
@@ -157,12 +157,16 @@ spec:
               operator: Exists
 ```
 
-Any component's paths then read each variable by its shape - the variable is in scope for every component, so the two examples below can live on different components. A `lookup` is read like any object; a `list` is iterated.
+Any component's paths then read each variable by its shape - the variable is in scope for every component, so the examples below can live on different components. A `lookup` is read like any object; a `list` is iterated.
 
 ```yaml
-# the base pod template comes from the runtime; the TrainJob's overrides, read from
-# the root object, are layered on top in the same expression:
-podTemplateSpecPath: $trainingRuntime.spec.template.spec.replicatedJobs[0].template.spec.template
+# The base pod spec lives in the runtime; the TrainJob's overrides sit on the root
+# object. Rather than one merged path, the effective value is built per-field with a
+# JQ fallback (override // base) via the fragmented pod spec - prefer the TrainJob's
+# value, fall back to the runtime's:
+fragmentedPodSpecDefinition:
+  imagePath: '.spec.trainer.image // $trainingRuntime.spec.template.spec.replicatedJobs[0].template.spec.template.spec.containers[0].image'
+  resourcesPath: '.spec.trainer.resourcesPerNode // $trainingRuntime.spec.template.spec.replicatedJobs[0].template.spec.template.spec.containers[0].resources'
 # an aggregate over the matched pods:
 runningPodsPath: '[ $pods[] | select(.status.phase == "Running") ] | length'
 ```

--- a/docs/design/references/high-level-design.md
+++ b/docs/design/references/high-level-design.md
@@ -1,7 +1,7 @@
-<!-- SPDX-License-Identifier: Apache-2.0 -->
+# Karta Resource References - High-Level Design
+## Background
+A Karta definition describes a workload by reading its manifest. Every value Karta extracts - pod spec, scale, status, pod selectors - is a JQ expression evaluated against a single root object: the workload CR itself. This works as long as everything Karta needs lives inside that one object.
 
-<!-- Copyright (c) 2026 NVIDIA Corporation -->
-# Karta Resource References - High-Level Design ## Background A Karta definition describes a workload by reading its manifest. Every value Karta extracts - pod spec, scale, status, pod selectors - is a JQ expression evaluated against a single root object: the workload CR itself. This works as long as everything Karta needs lives inside that one object.
 It often does not.
 
 Kubeflow Trainer v2 is the clearest example. A `TrainJob` points at a `ClusterTrainingRuntime` through `spec.runtimeRef`, and the runtime holds the base pod template - the containers and resources a job runs with. For example:
@@ -45,9 +45,9 @@ There is a second, related gap. Sometimes a value cannot be read from any single
 
 We want to enrich a Karta definition by letting it draw on other cluster resources - a specific object or a set of them - in the same JQ expressions, in a generic way.
 ## Concept
-A reference is a named pointer to another cluster resource, or set of resources, that Karta exposes to a definition's JQ expressions as the variable `$<Name>`. In this proposal, a Karta definition declares its references at the structure level. Each reference is resolved against the workload object itself (the root custom resource the definition describes, for example the `TrainJob`) - the expressions that pick the name, namespace, and labels run with that object as their input - and then fetched once from the cluster. Its result is in scope for the JQ expressions of every component. To the author it is just another input: where `.spec...` reads the workload object, `$trainingRuntime.spec...` reads a referenced one.
+A reference is a definition's way of reaching another resource in the cluster. A reference lets it name another resource - or a set of them - and use that resource's values too.
 
-Declaring references once, for the whole workload, means the same value - the runtime, or the pod set - can be read by any number of components without being fetched again.
+Concretely, a reference is a named pointer to another cluster resource, or set of resources, that Karta exposes to a definition's JQ expressions as the variable `$<Name>`. In this proposal, a Karta definition declares its references at the structure level. Each reference could be resolved against the workload object itself (the root custom resource the definition describes, for example the `TrainJob`) - the expressions that pick the name, namespace, and labels run with that object as their input - and then fetched once from the cluster. Its value can then be used anywhere in the Karta definition - in the JQ expressions of any component. To the author it is just another input: where `.spec...` reads the workload object, `$trainingRuntime.spec...` reads a referenced one.
 
 Karta stays declarative: it still fetches nothing itself. Resolving references is the consumer's job, and it adds one more input - the fetched values - to what the consumer passes when it evaluates a Karta definition.
 

--- a/docs/design/references/high-level-design.md
+++ b/docs/design/references/high-level-design.md
@@ -179,7 +179,7 @@ statusDefinition:
 
 The one-of rules - one of `lookup`/`list`, one of `value`/`expression`, and unique reference names - are enforced by Karta's existing validation function, alongside the JQ validation that already checks every expression field.
 ### Library API
-References add a small, opt-in surface to the Karta library. A consumer that uses none of it is unaffected, and a definition with no `references` behaves exactly as today. Three pieces cover the feature.
+References add a new surface to the Karta library. It is backward compatible - existing code keeps compiling, and a definition with no `references` behaves exactly as today - but it is opt-in only for a consumer that controls its own definitions. A consumer that accepts arbitrary Karta definitions must treat references as part of the definition contract: implement resolution, or explicitly reject definitions that declare them. Three pieces cover the feature.
 
 `ResolvedReferences` is what a reference resolves to - an object for a `lookup`, a list for a `list`, keyed by name:
 
@@ -193,8 +193,6 @@ type ReferenceValue struct {
 // ResolvedReferences maps each reference name to its fetched value.
 type ResolvedReferences map[string]ReferenceValue
 ```
-
-The values are `unstructured` - the same shape a `Get` or `List` of an arbitrary kind returns, so the fetch path needs no conversion, and a missing `lookup` is encoded naturally as a nil `Object` (which binds to JQ as null). A consumer building the map from its own store wraps each object with `unstructured.Unstructured{Object: m}`.
 
 `Resolve` fetches them. It lives in a new package, `pkg/references` - a new domain that owns reference resolution and is the one place in Karta that depends on a Kubernetes client; the types and `WithReferences` stay in the client-free `pkg/resource`. Given a reader, the Karta definition, and the workload object, it evaluates each reference's expressions against the workload, performs the `Get` (for a `lookup`) or `List` (for a `list`), and returns the map.
 
@@ -210,6 +208,50 @@ factory := resource.NewComponentFactoryFromObject(karta, workload, resource.With
 ```
 
 If a definition declares a reference that is not provided to the factory, evaluating an expression that reads `$<Name>` errors instead of silently resolving to null.
+### Integration options
+Three shapes are possible for the Go-level integration, from most convenient to most control. They stack rather than compete: option 1 is sugar over options 2 and 3, and all can be offered together.
+### Option 1: a reader in a new constructor
+```go
+factory, err := references.NewComponentFactory(ctx, reader, karta, workload)
+```
+
+A convenience constructor in `pkg/references` resolves and binds in one call. The expected path for a controller that already holds a client. Backward compatible because it is purely additive: the existing `resource.NewComponentFactoryFromObject` is untouched, and placing the new constructor in `pkg/references` keeps `pkg/resource` free of any client dependency.
+### Option 2: a Karta-owned reader interface
+```go
+type ResourceReader interface {
+    // Get returns the object's content, or ErrNotFound if it does not exist.
+    Get(ctx context.Context, gvk GroupVersionKind, namespace, name string) (*unstructured.Unstructured, error)
+    // List returns every object of gvk matching the query.
+    List(ctx context.Context, gvk GroupVersionKind, query ListQuery) ([]unstructured.Unstructured, error)
+}
+
+// ListQuery describes which objects List returns. New capabilities (field
+// selectors, limits) are added as fields, so the interface never breaks.
+type ListQuery struct {
+    Namespace string
+    Selector  labels.Selector
+}
+```
+
+The reader everywhere - in `Resolve` and in option 1's constructor - is this minimal `ResourceReader`, not controller-runtime's `client.Reader`: two methods, plain arguments, a sentinel not-found error. Cluster consumers bridge with one call, non-cluster consumers implement the two methods directly:
+
+```go
+// controller with a cluster: adapt the client it already holds
+factory, err := references.NewComponentFactory(ctx, references.FromClient(mgr.GetAPIReader()), karta, workload)
+
+// no cluster: any implementation of the two methods
+factory, err := references.NewComponentFactory(ctx, myStore, karta, workload)
+```
+
+Benefits: a consumer without a cluster implements two straightforward methods over its own store (an in-memory reader is a map and a label match), and the controller-runtime client dependency is confined to the `FromClient` adapter.
+### Option 3: the consumer wires the values into the factory
+```go
+factory := resource.NewComponentFactoryFromObject(karta, workload, resource.WithReferences(refs))
+```
+
+The consumer skips resolution entirely, builds the `ResolvedReferences` map from wherever its data lives - its own client, caching, batching, or no Kubernetes at all - and passes it to the existing factory constructor. Backward compatible because the option is variadic: existing call sites compile unchanged. Karta only sees the finished values.
+
+Anything built on top of the factory inherits references for free. The planned `WorkloadTree` builder, for example, should accept a constructed factory rather than building its own - the `$<Name>` variables are already bound, so tree extraction over referenced values just works and the tree stays reference-agnostic.
 ## Caveats
 A few points are worth calling out because they change the contract or carry real cost.
 

--- a/docs/design/references/high-level-design.md
+++ b/docs/design/references/high-level-design.md
@@ -205,13 +205,13 @@ factory := resource.NewComponentFactoryFromObject(karta, workload, resource.With
 
 If a definition declares a reference that is not provided to the factory, evaluating an expression that reads `$<Name>` errors instead of silently resolving to null.
 ### Integration options
-Three shapes are possible for the Go-level integration, from most convenient to most control. They stack rather than compete: option 1 is sugar over options 2 and 3, and all can be offered together.
-### Option 1: a reader in a new constructor
+Three shapes are possible for the Go-level integration, from most convenient to most control. They stack rather than compete: option 1 builds on option 2's reader and option 3's binding, and all can be offered together.
+### Option 1: a Kubernetes reader as a factory option
 ```go
-factory, err := references.NewComponentFactory(ctx, reader, karta, workload)
+factory := resource.NewComponentFactoryFromObject(karta, workload, resource.WithReferenceReader(reader))
 ```
 
-A convenience constructor in `pkg/references` resolves and binds in one call. The expected path for a controller that already holds a client. Backward compatible because it is purely additive: the existing `resource.NewComponentFactoryFromObject` is untouched, and placing the new constructor in `pkg/references` keeps `pkg/resource` free of any client dependency.
+The existing constructor gains an option carrying a reader - a Kubernetes client reader, or any implementation of option 2's interface - so the opt-in is explicit in the option name and there is no second constructor. Backward compatible because the option is purely additive.
 ### Option 2: a Karta-owned reader interface
 ```go
 type ResourceReader interface {
@@ -229,14 +229,15 @@ type ListQuery struct {
 }
 ```
 
-The reader everywhere - in `Resolve` and in option 1's constructor - is this minimal `ResourceReader`, not controller-runtime's `client.Reader`: two methods, plain arguments, a sentinel not-found error. Cluster consumers bridge with one call, non-cluster consumers implement the two methods directly:
+The reader everywhere - in `Resolve` and in option 1's factory option - is this minimal `ResourceReader`, not controller-runtime's `client.Reader`: two methods, plain arguments, a sentinel not-found error. Cluster consumers bridge with one call, non-cluster consumers implement the two methods directly:
 
 ```go
 // controller with a cluster: adapt the client it already holds
-factory, err := references.NewComponentFactory(ctx, references.FromClient(mgr.GetAPIReader()), karta, workload)
+reader := references.FromClient(mgr.GetAPIReader())
+factory := resource.NewComponentFactoryFromObject(karta, workload, resource.WithReferenceReader(reader))
 
 // no cluster: any implementation of the two methods
-factory, err := references.NewComponentFactory(ctx, myStore, karta, workload)
+factory := resource.NewComponentFactoryFromObject(karta, workload, resource.WithReferenceReader(myStore))
 ```
 
 Benefits: a consumer without a cluster implements two straightforward methods over its own store (an in-memory reader is a map and a label match), and the controller-runtime client dependency is confined to the `FromClient` adapter.
@@ -248,6 +249,19 @@ factory := resource.NewComponentFactoryFromObject(karta, workload, resource.With
 The consumer skips resolution entirely, builds the `ResolvedReferences` map from wherever its data lives - its own client, caching, batching, or no Kubernetes at all - and passes it to the existing factory constructor. Backward compatible because the option is variadic: existing call sites compile unchanged. Karta only sees the finished values.
 
 Anything built on top of the factory inherits references for free. The planned `WorkloadTree` builder, for example, should accept a constructed factory rather than building its own - the `$<Name>` variables are already bound, so tree extraction over referenced values just works and the tree stays reference-agnostic.
+## Hardening
+References make a definition ask the consumer to fetch cluster resources with the consumer's permissions. A malicious or careless definition could point at data it should not surface.
+
+The design already bounds this structurally: the API has no namespace field, so a definition cannot name another namespace - the resolver always resolves namespaced references in the workload's namespace.
+
+Further options, composable rather than exclusive:
+
+- **Namespace-scoped reader.** The reader handed to the factory can itself be pinned to the workload's namespace - a small wrapper over any reader that rejects every other namespace - so even a resolver bug cannot cross the boundary. The client behind the reader adds a second bound: give it RBAC covering only the kinds definitions legitimately need, and a reference to anything else fails at the API server.
+  
+- **References as consumer opt-in (or opt-out).** A consumer that passes no reader and no values behaves exactly as today. Resolution is lazy: the first accessor call that needs a reference resolves all of them with that call's context and memoizes the result, so a definition without references never touches the reader, resolution failures surface on first use rather than at construction, and the first extraction call performs cluster reads. A definition that declares references when nothing was provided fails on that first use with `ErrReferencesNotSupported`, not with a cryptic expression error - a consumer that has not implemented resolution rejects such definitions loudly. Opt-in (off unless wired) or opt-out (wired by default, disabled explicitly) is the consumer's choice; the library default is opt-in.
+  
+- **Validator opt-in (or opt-out).** `NewKartaValidator` grows an option: without it, a definition that declares references fails validation with a sentinel error (`ErrReferencesNotSupported`). Deny-by-default costs nothing today - no existing definition declares references - and gives two gates for free: a consumer enables it only once it supports resolution, and a cluster operator who leaves it off in the admission webhook makes reference-carrying definitions unstorable cluster-wide. The option can later carry constraints (which GVKs a definition may reference); the opt-out variant is the alternative if the feature should spread with no ceremony.
+  
 ## Caveats
 A few points are worth calling out because they change the contract or carry real cost.
 
@@ -258,5 +272,5 @@ A few points are worth calling out because they change the contract or carry rea
 - A label value resolves to exactly one scalar. There is no fan-out from one expression into a variable-length set of values; authors enumerate the values they want. Sourcing a whole value set from the root (for example, every replica type a workload declares) is intentionally out of scope for the first version and can be added later without breaking the API.
   
 - The reference uses `gvk` for its group/version/kind, while the existing `ComponentDefinition` names the same type `kind`. This inconsistency is deliberate for now - `kind.kind` reads poorly and `gvk` is accurate - but it should be resolved before the API stabilizes, either by renaming the existing field or accepting the divergence.
-
+  
 - Merging a referenced base with the workload's overrides has no vocabulary yet. The Kubeflow case is the sharpest instance: the effective container env is the runtime's env merged with `.spec.trainer.env` by `name`, and no path expression can express that read, let alone write through it. This is a general Karta gap, not a references one - the read path and the write path need to be separated - and is tracked in #183.

--- a/docs/design/references/high-level-design.md
+++ b/docs/design/references/high-level-design.md
@@ -53,7 +53,7 @@ Karta stays declarative: it still fetches nothing itself. Resolving references i
 
 A reference takes one of two shapes, declared in the API - `lookup` or `list` - and the shape decides what the variable holds:
 
-- `lookup` - fetch a single object (a `Get`). `$<Name>` is that one object, read like any object (`$<name>.field`), or null if it does not exist.
+- `lookup` - fetch a single object (a `Get`). `$<Name>` is that one object, read like any object (`$<name>.field`).
   
 - `list` - fetch a set of objects (a `List`). `$<Name>` is an array, read and iterated as `$<name>[]`, possibly empty.
   
@@ -63,6 +63,8 @@ Naming the two cases after what they return - one object versus many - keeps the
 References are declared on the structure definition, as a list, alongside the root component, child components, and additional child kinds. Each entry names the variable, the GVK to fetch, and one of `lookup` or `list`. The list is keyed by the unique `name`.
 
 A `lookup` names the single object to fetch: its `nameExpression` is a JQ expression against the root object that resolves the resource's name, and the consumer `Get`s that object.
+
+A reference is required by use. A `lookup` that finds no object is not an error by itself: the failure surfaces when an expression that uses `$<Name>` is evaluated, and expressions that do not mention it are unaffected. A `list` has no existence question - matching nothing yields an empty array. If optional references turn out to be needed, an explicit `optional` boolean can be introduced later without breaking the API.
 
 There is no namespace field, deliberately. A namespaced reference always resolves in the workload's own namespace; a cluster-scoped GVK (such as `ClusterTrainingRuntime`) has none. A definition can never reach into another namespace, which keeps references inside the workload's isolation boundary by construction.
 
@@ -182,7 +184,7 @@ References add a new surface to the Karta library. It is backward compatible - e
 ```go
 // ReferenceValue is the fetched value of one reference.
 type ReferenceValue struct {
-    Object *unstructured.Unstructured  // set for a lookup; nil when the object was not found
+    Object *unstructured.Unstructured  // set for a lookup; nil when the object was not found (never bound to JQ)
     List   []unstructured.Unstructured // set for a list; possibly empty
 }
 

--- a/docs/design/references/high-level-design.md
+++ b/docs/design/references/high-level-design.md
@@ -1,0 +1,213 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+<!-- Copyright (c) 2026 NVIDIA Corporation -->
+# Karta Resource References - High-Level Design
+## Background
+A Karta definition describes a workload by reading its manifest. Every value Karta extracts - pod spec, scale, status, pod selectors - is a JQ expression evaluated against a single root object: the workload CR itself. This works as long as everything Karta needs lives inside that one object.
+
+It often does not.
+
+Kubeflow Trainer v2 is the clearest example. A `TrainJob` points at a `ClusterTrainingRuntime` through `spec.runtimeRef`, and the runtime holds the base pod template - the containers and resources a job runs with. For example:
+
+```yaml
+# ClusterTrainingRuntime - the shared base every TrainJob of this kind runs with
+kind: ClusterTrainingRuntime
+metadata:
+  name: torch-distributed
+spec:
+  template:               # a JobSet template
+    spec:
+      replicatedJobs:
+        - name: node
+          template:       # Job -> Pod template, trimmed to the container
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: node
+                      image: pytorch/pytorch:2.3.0
+                      resources:
+                        limits: { nvidia.com/gpu: 1 }
+---
+# TrainJob - points at the runtime by name and overrides a few fields
+kind: TrainJob
+metadata:
+  name: fine-tune
+spec:
+  runtimeRef:
+    name: torch-distributed
+  trainer:
+    numNodes: 4
+    resourcesPerNode:
+      limits: { nvidia.com/gpu: 8 }
+```
+
+The `TrainJob` can override parts of it (nodes, resources, image, and so on), and those overrides take precedence over the runtime. The effective pod spec is therefore the combination of the runtime's template and the `TrainJob`'s overrides layered on top. A Karta definition for `TrainJob` can read the override fields on the `TrainJob` itself, but it has no way to reach the runtime, so it never sees the base it is overriding - it only ever has half of the spec. The same shape recurs elsewhere - a workload that points at a config object, a policy, or a dataset that holds part of the picture.
+
+There is a second, related gap. Sometimes a value cannot be read from any single object and has to be computed from a set of them. Phase is the clearest case: some workloads do not report a usable status of their own, and the only way to tell whether one is running, degraded, or failed is to look across its pods and aggregate their states. To compute that, a definition needs the workload's pods as an input, not just the workload object.
+
+We want to enrich a Karta definition by letting it draw on other cluster resources - a specific object or a set of them - in the same JQ expressions, in a generic way.
+## Concept
+A reference is a named pointer to another cluster resource, or set of resources, that Karta exposes to a definition's JQ expressions as the variable `$<Name>`. In this proposal, a Karta definition declares its references at the structure level. Each reference is resolved and fetched once against the workload object itself (the root custom resource the definition describes, for example the `TrainJob`), and its result is in scope for the JQ expressions of every component. To the author it is just another input: where `.spec...` reads the workload object, `$trainingRuntime.spec...` reads a referenced one.
+
+Declaring references once, for the whole workload, means the same value - the runtime, or the pod set - can be read by any number of components without being fetched again.
+
+Karta stays declarative: it still fetches nothing itself. Resolving references is the consumer's job, and it adds one more input - the fetched values - to what the consumer passes when it evaluates a Karta definition.
+
+A reference takes one of two shapes, declared in the API - `lookup` or `list` - and the shape decides what the variable holds:
+
+- `lookup` - fetch a single object (a `Get`). `$<Name>` is that one object, read like any object (`$<name>.field`), or null if it does not exist.
+  
+- `list` - fetch a set of objects (a `List`). `$<Name>` is an array, read and iterated as `$<name>[]`, possibly empty.
+  
+
+Naming the two cases after what they return - one object versus many - keeps the variable's shape obvious to whoever writes the downstream expression.
+## API
+References are declared on the structure definition, as a list, alongside the root component, child components, and additional child kinds. Each entry names the variable, the GVK to fetch, and one of `lookup` or `list`. The list is keyed by the unique `name`.
+
+A `lookup` names the single object to fetch: its `nameExpression` is a JQ expression against the root object that resolves the resource's name, and the consumer `Get`s that object (in the namespace from `namespaceExpression`, or the workload's own namespace).
+
+A `list` selects its set with a structured selector in the shape of a Kubernetes `LabelSelector` (`matchLabels` plus `matchExpressions`), so it converts directly into a real selector for the `List` call. The one addition over a plain Kubernetes selector is that a value can be sourced from the root object (using JQ) rather than being a constant: most values are literals, but the workload's own name (for "pods of this workload") only exists at runtime. A value is therefore either a literal or a JQ expression evaluated against the root.
+
+```go
+type StructureDefinition struct {
+    // ... RootComponent, ChildComponents, AdditionalChildKinds ...
+
+    // References declares cluster resources whose values are exposed to the
+    // workload's JQ expressions as the variable $<Name>.
+    References []ResourceReference // +listType=map, +listMapKey=name
+}
+
+// ResourceReference declares another resource (or set of resources) whose values are
+// exposed to every component's JQ expressions as the variable $<Name>.
+// Exactly one of Lookup or List is set:
+//   Lookup -> $<Name> is a single object (or null)
+//   List   -> $<Name> is an array (possibly empty)
+type ResourceReference struct {
+    Name string           // variable name exposed to JQ as $<Name>
+    GVK  GroupVersionKind // group/version/kind of the referenced resource(s)
+
+    // NamespaceExpression is a JQ expression against the root object resolving the
+    // namespace to fetch from. If empty, a namespaced GVK defaults to the root
+    // object's namespace.
+    NamespaceExpression *string
+
+    Lookup *LookupReference
+    List   *ListReference
+}
+
+// LookupReference fetches a single resource by name (consumer: client.Get).
+type LookupReference struct {
+    // NameExpression is a JQ expression against the root object resolving the
+    // referenced resource's name.
+    NameExpression string
+}
+
+// ListReference fetches a set of resources by a structured label selector
+// (consumer: client.List). After value resolution it maps onto metav1.LabelSelector.
+// At least one of MatchLabels or MatchExpressions must be set.
+type ListReference struct {
+    MatchLabels      map[string]LabelValue
+    MatchExpressions []LabelSelectorRequirement
+}
+
+// LabelSelectorRequirement mirrors metav1.LabelSelectorRequirement, except its values
+// may be sourced from the root object.
+type LabelSelectorRequirement struct {
+    Key      string
+    Operator LabelSelectorOperator // In, NotIn, Exists, DoesNotExist
+    Values   []LabelValue          // required for In/NotIn, empty for Exists/DoesNotExist
+}
+
+// LabelValue is a single label value: either a literal (Value) or a JQ expression
+// evaluated against the root object (Expression). Value and Expression are a one-of;
+// exactly one is set.
+type LabelValue struct {
+    Value      *string
+    Expression *string
+}
+```
+
+A definition reads as follows, with `references` a sibling of `rootComponent` under the structure definition. The first reference resolves the Kubeflow runtime; the second lists the workload's pods.
+
+```yaml
+spec:
+  structureDefinition:
+    rootComponent: { ... }
+    childComponents: [ ... ]
+    references:
+      # single object: $trainingRuntime
+      - name: trainingRuntime
+        gvk: { group: trainer.kubeflow.org, version: v1alpha1, kind: ClusterTrainingRuntime }
+        lookup:
+          nameExpression: .spec.runtimeRef.name
+
+      # set of objects: $pods
+      - name: pods
+        gvk: { group: "", version: v1, kind: Pod }
+        namespaceExpression: .metadata.namespace
+        list:
+          matchLabels:
+            training.kubeflow.org/job-name: { expression: .metadata.name }  # value from the root
+            app.kubernetes.io/managed-by:   { value: karta }                # literal value
+          matchExpressions:
+            - key: training.kubeflow.org/replica-type
+              operator: In
+              values:
+                - value: worker                          # literal
+                - expression: .spec.primaryReplicaType   # value from the root
+            - key: app.kubernetes.io/component
+              operator: Exists
+```
+
+Any component's paths then read each variable by its shape - the variable is in scope for every component, so the two examples below can live on different components. A `lookup` is read like any object; a `list` is iterated.
+
+```yaml
+# the base pod template comes from the runtime; the TrainJob's overrides, read from
+# the root object, are layered on top in the same expression:
+podTemplateSpecPath: $trainingRuntime.spec.template.spec.replicatedJobs[0].template.spec.template
+# an aggregate over the matched pods:
+runningPodsPath: '[ $pods[] | select(.status.phase == "Running") ] | length'
+```
+
+The one-of rules - one of `lookup`/`list`, one of `value`/`expression`, and unique reference names - are enforced by Karta's existing validation function, alongside the JQ validation that already checks every expression field.
+### Library API
+References add a small, opt-in surface to the Karta library. A consumer that uses none of it is unaffected, and a definition with no `references` behaves exactly as today. Three pieces cover the feature.
+
+`ResolvedReferences` is what a reference resolves to - an object for a `lookup`, a list for a `list`, keyed by name:
+
+```go
+// ReferenceValue is the fetched value of one reference.
+type ReferenceValue struct {
+    Object map[string]any   // set for a lookup
+    List   []map[string]any // set for a list
+}
+
+// ResolvedReferences maps each reference name to its fetched value.
+type ResolvedReferences map[string]ReferenceValue
+```
+
+`Resolve` fetches them. It lives in a new package, `pkg/references` - a new domain that owns reference resolution and is the one place in Karta that depends on a Kubernetes client; the types and `WithReferences` stay in the client-free `pkg/resource`. Given a reader, the Karta definition, and the workload object, it evaluates each reference's expressions against the workload, performs the `Get` (for a `lookup`) or `List` (for a `list`), and returns the map.
+
+```go
+func Resolve(ctx context.Context, reader client.Reader, karta *Karta, workload client.Object) (ResolvedReferences, error)
+```
+
+`WithReferences` binds them. When the component factory is built, the resolved references are passed as an option; each becomes the JQ variable `$<Name>`, in scope for every component's expressions.
+
+```go
+refs, err := references.Resolve(ctx, reader, karta, workload)
+factory := resource.NewComponentFactoryFromObject(karta, workload, resource.WithReferences(refs))
+```
+
+If a definition declares a reference that is not provided to the factory, evaluating an expression that reads `$<Name>` errors instead of silently resolving to null.
+## Caveats
+A few points are worth calling out because they change the contract or carry real cost.
+
+- References add a fetching step to the consumer. Until now a consumer could evaluate a Karta definition against an object it already held, with no cluster access. A definition that uses references requires a Kubernetes client and the RBAC to read the referenced kinds, and will not work with a consumer that has not implemented resolution. This is a capability the consumer opts into.
+  
+- Referencing arbitrary kinds could be expensive, depending on how the consumer fetches them and how many objects a `list` returns. Fetching through a cache can add further cost, so the consumer should choose its reader deliberately.
+  
+- A label value resolves to exactly one scalar. There is no fan-out from one expression into a variable-length set of values; authors enumerate the values they want. Sourcing a whole value set from the root (for example, every replica type a workload declares) is intentionally out of scope for the first version and can be added later without breaking the API.
+  
+- The reference uses `gvk` for its group/version/kind, while the existing `ComponentDefinition` names the same type `kind`. This inconsistency is deliberate for now - `kind.kind` reads poorly and `gvk` is accurate - but it should be resolved before the API stabilizes, either by renaming the existing field or accepting the divergence.

--- a/docs/design/references/high-level-design.md
+++ b/docs/design/references/high-level-design.md
@@ -186,13 +186,15 @@ References add a small, opt-in surface to the Karta library. A consumer that use
 ```go
 // ReferenceValue is the fetched value of one reference.
 type ReferenceValue struct {
-    Object map[string]any   // set for a lookup
-    List   []map[string]any // set for a list
+    Object *unstructured.Unstructured  // set for a lookup; nil when the object was not found
+    List   []unstructured.Unstructured // set for a list; possibly empty
 }
 
 // ResolvedReferences maps each reference name to its fetched value.
 type ResolvedReferences map[string]ReferenceValue
 ```
+
+The values are `unstructured` - the same shape a `Get` or `List` of an arbitrary kind returns, so the fetch path needs no conversion, and a missing `lookup` is encoded naturally as a nil `Object` (which binds to JQ as null). A consumer building the map from its own store wraps each object with `unstructured.Unstructured{Object: m}`.
 
 `Resolve` fetches them. It lives in a new package, `pkg/references` - a new domain that owns reference resolution and is the one place in Karta that depends on a Kubernetes client; the types and `WithReferences` stay in the client-free `pkg/resource`. Given a reader, the Karta definition, and the workload object, it evaluates each reference's expressions against the workload, performs the `Get` (for a `lookup`) or `List` (for a `list`), and returns the map.
 


### PR DESCRIPTION
## What does this PR do?

Adds a high-level design for referencing and querying other cluster resources from a Karta definition (issue #81). It proposes structure-level `references` with two shapes - `lookup` (a single `Get`) and `list` (a structured, `LabelSelector`-shaped `List`) - resolved once against the workload object and exposed to a definition's JQ expressions as `$<Name>` variables.

The document covers:

- Motivation: values that live outside the workload object (e.g. a Kubeflow `TrainJob` whose base pod template lives in a referenced `ClusterTrainingRuntime`) and values that must be computed from a set of objects (e.g. pods).
- Concept and the `lookup` / `list` shapes.
- API types (`ResourceReference`, `LookupReference`, `ListReference`, `LabelSelectorRequirement`, `LabelValue`) added to `StructureDefinition`, with label values that are either literals or JQ expressions against the root.
- Library changes: a new `pkg/references` package with `Resolve` (the only cluster-touching part), and a `WithReferences` option on the component factory that binds the results as JQ variables. Opt-in and backward compatible.
- Caveats.

Design only - no code, API type, or CRD changes in this PR.

## Related issue(s)

Refs #81

## Checklist

- [x] All commits are signed off with DCO (`git commit -s`)
- [x] New/modified files have SPDX license and copyright headers
- [x] Documentation updated (docs-only change)
- [ ] Tests pass (`make check`) - docs-only change; not run
- [x] No proprietary or internal information included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added high-level design documentation for Karta Resource References.
  * Defined `lookup` (single object) and `list` (multiple objects) reference behaviors and validation rules.
  * Documented how resolved reference data is provided to JQ evaluation through named variables.
  * Included expected failure behavior when references aren’t bound, plus guidance on cluster access (RBAC) and selector/result limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->