### PR TITLE
Fix/crd cache transform

### DIFF
--- a/.github/workflows/push-artifacts.yaml
+++ b/.github/workflows/push-artifacts.yaml
@@ -4,7 +4,7 @@
 name: Upload artifacts to GitHub Container Registry
 on:
   push:
-    branches: [ main, fix/crd-cache-transform ]
+    branches: [ main ]
     tags:
       - 'v[0-9]*.[0-9]*.[0-9]*'
       - '[0-9]+.[0-9]+.[0-9]+'

--- a/.github/workflows/push-artifacts.yaml
+++ b/.github/workflows/push-artifacts.yaml
@@ -4,7 +4,7 @@
 name: Upload artifacts to GitHub Container Registry
 on:
   push:
-    branches: [ main ]
+    branches: [ main, fix/crd-cache-transform ]
     tags:
       - 'v[0-9]*.[0-9]*.[0-9]*'
       - '[0-9]+.[0-9]+.[0-9]+'

--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -67,7 +67,7 @@ func stripCRDSchemas(i any) (any, error) {
 	}, nil
 }
 
-var _ toolscache.TransformFunc = stripCRDSchemas
+var _ toolscache.TransformFunc = stripCRDSchemas // compile-time signature check
 
 func run() error {
 	var (

--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -42,8 +42,7 @@ func main() {
 }
 
 // stripCRDSchemas projects each CRD down to only the fields the reconciler
-// reads, so that unrelated heavy fields (OpenAPI schemas, printer columns,
-// conversion webhooks, status, etc.) are never retained in the cache.
+// reads, so that unrelated fields are never retained in the cache.
 func stripCRDSchemas(i any) (any, error) {
 	crd, ok := i.(*apiextensionsv1.CustomResourceDefinition)
 	if !ok {

--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -41,9 +41,9 @@ func main() {
 	}
 }
 
-// stripCRDSchemas projects each CRD down to only the fields the reconciler
+// trimCRDFields trims each CRD down to only the fields the reconciler
 // reads, so that unrelated fields are never retained in the cache.
-func stripCRDSchemas(i any) (any, error) {
+func trimCRDFields(i any) (any, error) {
 	crd, ok := i.(*apiextensionsv1.CustomResourceDefinition)
 	if !ok {
 		return i, nil
@@ -67,7 +67,7 @@ func stripCRDSchemas(i any) (any, error) {
 	}, nil
 }
 
-var _ toolscache.TransformFunc = stripCRDSchemas // compile-time signature check
+var _ toolscache.TransformFunc = trimCRDFields // compile-time signature check
 
 func run() error {
 	var (
@@ -110,7 +110,7 @@ func run() error {
 		Cache: cache.Options{
 			ByObject: map[client.Object]cache.ByObject{
 				&apiextensionsv1.CustomResourceDefinition{}: {
-					Transform: stripCRDSchemas,
+					Transform: trimCRDFields,
 				},
 			},
 		},

--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -16,10 +16,8 @@ import (
 	kartav1alpha1 "github.com/run-ai/karta/pkg/api/runai/v1alpha1"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	toolscache "k8s.io/client-go/tools/cache"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -41,38 +39,6 @@ func main() {
 		os.Exit(1)
 	}
 }
-
-// trimCRDFields trims each CRD down to only the fields the reconciler
-// reads, so that unrelated fields are never retained in the cache.
-func trimCRDFields(i any) (any, error) {
-	crd, ok := i.(*apiextensionsv1.CustomResourceDefinition)
-	if !ok {
-		return i, nil
-	}
-	versions := make([]apiextensionsv1.CustomResourceDefinitionVersion, len(crd.Spec.Versions))
-	for j, v := range crd.Spec.Versions {
-		versions[j] = apiextensionsv1.CustomResourceDefinitionVersion{
-			Name:   v.Name,
-			Served: v.Served,
-		}
-	}
-	return &apiextensionsv1.CustomResourceDefinition{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            crd.Name,
-			ResourceVersion: crd.ResourceVersion,
-			Generation:      crd.Generation,
-		},
-		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
-			Group: crd.Spec.Group,
-			Names: apiextensionsv1.CustomResourceDefinitionNames{
-				Kind: crd.Spec.Names.Kind,
-			},
-			Versions: versions,
-		},
-	}, nil
-}
-
-var _ toolscache.TransformFunc = trimCRDFields // compile-time signature check
 
 func run() error {
 	var (
@@ -115,7 +81,7 @@ func run() error {
 		Cache: cache.Options{
 			ByObject: map[client.Object]cache.ByObject{
 				&apiextensionsv1.CustomResourceDefinition{}: {
-					Transform: trimCRDFields,
+					Transform: pkg.TrimCRDFields,
 				},
 			},
 		},

--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -18,7 +18,10 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	toolscache "k8s.io/client-go/tools/cache"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -37,6 +40,35 @@ func main() {
 		os.Exit(1)
 	}
 }
+
+// stripCRDSchemas projects each CRD down to only the fields the reconciler
+// reads, so that unrelated heavy fields (OpenAPI schemas, printer columns,
+// conversion webhooks, status, etc.) are never retained in the cache.
+func stripCRDSchemas(i any) (any, error) {
+	crd, ok := i.(*apiextensionsv1.CustomResourceDefinition)
+	if !ok {
+		return i, nil
+	}
+	versions := make([]apiextensionsv1.CustomResourceDefinitionVersion, len(crd.Spec.Versions))
+	for j, v := range crd.Spec.Versions {
+		versions[j] = apiextensionsv1.CustomResourceDefinitionVersion{
+			Name:   v.Name,
+			Served: v.Served,
+		}
+	}
+	return &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: crd.ObjectMeta,
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: crd.Spec.Group,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Kind: crd.Spec.Names.Kind,
+			},
+			Versions: versions,
+		},
+	}, nil
+}
+
+var _ toolscache.TransformFunc = stripCRDSchemas
 
 func run() error {
 	var (
@@ -76,6 +108,13 @@ func run() error {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       leaderElectionID,
+		Cache: cache.Options{
+			ByObject: map[client.Object]cache.ByObject{
+				&apiextensionsv1.CustomResourceDefinition{}: {
+					Transform: stripCRDSchemas,
+				},
+			},
+		},
 	})
 	if err != nil {
 		return fmt.Errorf("create manager: %w", err)

--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -16,6 +16,7 @@ import (
 	kartav1alpha1 "github.com/run-ai/karta/pkg/api/runai/v1alpha1"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	toolscache "k8s.io/client-go/tools/cache"
@@ -56,7 +57,11 @@ func trimCRDFields(i any) (any, error) {
 		}
 	}
 	return &apiextensionsv1.CustomResourceDefinition{
-		ObjectMeta: crd.ObjectMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            crd.Name,
+			ResourceVersion: crd.ResourceVersion,
+			Generation:      crd.Generation,
+		},
 		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
 			Group: crd.Spec.Group,
 			Names: apiextensionsv1.CustomResourceDefinitionNames{

--- a/operator/pkg/cache.go
+++ b/operator/pkg/cache.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package pkg
+
+import (
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	toolscache "k8s.io/client-go/tools/cache"
+)
+
+// TrimCRDFields trims each CRD down to only the fields the reconciler
+// reads, so that unrelated fields are never retained in the cache.
+func TrimCRDFields(i any) (any, error) {
+	crd, ok := i.(*apiextensionsv1.CustomResourceDefinition)
+	if !ok {
+		return i, nil
+	}
+	versions := make([]apiextensionsv1.CustomResourceDefinitionVersion, len(crd.Spec.Versions))
+	for j, v := range crd.Spec.Versions {
+		versions[j] = apiextensionsv1.CustomResourceDefinitionVersion{
+			Name:   v.Name,
+			Served: v.Served,
+		}
+	}
+	return &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            crd.Name,
+			ResourceVersion: crd.ResourceVersion,
+			Generation:      crd.Generation,
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: crd.Spec.Group,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Kind: crd.Spec.Names.Kind,
+			},
+			Versions: versions,
+		},
+	}, nil
+}
+
+var _ toolscache.TransformFunc = TrimCRDFields // compile-time signature check

--- a/operator/pkg/cache_test.go
+++ b/operator/pkg/cache_test.go
@@ -9,14 +9,17 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("TrimCRDFields", func() {
-	var full *apiextensionsv1.CustomResourceDefinition
+	It("passes through non-CRD objects unchanged", func() {
+		result, err := TrimCRDFields("not-a-crd")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal("not-a-crd"))
+	})
 
-	BeforeEach(func() {
-		full = &apiextensionsv1.CustomResourceDefinition{
+	It("keeps only the fields the reconciler reads, and nothing else", func() {
+		full := &apiextensionsv1.CustomResourceDefinition{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "foos.test.io",
 				ResourceVersion: "42",
@@ -27,10 +30,7 @@ var _ = Describe("TrimCRDFields", func() {
 			},
 			Spec: apiextensionsv1.CustomResourceDefinitionSpec{
 				Group: "test.io",
-				Names: apiextensionsv1.CustomResourceDefinitionNames{
-					Kind:   "Foo",
-					Plural: "foos",
-				},
+				Names: apiextensionsv1.CustomResourceDefinitionNames{Kind: "Foo", Plural: "foos"},
 				Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
 					{Name: "v1", Served: true, Storage: true,
 						Schema: &apiextensionsv1.CustomResourceValidation{
@@ -45,78 +45,31 @@ var _ = Describe("TrimCRDFields", func() {
 				Conversion: &apiextensionsv1.CustomResourceConversion{Strategy: "None"},
 			},
 		}
-	})
 
-	It("passes through non-CRD objects unchanged", func() {
-		other := "not-a-crd"
-		result, err := TrimCRDFields(other)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(result).To(Equal(other))
-	})
-
-	It("retains only the required ObjectMeta fields", func() {
 		result, err := TrimCRDFields(full)
 		Expect(err).NotTo(HaveOccurred())
+
+		// Deep-equal the minimal object: any leaked or dropped field fails here.
+		Expect(result).To(Equal(&apiextensionsv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "foos.test.io",
+				ResourceVersion: "42",
+				Generation:      3,
+			},
+			Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+				Group: "test.io",
+				Names: apiextensionsv1.CustomResourceDefinitionNames{Kind: "Foo"},
+				Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+					{Name: "v1", Served: true},
+					{Name: "v1beta1", Served: false},
+				},
+			},
+		}))
+
+		// Drift guard: still usable by the cache readers.
 		trimmed := result.(*apiextensionsv1.CustomResourceDefinition)
-
-		Expect(trimmed.Name).To(Equal("foos.test.io"))
-		Expect(trimmed.ResourceVersion).To(Equal("42"))
-		Expect(trimmed.Generation).To(Equal(int64(3)))
-		Expect(trimmed.Labels).To(BeNil())
-		Expect(trimmed.Annotations).To(BeNil())
-		Expect(trimmed.ManagedFields).To(BeEmpty())
-	})
-
-	It("retains Group and Kind, drops Plural and other Names fields", func() {
-		result, err := TrimCRDFields(full)
-		Expect(err).NotTo(HaveOccurred())
-		trimmed := result.(*apiextensionsv1.CustomResourceDefinition)
-
-		Expect(trimmed.Spec.Group).To(Equal("test.io"))
-		Expect(trimmed.Spec.Names.Kind).To(Equal("Foo"))
-		Expect(trimmed.Spec.Names.Plural).To(BeEmpty())
-	})
-
-	It("retains version Name and Served, drops Schema and printer columns", func() {
-		result, err := TrimCRDFields(full)
-		Expect(err).NotTo(HaveOccurred())
-		trimmed := result.(*apiextensionsv1.CustomResourceDefinition)
-
-		Expect(trimmed.Spec.Versions).To(HaveLen(2))
-		Expect(trimmed.Spec.Versions[0].Name).To(Equal("v1"))
-		Expect(trimmed.Spec.Versions[0].Served).To(BeTrue())
-		Expect(trimmed.Spec.Versions[0].Schema).To(BeNil())
-		Expect(trimmed.Spec.Versions[0].AdditionalPrinterColumns).To(BeEmpty())
-		Expect(trimmed.Spec.Versions[1].Name).To(Equal("v1beta1"))
-		Expect(trimmed.Spec.Versions[1].Served).To(BeFalse())
-	})
-
-	It("drops Conversion", func() {
-		result, err := TrimCRDFields(full)
-		Expect(err).NotTo(HaveOccurred())
-		trimmed := result.(*apiextensionsv1.CustomResourceDefinition)
-		Expect(trimmed.Spec.Conversion).To(BeNil())
-	})
-
-	It("satisfies the crdGroupKindIndex func", func() {
-		result, err := TrimCRDFields(full)
-		Expect(err).NotTo(HaveOccurred())
-		trimmed := result.(*apiextensionsv1.CustomResourceDefinition)
-
-		indexFunc := func(obj client.Object) []string {
-			crd := obj.(*apiextensionsv1.CustomResourceDefinition)
-			return []string{schema.GroupKind{Group: crd.Spec.Group, Kind: crd.Spec.Names.Kind}.String()}
-		}
-		Expect(indexFunc(trimmed)).To(ConsistOf("Foo.test.io"))
-	})
-
-	It("satisfies crdServesVersion for served versions", func() {
-		result, err := TrimCRDFields(full)
-		Expect(err).NotTo(HaveOccurred())
-		trimmed := result.(*apiextensionsv1.CustomResourceDefinition)
-
+		Expect(schema.GroupKind{Group: trimmed.Spec.Group, Kind: trimmed.Spec.Names.Kind}.String()).To(Equal("Foo.test.io"))
 		Expect(crdServesVersion(trimmed, "v1")).To(BeTrue())
 		Expect(crdServesVersion(trimmed, "v1beta1")).To(BeFalse())
-		Expect(crdServesVersion(trimmed, "v2")).To(BeFalse())
 	})
 })

--- a/operator/pkg/cache_test.go
+++ b/operator/pkg/cache_test.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package pkg
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("TrimCRDFields", func() {
+	var full *apiextensionsv1.CustomResourceDefinition
+
+	BeforeEach(func() {
+		full = &apiextensionsv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "foos.test.io",
+				ResourceVersion: "42",
+				Generation:      3,
+				Labels:          map[string]string{"some": "label"},
+				Annotations:     map[string]string{"some": "annotation"},
+				ManagedFields:   []metav1.ManagedFieldsEntry{{Manager: "kubectl"}},
+			},
+			Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+				Group: "test.io",
+				Names: apiextensionsv1.CustomResourceDefinitionNames{
+					Kind:   "Foo",
+					Plural: "foos",
+				},
+				Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+					{Name: "v1", Served: true, Storage: true,
+						Schema: &apiextensionsv1.CustomResourceValidation{
+							OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{Type: "object"},
+						},
+						AdditionalPrinterColumns: []apiextensionsv1.CustomResourceColumnDefinition{
+							{Name: "Age", Type: "date", JSONPath: ".metadata.creationTimestamp"},
+						},
+					},
+					{Name: "v1beta1", Served: false, Storage: false},
+				},
+				Conversion: &apiextensionsv1.CustomResourceConversion{Strategy: "None"},
+			},
+		}
+	})
+
+	It("passes through non-CRD objects unchanged", func() {
+		other := "not-a-crd"
+		result, err := TrimCRDFields(other)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(other))
+	})
+
+	It("retains only the required ObjectMeta fields", func() {
+		result, err := TrimCRDFields(full)
+		Expect(err).NotTo(HaveOccurred())
+		trimmed := result.(*apiextensionsv1.CustomResourceDefinition)
+
+		Expect(trimmed.Name).To(Equal("foos.test.io"))
+		Expect(trimmed.ResourceVersion).To(Equal("42"))
+		Expect(trimmed.Generation).To(Equal(int64(3)))
+		Expect(trimmed.Labels).To(BeNil())
+		Expect(trimmed.Annotations).To(BeNil())
+		Expect(trimmed.ManagedFields).To(BeEmpty())
+	})
+
+	It("retains Group and Kind, drops Plural and other Names fields", func() {
+		result, err := TrimCRDFields(full)
+		Expect(err).NotTo(HaveOccurred())
+		trimmed := result.(*apiextensionsv1.CustomResourceDefinition)
+
+		Expect(trimmed.Spec.Group).To(Equal("test.io"))
+		Expect(trimmed.Spec.Names.Kind).To(Equal("Foo"))
+		Expect(trimmed.Spec.Names.Plural).To(BeEmpty())
+	})
+
+	It("retains version Name and Served, drops Schema and printer columns", func() {
+		result, err := TrimCRDFields(full)
+		Expect(err).NotTo(HaveOccurred())
+		trimmed := result.(*apiextensionsv1.CustomResourceDefinition)
+
+		Expect(trimmed.Spec.Versions).To(HaveLen(2))
+		Expect(trimmed.Spec.Versions[0].Name).To(Equal("v1"))
+		Expect(trimmed.Spec.Versions[0].Served).To(BeTrue())
+		Expect(trimmed.Spec.Versions[0].Schema).To(BeNil())
+		Expect(trimmed.Spec.Versions[0].AdditionalPrinterColumns).To(BeEmpty())
+		Expect(trimmed.Spec.Versions[1].Name).To(Equal("v1beta1"))
+		Expect(trimmed.Spec.Versions[1].Served).To(BeFalse())
+	})
+
+	It("drops Conversion", func() {
+		result, err := TrimCRDFields(full)
+		Expect(err).NotTo(HaveOccurred())
+		trimmed := result.(*apiextensionsv1.CustomResourceDefinition)
+		Expect(trimmed.Spec.Conversion).To(BeNil())
+	})
+
+	It("satisfies the crdGroupKindIndex func", func() {
+		result, err := TrimCRDFields(full)
+		Expect(err).NotTo(HaveOccurred())
+		trimmed := result.(*apiextensionsv1.CustomResourceDefinition)
+
+		indexFunc := func(obj client.Object) []string {
+			crd := obj.(*apiextensionsv1.CustomResourceDefinition)
+			return []string{schema.GroupKind{Group: crd.Spec.Group, Kind: crd.Spec.Names.Kind}.String()}
+		}
+		Expect(indexFunc(trimmed)).To(ConsistOf("test.io/Foo"))
+	})
+
+	It("satisfies crdServesVersion for served versions", func() {
+		result, err := TrimCRDFields(full)
+		Expect(err).NotTo(HaveOccurred())
+		trimmed := result.(*apiextensionsv1.CustomResourceDefinition)
+
+		Expect(crdServesVersion(trimmed, "v1")).To(BeTrue())
+		Expect(crdServesVersion(trimmed, "v1beta1")).To(BeFalse())
+		Expect(crdServesVersion(trimmed, "v2")).To(BeFalse())
+	})
+})

--- a/operator/pkg/cache_test.go
+++ b/operator/pkg/cache_test.go
@@ -107,7 +107,7 @@ var _ = Describe("TrimCRDFields", func() {
 			crd := obj.(*apiextensionsv1.CustomResourceDefinition)
 			return []string{schema.GroupKind{Group: crd.Spec.Group, Kind: crd.Spec.Names.Kind}.String()}
 		}
-		Expect(indexFunc(trimmed)).To(ConsistOf("test.io/Foo"))
+		Expect(indexFunc(trimmed)).To(ConsistOf("Foo.test.io"))
 	})
 
 	It("satisfies crdServesVersion for served versions", func() {


### PR DESCRIPTION
## What does this PR do?
Adds a cache.TransformFunc that projects each CRD to only the fields the reconciler reads before storing it in the controller-runtime informer cache.

## Related issue(s)

<!-- Every PR must reference at least one open GitHub issue -->
Fixes #

## Checklist

- [ ] All commits are signed off with DCO (`git commit -s`)
- [ ] New/modified files have SPDX license and copyright headers
- [ ] Documentation updated (if applicable)
- [ ] Tests pass (`make check`)
- [ ] No proprietary or internal information included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced memory usage by storing trimmed CustomResourceDefinition data in the operator’s internal cache.
  * Kept only the CRD fields needed for reconciliation (core metadata, group/kind, and served version indicators).

* **Bug Fixes**
  * Improved reliability of CRD-related lookups and version checks by ensuring cached CRD data retains the required shape.

* **Tests**
  * Added comprehensive coverage for CRD trimming behavior, including metadata/spec/version handling and served-vs-non-served version logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->