### PR TITLE
fix(api): omit empty optional pointer fields in ConditionsDefinition

### DIFF
--- a/pkg/api/runai/v1alpha1/structure.go
+++ b/pkg/api/runai/v1alpha1/structure.go
@@ -306,12 +306,12 @@ type ConditionsDefinition struct {
 	// MessageFieldName is the field name for the condition text message
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=message
-	MessageFieldName *string `json:"messageFieldName"`
+	MessageFieldName *string `json:"messageFieldName,omitempty"`
 
 	// ReasonFieldName is the field name for the condition reason
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=reason
-	ReasonFieldName *string `json:"reasonFieldName"`
+	ReasonFieldName *string `json:"reasonFieldName,omitempty"`
 }
 
 // StatusMappings define how to map extracted status information to ResourceStatus values.


### PR DESCRIPTION
## What does this PR do?

Adds `,omitempty` to the two optional `*string` fields in the `ConditionsDefinition` struct (`pkg/api/runai/v1alpha1/structure.go`): `MessageFieldName` and `ReasonFieldName`. Previously a nil pointer serialized to an explicit `null` instead of being omitted, inconsistent with every other optional pointer field in the CRD package.

Both fields also carry `+kubebuilder:default` markers; defaulting is unaffected because `omitempty` only changes serialization of a nil pointer. `make generate && make manifests` produced no CRD schema drift.

## Related issue(s)

Fixes #175

## Checklist

- [x] All commits are signed off with DCO (`git commit -s`)
- [ ] New/modified files have SPDX license and copyright headers (N/A - no new files)
- [ ] Documentation updated (if applicable) (N/A)
- [x] Tests pass (`make check`)
- [x] No proprietary or internal information included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API serialization by omitting optional message and reason fields when they are not set.
  * Prevented unnecessary empty fields from appearing in API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->