### PR TITLE
docs(adopters): add Elotl Nova

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -11,4 +11,5 @@ To add your project or organization, open a pull request that adds a row to the 
 
 | Adopter | Type | How Karta is used |
 |---------|------|-------------------|
+| [Elotl Nova](https://www.elotl.co) | Commercial multi-cluster Kubernetes scheduler | Uses Karta to parse resource requirements of custom resource workloads (RayCluster, PyTorchJob, and others) for multi-cluster scheduling. Documented in [Nova supported API resources](https://docs.elotl.co/nova/Appendix/api-resources/#custom-resource-objects) (Nova v1.5). |
 | [KAI Scheduler](https://github.com/kai-scheduler/KAI-Scheduler) | Open-source Kubernetes GPU scheduler | Pod-grouper fallback plugin: gang scheduling for any workload type through Karta workload descriptions. Native plugins take precedence; Karta is the generic fallback. Merged 2026-07-13 in [KAI PR #1877](https://github.com/kai-scheduler/KAI-Scheduler/pull/1877). |


### PR DESCRIPTION
## What does this PR do?

Adds Elotl Nova to the adopters table. Nova publicly documents its Karta usage: the Nova v1.5 supported API resources page states Nova uses Karta to parse resource requirements for custom resource workload types. Elotl has additionally granted permission to be named.

Public record: https://docs.elotl.co/nova/Appendix/api-resources/#custom-resource-objects

## Related issue(s)

Fixes #172

## Checklist

- [x] All commits are signed off with DCO (`git commit -s`)
- [x] New/modified files have SPDX license and copyright headers
- [x] Documentation updated (if applicable)
- [x] Tests pass (`make check`)
- [x] No proprietary or internal information included

🤖 Generated with [Claude Code](https://claude.com/claude-code)