### PR TITLE
ci: add v0.* branch filter to push and pull_request triggers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,9 @@ name: Pull Request
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, v0.* ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, v0.* ]
 
 jobs:
   ci:


### PR DESCRIPTION
## What does this PR do?

<!-- Brief description of the change -->

## Related issue(s)

<!-- Every PR must reference at least one open GitHub issue -->
Fixes #

## Checklist

- [ ] All commits are signed off with DCO (`git commit -s`)
- [ ] New/modified files have SPDX license and copyright headers
- [ ] Documentation updated (if applicable)
- [ ] Tests pass (`make check`)
- [ ] No proprietary or internal information included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded automated checks to run for pushes and pull requests targeting `main` and versioned `v0.*` branches.
  * No changes were made to the validation steps themselves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->