### PR TITLE
fix(chart): bump operator memory limit to 256Mi

### DIFF
--- a/charts/karta/values.yaml
+++ b/charts/karta/values.yaml
@@ -67,7 +67,7 @@ resources:
     memory: 64Mi
   limits:
     cpu: 200m
-    memory: 128Mi
+    memory: 256Mi
 
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
Temporary increase to prevent OOMKill on clusters with many CRDs. 

## What does this PR do?

<!-- Brief description of the change -->

## Related issue(s)

<!-- Every PR must reference at least one open GitHub issue -->
Fixes #

## Checklist

- [ ] All commits are signed off with DCO (`git commit -s`)
- [ ] New/modified files have SPDX license and copyright headers
- [ ] Documentation updated (if applicable)
- [ ] Tests pass (`make check`)
- [ ] No proprietary or internal information included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the default memory allocation for the Karta operator to improve runtime stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->