### PR TITLE
fix(cli): sync bundled Karta defs with docs/samples

### DIFF
--- a/cmd/karta/internal/definitions/community/dynamo.yaml
+++ b/cmd/karta/internal/definitions/community/dynamo.yaml
@@ -15,6 +15,7 @@ spec:
           path: .status.state
         statusMappings:
           initializing:
+          - byPhase: initializing
           - byPhase: pending
           running:
           - byPhase: successful

--- a/cmd/karta/internal/definitions/community/jobset.yaml
+++ b/cmd/karta/internal/definitions/community/jobset.yaml
@@ -1,32 +1,42 @@
 apiVersion: run.ai/v1alpha1
 kind: Karta
+metadata:
+  name: jobset-x-k8s-io-v1alpha2-jobset
 spec:
   structureDefinition:
     rootComponent:
       name: jobset
-      # specPath omitted for root component (defaults to .spec)
       kind:
         group: jobset.x-k8s.io
         version: v1alpha2
         kind: JobSet
+      suspendDefinition:
+        suspendActions:
+          - path: .spec.suspend
+            value: "true"
+        resumeActions:
+          - path: .spec.suspend
+            value: "false"
       statusDefinition:
         conditionsDefinition:
           path: .status.conditions
           typeFieldName: type
           statusFieldName: status
+          messageFieldName: message
+          reasonFieldName: reason
         statusMappings:
           initializing:
-          - byConditions:
-            - type: StartupPolicyInProgress
-              status: "True"
+          - byExpression:
+              # Some replicatedJobs are active but none are ready yet.
+              # Guard against a null replicatedJobsStatus before the JobSet
+              # controller initializes status.
+              expression: "(.status.replicatedJobsStatus // []) | any(.active > 0 and (.ready // 0) == 0) and all(.failed == 0)"
+              expectedResult: "true"
           running:
-          - byConditions:
-            - type: StartupPolicyCompleted
-              status: "True"
-            - type: Completed
-              status: "False"
-            - type: Failed
-              status: "False"
+          - byExpression:
+              # Total ready across all replicatedJobs equals total expected replicas
+              expression: "(.status.replicatedJobsStatus // []) | any(.ready > 0 and .active > 0) and all(.failed == 0)"
+              expectedResult: "true"
           completed:
           - byConditions:
             - type: Completed
@@ -34,6 +44,10 @@ spec:
           failed:
           - byConditions:
             - type: Failed
+              status: "True"
+          suspended:
+          - byConditions:
+            - type: Suspended
               status: "True"
 
     childComponents:
@@ -47,15 +61,14 @@ spec:
       specDefinition:
         podTemplateSpecPath: .spec.replicatedJobs[].template.spec.template
       scaleDefinition:
-        replicasPath: .spec.replicatedJobs[].replicas
+        # Total pods per replicatedJob = replicas (Job instances) * parallelism (pods per Job)
+        replicasPath: .spec.replicatedJobs[] | .replicas * .template.spec.parallelism
       instanceIdPath: .spec.replicatedJobs[].name
       podSelector:
         componentInstanceSelector:
           idPath: .metadata.labels["jobset.sigs.k8s.io/replicatedjob-name"]
 
-  # Optimization instructions
   optimizationInstructions:
-    # Gang scheduling for coordinated job execution
     gangScheduling:
       podGroups:
       - name: job

--- a/cmd/karta/internal/definitions/community/lws.yaml
+++ b/cmd/karta/internal/definitions/community/lws.yaml
@@ -18,21 +18,23 @@ spec:
           messageFieldName: message
         statusMappings:
           initializing:
-          - byConditions:
-            - type: Available
-              status: "False"
-            - type: Progressing
-              status: "False"
-            - type: UpdateInProgress
-              status: "False"
+            - byConditions:
+                - status: "True"
+                  type: Progressing
+                - status: "False"
+                  type: Available
           running:
           - byConditions:
               - type: Available
                 status: "True"
+                reason: "AllGroupsReady"
               - type: Progressing
                 status: "False"
               - type: UpdateInProgress
                 status: "False"
+          - byExpression:
+              expression: "(.status.replicas // 0) > 0 and .status.readyReplicas == .status.replicas and .status.updatedReplicas == .status.replicas"
+              expectedResult: "true"
           failed:
           - byConditions:
               - type: Available

--- a/cmd/karta/internal/definitions/community/milvus.yaml
+++ b/cmd/karta/internal/definitions/community/milvus.yaml
@@ -1,77 +1,113 @@
 apiVersion: run.ai/v1alpha1
 kind: Karta
+metadata:
+  name: milvus
 spec:
   structureDefinition:
     rootComponent:
       name: milvus
-      # specPath omitted for root component (defaults to .spec)
       kind:
         group: milvus.io
         version: v1beta1
         kind: Milvus
       statusDefinition:
+        phaseDefinition:
+          # .status.status is an enum string: Healthy, Pending, Unhealthy
+          path: .status.status
         conditionsDefinition:
           path: .status.conditions
           typeFieldName: type
           statusFieldName: status
         statusMappings:
-          initializing:
-          - byConditions:
-            - type: EtcdReady
-              status: "False"
-            - type: StorageReady
-              status: "False"
-            - type: MsgStreamReady
-              status: "False"
-            - type: MilvusReady
-              status: "False"
           running:
-          - byConditions:
-            - type: EtcdReady
-              status: "True"
-            - type: StorageReady
-              status: "True"
-            - type: MsgStreamReady
-              status: "True"
-            - type: MilvusReady
-              status: "True"
-          failed:
-          - byConditions:
-            - type: MilvusReady
-              status: "False"
-            - type: EtcdReady
-              status: "False"
-            - type: StorageReady
-              status: "False"
-            - type: MsgStreamReady
-              status: "False"
+          - byPhase: "Healthy"
+          initializing:
+          - byPhase: "Pending"
+          degraded:
+          - byPhase: "Unhealthy"
 
     childComponents:
-    # QueryNode - handles vector search queries
-    - name: querynode
+    - name: standalone
       kind:
         group: apps
         version: v1
-        kind: StatefulSet
+        kind: Deployment
       ownerRef: milvus
       specDefinition:
-        podTemplateSpecPath: .spec.components.queryNode.template
+        fragmentedPodSpecDefinition:
+          schedulerNamePath: .spec.components.standalone.schedulerName
+          labelsPath: .spec.components.standalone.podLabels
+          annotationsPath: .spec.components.standalone.podAnnotations
+          resourcesPath: .spec.components.standalone.resources
+          priorityClassNamePath: .spec.components.standalone.priorityClassName
+          nodeAffinityPath: .spec.components.standalone.affinity.nodeAffinity
+          podAffinityPath: .spec.components.standalone.affinity.podAffinity
       scaleDefinition:
-        replicasPath: .spec.components.queryNode.replicas
+        replicasPath: .spec.components.standalone.replicas
       podSelector:
         componentTypeSelector:
           keyPath: .metadata.labels["app.kubernetes.io/component"]
-          value: querynode
+          value: standalone
 
-    # DataNode - processes and stores vector data
+    - name: proxy
+      kind:
+        group: apps
+        version: v1
+        kind: Deployment
+      ownerRef: milvus
+      specDefinition:
+        fragmentedPodSpecDefinition:
+          schedulerNamePath: .spec.components.proxy.schedulerName
+          labelsPath: .spec.components.proxy.podLabels
+          annotationsPath: .spec.components.proxy.podAnnotations
+          resourcesPath: .spec.components.proxy.resources
+          priorityClassNamePath: .spec.components.proxy.priorityClassName
+          nodeAffinityPath: .spec.components.proxy.affinity.nodeAffinity
+          podAffinityPath: .spec.components.proxy.affinity.podAffinity
+      scaleDefinition:
+        replicasPath: .spec.components.proxy.replicas
+      podSelector:
+        componentTypeSelector:
+          keyPath: .metadata.labels["app.kubernetes.io/component"]
+          value: proxy
+
+    - name: mixcoord
+      kind:
+        group: apps
+        version: v1
+        kind: Deployment
+      ownerRef: milvus
+      specDefinition:
+        fragmentedPodSpecDefinition:
+          schedulerNamePath: .spec.components.mixCoord.schedulerName
+          labelsPath: .spec.components.mixCoord.podLabels
+          annotationsPath: .spec.components.mixCoord.podAnnotations
+          resourcesPath: .spec.components.mixCoord.resources
+          priorityClassNamePath: .spec.components.mixCoord.priorityClassName
+          nodeAffinityPath: .spec.components.mixCoord.affinity.nodeAffinity
+          podAffinityPath: .spec.components.mixCoord.affinity.podAffinity
+      scaleDefinition:
+        replicasPath: .spec.components.mixCoord.replicas
+      podSelector:
+        componentTypeSelector:
+          keyPath: .metadata.labels["app.kubernetes.io/component"]
+          value: mixcoord
+
     - name: datanode
       kind:
         group: apps
         version: v1
-        kind: StatefulSet
+        kind: Deployment
       ownerRef: milvus
       specDefinition:
-        podTemplateSpecPath: .spec.components.dataNode.template
+        fragmentedPodSpecDefinition:
+          schedulerNamePath: .spec.components.dataNode.schedulerName
+          labelsPath: .spec.components.dataNode.podLabels
+          annotationsPath: .spec.components.dataNode.podAnnotations
+          resourcesPath: .spec.components.dataNode.resources
+          priorityClassNamePath: .spec.components.dataNode.priorityClassName
+          nodeAffinityPath: .spec.components.dataNode.affinity.nodeAffinity
+          podAffinityPath: .spec.components.dataNode.affinity.podAffinity
       scaleDefinition:
         replicasPath: .spec.components.dataNode.replicas
       podSelector:
@@ -79,9 +115,253 @@ spec:
           keyPath: .metadata.labels["app.kubernetes.io/component"]
           value: datanode
 
-  # Optimization instructions
+    - name: querynode
+      kind:
+        group: apps
+        version: v1
+        kind: Deployment
+      ownerRef: milvus
+      specDefinition:
+        fragmentedPodSpecDefinition:
+          schedulerNamePath: .spec.components.queryNode.schedulerName
+          labelsPath: .spec.components.queryNode.podLabels
+          annotationsPath: .spec.components.queryNode.podAnnotations
+          resourcesPath: .spec.components.queryNode.resources
+          priorityClassNamePath: .spec.components.queryNode.priorityClassName
+          nodeAffinityPath: .spec.components.queryNode.affinity.nodeAffinity
+          podAffinityPath: .spec.components.queryNode.affinity.podAffinity
+      scaleDefinition:
+        replicasPath: .spec.components.queryNode.replicas
+      podSelector:
+        componentTypeSelector:
+          keyPath: .metadata.labels["app.kubernetes.io/component"]
+          value: querynode
+
+    - name: streamingnode
+      kind:
+        group: apps
+        version: v1
+        kind: Deployment
+      ownerRef: milvus
+      specDefinition:
+        fragmentedPodSpecDefinition:
+          schedulerNamePath: .spec.components.streamingNode.schedulerName
+          labelsPath: .spec.components.streamingNode.podLabels
+          annotationsPath: .spec.components.streamingNode.podAnnotations
+          resourcesPath: .spec.components.streamingNode.resources
+          priorityClassNamePath: .spec.components.streamingNode.priorityClassName
+          nodeAffinityPath: .spec.components.streamingNode.affinity.nodeAffinity
+          podAffinityPath: .spec.components.streamingNode.affinity.podAffinity
+      scaleDefinition:
+        replicasPath: .spec.components.streamingNode.replicas
+      podSelector:
+        componentTypeSelector:
+          keyPath: .metadata.labels["app.kubernetes.io/component"]
+          value: streamingnode
+
+    - name: indexnode
+      kind:
+        group: apps
+        version: v1
+        kind: Deployment
+      ownerRef: milvus
+      specDefinition:
+        fragmentedPodSpecDefinition:
+          schedulerNamePath: .spec.components.indexNode.schedulerName
+          labelsPath: .spec.components.indexNode.podLabels
+          annotationsPath: .spec.components.indexNode.podAnnotations
+          resourcesPath: .spec.components.indexNode.resources
+          priorityClassNamePath: .spec.components.indexNode.priorityClassName
+          nodeAffinityPath: .spec.components.indexNode.affinity.nodeAffinity
+          podAffinityPath: .spec.components.indexNode.affinity.podAffinity
+      scaleDefinition:
+        replicasPath: .spec.components.indexNode.replicas
+      podSelector:
+        componentTypeSelector:
+          keyPath: .metadata.labels["app.kubernetes.io/component"]
+          value: indexnode
+
+    - name: rootcoord
+      kind:
+        group: apps
+        version: v1
+        kind: Deployment
+      ownerRef: milvus
+      specDefinition:
+        fragmentedPodSpecDefinition:
+          schedulerNamePath: .spec.components.rootCoord.schedulerName
+          labelsPath: .spec.components.rootCoord.podLabels
+          annotationsPath: .spec.components.rootCoord.podAnnotations
+          resourcesPath: .spec.components.rootCoord.resources
+          priorityClassNamePath: .spec.components.rootCoord.priorityClassName
+          nodeAffinityPath: .spec.components.rootCoord.affinity.nodeAffinity
+          podAffinityPath: .spec.components.rootCoord.affinity.podAffinity
+      scaleDefinition:
+        replicasPath: .spec.components.rootCoord.replicas
+      podSelector:
+        componentTypeSelector:
+          keyPath: .metadata.labels["app.kubernetes.io/component"]
+          value: rootcoord
+
+    - name: datacoord
+      kind:
+        group: apps
+        version: v1
+        kind: Deployment
+      ownerRef: milvus
+      specDefinition:
+        fragmentedPodSpecDefinition:
+          schedulerNamePath: .spec.components.dataCoord.schedulerName
+          labelsPath: .spec.components.dataCoord.podLabels
+          annotationsPath: .spec.components.dataCoord.podAnnotations
+          resourcesPath: .spec.components.dataCoord.resources
+          priorityClassNamePath: .spec.components.dataCoord.priorityClassName
+          nodeAffinityPath: .spec.components.dataCoord.affinity.nodeAffinity
+          podAffinityPath: .spec.components.dataCoord.affinity.podAffinity
+      scaleDefinition:
+        replicasPath: .spec.components.dataCoord.replicas
+      podSelector:
+        componentTypeSelector:
+          keyPath: .metadata.labels["app.kubernetes.io/component"]
+          value: datacoord
+
+    - name: querycoord
+      kind:
+        group: apps
+        version: v1
+        kind: Deployment
+      ownerRef: milvus
+      specDefinition:
+        fragmentedPodSpecDefinition:
+          schedulerNamePath: .spec.components.queryCoord.schedulerName
+          labelsPath: .spec.components.queryCoord.podLabels
+          annotationsPath: .spec.components.queryCoord.podAnnotations
+          resourcesPath: .spec.components.queryCoord.resources
+          priorityClassNamePath: .spec.components.queryCoord.priorityClassName
+          nodeAffinityPath: .spec.components.queryCoord.affinity.nodeAffinity
+          podAffinityPath: .spec.components.queryCoord.affinity.podAffinity
+      scaleDefinition:
+        replicasPath: .spec.components.queryCoord.replicas
+      podSelector:
+        componentTypeSelector:
+          keyPath: .metadata.labels["app.kubernetes.io/component"]
+          value: querycoord
+
+    - name: indexcoord
+      kind:
+        group: apps
+        version: v1
+        kind: Deployment
+      ownerRef: milvus
+      specDefinition:
+        fragmentedPodSpecDefinition:
+          schedulerNamePath: .spec.components.indexCoord.schedulerName
+          labelsPath: .spec.components.indexCoord.podLabels
+          annotationsPath: .spec.components.indexCoord.podAnnotations
+          resourcesPath: .spec.components.indexCoord.resources
+          priorityClassNamePath: .spec.components.indexCoord.priorityClassName
+          nodeAffinityPath: .spec.components.indexCoord.affinity.nodeAffinity
+          podAffinityPath: .spec.components.indexCoord.affinity.podAffinity
+      scaleDefinition:
+        replicasPath: .spec.components.indexCoord.replicas
+      podSelector:
+        componentTypeSelector:
+          keyPath: .metadata.labels["app.kubernetes.io/component"]
+          value: indexcoord
+
+    - name: cdc
+      kind:
+        group: apps
+        version: v1
+        kind: Deployment
+      ownerRef: milvus
+      specDefinition:
+        fragmentedPodSpecDefinition:
+          schedulerNamePath: .spec.components.cdc.schedulerName
+          labelsPath: .spec.components.cdc.podLabels
+          annotationsPath: .spec.components.cdc.podAnnotations
+          resourcesPath: .spec.components.cdc.resources
+          priorityClassNamePath: .spec.components.cdc.priorityClassName
+          nodeAffinityPath: .spec.components.cdc.affinity.nodeAffinity
+          podAffinityPath: .spec.components.cdc.affinity.podAffinity
+      scaleDefinition:
+        replicasPath: .spec.components.cdc.replicas
+      podSelector:
+        componentTypeSelector:
+          keyPath: .metadata.labels["app.kubernetes.io/component"]
+          value: cdc
+
+    - name: etcd
+      kind:
+        group: apps
+        version: v1
+        kind: StatefulSet
+      ownerRef: milvus
+      specDefinition:
+        fragmentedPodSpecDefinition:
+          resourcesPath: .spec.dependencies.etcd.inCluster.values.resources
+      scaleDefinition:
+        replicasPath: .spec.dependencies.etcd.inCluster.values.replicaCount
+
+    - name: minio
+      kind:
+        group: apps
+        version: v1
+        kind: StatefulSet
+      ownerRef: milvus
+      specDefinition:
+        fragmentedPodSpecDefinition:
+          resourcesPath: .spec.dependencies.storage.inCluster.values.resources
+
+    - name: pulsar-zookeeper
+      kind:
+        group: apps
+        version: v1
+        kind: StatefulSet
+      ownerRef: milvus
+      specDefinition:
+        fragmentedPodSpecDefinition:
+          resourcesPath: .spec.dependencies.pulsar.inCluster.values.zookeeper.resources
+      scaleDefinition:
+        replicasPath: .spec.dependencies.pulsar.inCluster.values.zookeeper.replicaCount
+
+    - name: pulsar-bookkeeper
+      kind:
+        group: apps
+        version: v1
+        kind: StatefulSet
+      ownerRef: milvus
+      specDefinition:
+        fragmentedPodSpecDefinition:
+          resourcesPath: .spec.dependencies.pulsar.inCluster.values.bookkeeper.resources
+      scaleDefinition:
+        replicasPath: .spec.dependencies.pulsar.inCluster.values.bookkeeper.replicaCount
+
+    - name: pulsar-broker
+      kind:
+        group: apps
+        version: v1
+        kind: StatefulSet
+      ownerRef: milvus
+      specDefinition:
+        fragmentedPodSpecDefinition:
+          resourcesPath: .spec.dependencies.pulsar.inCluster.values.broker.resources
+      scaleDefinition:
+        replicasPath: .spec.dependencies.pulsar.inCluster.values.broker.replicaCount
+
+    - name: pulsar-proxy
+      kind:
+        group: apps
+        version: v1
+        kind: StatefulSet
+      ownerRef: milvus
+      specDefinition:
+        fragmentedPodSpecDefinition:
+          resourcesPath: .spec.dependencies.pulsar.inCluster.values.proxy.resources
+      scaleDefinition:
+        replicasPath: .spec.dependencies.pulsar.inCluster.values.proxy.replicaCount
+
   optimizationInstructions:
-    # Gang scheduling for Milvus component coordination
     gangScheduling:
       podGroups:
       - name: cluster
@@ -92,5 +372,6 @@ spec:
         - componentName: datanode
           groupByKeyPaths:
           - .metadata.labels["app.kubernetes.io/instance"]
-
- 
+        - componentName: streamingnode
+          groupByKeyPaths:
+          - .metadata.labels["app.kubernetes.io/instance"]

--- a/cmd/karta/internal/definitions/community/mpijob.yaml
+++ b/cmd/karta/internal/definitions/community/mpijob.yaml
@@ -1,36 +1,38 @@
 apiVersion: run.ai/v1alpha1
 kind: Karta
 metadata:
-  name: kubeflow-org-mpijob-v1
+  name: kubeflow-org-mpijob-v2beta1
 spec:
   structureDefinition:
     rootComponent:
       name: mpijob
       kind:
         group: kubeflow.org
-        version: v1
+        version: v2beta1
         kind: MPIJob
+      suspendDefinition:
+        suspendActions:
+          - path: .spec.runPolicy.suspend
+            value: "true"
+        resumeActions:
+          - path: .spec.runPolicy.suspend
+            value: "false"
       statusDefinition:
         conditionsDefinition:
           path: .status.conditions
           typeFieldName: type
           statusFieldName: status
+          reasonFieldName: reason
           messageFieldName: message
         statusMappings:
           initializing:
           - byConditions:
               - type: Created
                 status: "True"
-              - type: Running
-                status: "False"
           running:
           - byConditions:
               - type: Running
                 status: "True"
-              - type: Succeeded
-                status: "False"
-              - type: Failed
-                status: "False"
           completed:
           - byConditions:
               - type: Succeeded
@@ -38,6 +40,10 @@ spec:
           failed:
           - byConditions:
               - type: Failed
+                status: "True"
+          suspended:
+          - byConditions:
+              - type: Suspended
                 status: "True"
     childComponents:
       - name: launcher
@@ -52,7 +58,7 @@ spec:
           replicasPath: .spec.mpiReplicaSpecs.Launcher.replicas // 1
         podSelector:
           componentTypeSelector:
-            keyPath: .metadata.labels["training.kubeflow.org/replica-type"]
+            keyPath: .metadata.labels["training.kubeflow.org/job-role"]
             value: launcher
       - name: worker
         kind:
@@ -66,12 +72,9 @@ spec:
           replicasPath: .spec.mpiReplicaSpecs.Worker.replicas // 1
         podSelector:
           componentTypeSelector:
-            keyPath: .metadata.labels["training.kubeflow.org/replica-type"]
+            keyPath: .metadata.labels["training.kubeflow.org/job-role"]
             value: worker
-  
-  # Optimization instructions
   optimizationInstructions:
-    # Gang scheduling for distributed training coordination
     gangScheduling:
       podGroups:
         - name: job

--- a/cmd/karta/internal/definitions/community/nimservice.yaml
+++ b/cmd/karta/internal/definitions/community/nimservice.yaml
@@ -31,13 +31,12 @@ spec:
         statusMappings:
           initializing:
           - byPhase: NotReady
+          - byPhase: Pending
           running:
           - byPhase: Ready
           failed:
           - byPhase: Failed
-  # Optimization instructions using new structure
   optimizationInstructions:
-    # Gang scheduling for inference pipeline coordination (preferred for serving)
     gangScheduling:
       podGroups:
       - name: service

--- a/cmd/karta/internal/definitions/community/pytorch.yaml
+++ b/cmd/karta/internal/definitions/community/pytorch.yaml
@@ -10,13 +10,12 @@ spec:
         group: kubeflow.org
         version: v1
         kind: PyTorchJob
-      # suspendDefinition sets spec.suspend to pause/resume the job natively.
       suspendDefinition:
         suspendActions:
-          - path: .spec.suspend
+          - path: .spec.runPolicy.suspend
             value: "true"
         resumeActions:
-          - path: .spec.suspend
+          - path: .spec.runPolicy.suspend
             value: "false"
       statusDefinition:
         conditionsDefinition:
@@ -44,10 +43,6 @@ spec:
           suspended:
           - byConditions:
               - type: Suspended
-                status: "True"
-          suspending:
-          - byConditions:
-              - type: Suspending
                 status: "True"
     childComponents:
       - name: master

--- a/cmd/karta/internal/definitions/community/raycluster.yaml
+++ b/cmd/karta/internal/definitions/community/raycluster.yaml
@@ -10,6 +10,13 @@ spec:
         group: ray.io
         version: v1
         kind: RayCluster
+      suspendDefinition:
+        suspendActions:
+          - path: .spec.suspend
+            value: "true"
+        resumeActions:
+          - path: .spec.suspend
+            value: "false"
       statusDefinition:
         phaseDefinition:
           path: .status.state
@@ -18,6 +25,10 @@ spec:
           - byPhase: ready
           failed:
           - byPhase: failed
+          suspended:
+          - byExpression:
+              expression: .spec.suspend == true and (.status.state == "suspended" or (.status.state | not))
+              expectedResult: "true"
     childComponents:
       - name: head
         kind:

--- a/cmd/karta/internal/definitions/community/rayjob.yaml
+++ b/cmd/karta/internal/definitions/community/rayjob.yaml
@@ -10,6 +10,13 @@ spec:
         group: ray.io
         version: v1
         kind: RayJob
+      suspendDefinition:
+        suspendActions:
+          - path: .spec.suspend
+            value: "true"
+        resumeActions:
+          - path: .spec.suspend
+            value: "false"
       statusDefinition:
         phaseDefinition:
           path: .status.jobStatus
@@ -28,6 +35,10 @@ spec:
           - byPhase: SUCCEEDED
           failed:
           - byPhase: FAILED
+          suspended:
+          - byExpression:
+              expression: .status.jobDeploymentStatus == "Suspended"
+              expectedResult: "true"
     childComponents:
       - name: head
         kind:
@@ -53,7 +64,7 @@ spec:
           podTemplateSpecPath: .spec.rayClusterSpec.workerGroupSpecs[].template
         scaleDefinition:
           replicasPath: .spec.rayClusterSpec.workerGroupSpecs[].replicas // 1
-        instanceIdPath: .spec.workerGroupSpecs[].groupName
+        instanceIdPath: .spec.rayClusterSpec.workerGroupSpecs[].groupName
         podSelector:
           componentTypeSelector:
             keyPath: .metadata.labels["ray.io/node-type"]


### PR DESCRIPTION
## What does this PR do?

Syncs the CLI's bundled `internal/definitions/community/*.yaml` to the canonical `docs/samples/*.yaml`, so the embedded definitions the CLI ships track the maintained source of truth.

Started with JobSet: its bundled copy mapped `running` via `StartupPolicyCompleted=True`, a condition JobSet does not set while running, so `karta workload tree` rendered phase `Undefined` for a healthy running JobSet. The canonical def derives `running` from `.status.replicatedJobsStatus`, which resolves correctly.

A sweep of the rest found the same class of drift in several defs (Milvus had the largest divergence; lws, mpijob, pytorch, raycluster, rayjob differed in status mappings and scale expressions). All bundled defs that have a `docs/samples` counterpart are now byte-for-byte in sync.

Verified against a live JobSet: the CLI now shows `JobSet/demo [Running]` with the same tree Run:ai renders from the same definition. CLI builds and `go test ./...` passes; the registry loads every synced def.

Not in this PR (flagging): the bundled set is still missing four defs that `docs/samples` ships (dynamo-v1beta1, grove-podcliqueset, nimcache, rayservice). Adding those would make the CLI support the full documented set.

## Related issue(s)

Fixes #179

## Checklist

- [x] All commits signed off with DCO (`git commit -s`)
- [x] Data-only change (bundled YAML defs)
- [x] CLI builds and `go test ./...` passes
- [x] No proprietary or internal information included
