### PR TITLE
docs(readme): expand community section into a how-to-connect guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,9 @@ See [ADOPTERS.md](ADOPTERS.md) for the full list of adopters. If you use Karta, 
 
 ## Community
 
-Have a question, an idea, or want to show what you built with Karta? Join the conversation in [GitHub Discussions](https://github.com/run-ai/karta/discussions). For bugs and feature requests, [open an issue](https://github.com/run-ai/karta/issues).
+Have a question, an idea, or want to show what you built with Karta? Join the conversation in [GitHub Discussions](https://github.com/run-ai/karta/discussions). For bugs and feature requests, [open an issue](https://github.com/run-ai/karta/issues). Discussions and issues are the channels maintainers monitor; expect an initial response within 5 business days, usually sooner.
+
+New to the project? Introduce yourself in Discussions - what you are building and which workload types you care about. Good entry points are issues labeled [good first issue](https://github.com/run-ai/karta/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) and [help wanted](https://github.com/run-ai/karta/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22), and [CONTRIBUTING.md](CONTRIBUTING.md) covers the development workflow end to end.
 
 ## Status
 


### PR DESCRIPTION
## What

Expands the README Community section into a short how-to-connect guide: which channels maintainers monitor (Discussions, issues), the expected initial response window (matching the 5-business-day commitment already documented in CONTRIBUTING.md), an invitation for newcomers to introduce themselves, and pointers to the good-first-issue / help-wanted labels as entry points.

## Why

Part of #166 (contributor onboarding readiness). The section previously said where to talk but not what response to expect or how to start contributing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded community engagement guidance, including response expectations and contribution pathways.
  * Added pointers for newcomers to introduce themselves, find beginner-friendly issues, and review the contribution workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->