### PR TITLE
docs: add ADOPTERS.md with KAI Scheduler as first entry

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -7,7 +7,7 @@ Copyright (c) 2026 NVIDIA Corporation
 
 Projects and organizations using Karta.
 
-To add your project or organization, open a pull request that adds a row to the table below. If you use Karta but cannot share details publicly, contact the maintainers.
+To add your project or organization, open a pull request that adds a row to the table below. Include a link to a public record showing Karta usage or explicit permission from the adopter to name it. If you use Karta but cannot share details publicly, contact the maintainers.
 
 | Adopter | Type | How Karta is used |
 |---------|------|-------------------|

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,14 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 NVIDIA Corporation
+-->
+
+# Adopters
+
+Projects and organizations using Karta.
+
+To add your project or organization, open a pull request that adds a row to the table below. If you use Karta but cannot share details publicly, contact the maintainers.
+
+| Adopter | Type | How Karta is used |
+|---------|------|-------------------|
+| [KAI Scheduler](https://github.com/kai-scheduler/KAI-Scheduler) | Open-source Kubernetes GPU scheduler | Pod-grouper fallback plugin: gang scheduling for any workload type through Karta workload descriptions. Native plugins take precedence; Karta is the generic fallback. Merged 2026-07-13 in [KAI PR #1877](https://github.com/kai-scheduler/KAI-Scheduler/pull/1877). |

--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ Karta was created at [Run:ai](https://run.ai) (NVIDIA) to power workload managem
 
 [KAI Scheduler](https://github.com/kai-scheduler/KAI-Scheduler), a CNCF sandbox open-source Kubernetes scheduler for AI and GPU workloads, uses Karta as the generic fallback plugin in its pod grouper ([kai-scheduler/KAI-Scheduler#1527](https://github.com/kai-scheduler/KAI-Scheduler/issues/1527)). A Karta definition gives any CRD correct pod grouping and gang scheduling in KAI, with no scheduler plugin to write and no KAI release to wait for. Native in-tree plugins keep precedence; Karta handles the long tail.
 
+See [ADOPTERS.md](ADOPTERS.md) for the full list of adopters. If you use Karta, add yourself with a pull request.
+
 ## Documentation
 
 - [Technical Guide](docs/Technical%20Guide.md) - Full Karta spec, path syntax (jq), validation rules


### PR DESCRIPTION
## What does this PR do?

Adds an ADOPTERS.md at the repo root listing projects and organizations using Karta, with a self-service PR path for new entries.

First entry: KAI Scheduler's Karta pod-grouper fallback plugin (public record: kai-scheduler/KAI-Scheduler#1877, merged 2026-07-13). Additional adopters will be added in follow-up PRs once their permission to be named is confirmed, per the repo rule on referencing partners.

## Related issue(s)

Fixes #159

## Checklist

- [x] All commits are signed off with DCO (`git commit -s`)
- [x] New/modified files have SPDX license and copyright headers
- [x] Documentation updated (if applicable)
- [x] Tests pass (`make check`)
- [x] No proprietary or internal information included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an adopters page listing projects using Karta, with guidance to submit new entries and an initial entry for KAI Scheduler.
  * Updated the README “Who Uses Karta?” section to point readers to the adopters page and invite contributions via pull request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->