### PR TITLE
docs(readme): align samples table and fix stale JobSet example

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,13 +208,16 @@ Karta supports any workload type. The following are pre-built and tested Karta d
 | PyTorchJob | Kubeflow |
 | RayCluster | Ray |
 | RayJob | Ray |
+| RayService | Ray |
 | InferenceService | KServe |
 | Knative Service | Knative |
 | MPIJob | Kubeflow |
 | NIM Service | NVIDIA |
+| NIM Cache | NVIDIA |
 | LeaderWorkerSet | Kubernetes |
 | Milvus | Milvus |
 | DynamoGraphDeployment | NVIDIA Dynamo |
+| PodCliqueSet | Grove |
 
 See [`docs/samples/`](docs/samples/) for the full Karta definitions.
 

--- a/README.md
+++ b/README.md
@@ -121,9 +121,9 @@ spec:
           statusFieldName: status
         statusMappings:
           running:
-          - byConditions:
-            - type: StartupPolicyCompleted
-              status: "True"
+          - byExpression:
+              expression: "(.status.replicatedJobsStatus // []) | any(.ready > 0 and .active > 0) and all(.failed == 0)"
+              expectedResult: "true"
           completed:
           - byConditions:
             - type: Completed
@@ -143,7 +143,7 @@ spec:
       specDefinition:
         podTemplateSpecPath: .spec.replicatedJobs[].template.spec.template
       scaleDefinition:
-        replicasPath: .spec.replicatedJobs[].replicas
+        replicasPath: .spec.replicatedJobs[] | .replicas * .template.spec.parallelism
       instanceIdPath: .spec.replicatedJobs[].name  # Instances: "master", "worker"
 ```
 


### PR DESCRIPTION
## What does this PR do?

Two README accuracy fixes for the JobSet content:

1. Aligns the "Pre-built Karta Definitions" table with `docs/samples/`. The table listed 11 types while the directory ships 15 definitions (14 distinct types; Dynamo has two API versions). Adds the three missing rows: RayService, NIM Cache, PodCliqueSet (Grove).

2. Fixes the stale JobSet status mapping in the "Define a Karta" example. It mapped `running` off `StartupPolicyCompleted=True`, a condition JobSet does not set while running, so the example never matched. Now derives `running` from `.status.replicatedJobsStatus` and makes the scale expression parallelism-aware, matching `docs/samples/jobset.yaml`.

## Related issue(s)

Fixes #181

## Checklist

- [x] All commits signed off with DCO (`git commit -s`)
- [x] Docs-only change
- [x] No proprietary or internal information included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the JobSet Karta example to use a jq expression for `running` status based on readiness/active and no failures.
  * Adjusted the example’s replica calculation to derive replicas from `.replicas` and `.template.spec.parallelism`.
  * Expanded and re-ordered the “Pre-built Karta Definitions” table, adding RayService, NIM Cache, and PodCliqueSet and refining existing workload/framework coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->