### PR TITLE
feat(chart): add CRD upgrader hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,9 +132,14 @@ helm-build: ## Build the helm chart
 helm-lint: ## Lint the helm chart
 	helm lint $(KARTA_CHART_DIR)
 
+# The crd-upgrader ships the CRDs in a ConfigMap, capped at ~1 MiB per etcd
+# object; fail here if a growing CRD would breach it, not on a user's upgrade.
+CRD_CONFIGMAP_MAX_BYTES ?= 1000000
+
 .PHONY: helm-validate
-helm-validate: ## Validate the helm chart renders
+helm-validate: ## Validate the chart renders and the CRD ConfigMap fits in etcd
 	helm template $(KARTA_CHART_DIR)
+	@set -e; tmp=$$(mktemp); trap 'rm -f "$$tmp"' EXIT; helm template $(KARTA_CHART_DIR) -s templates/hooks/pre/crd-upgrader-configmap.yaml > "$$tmp"; s=$$(wc -c < "$$tmp"); echo "crd-upgrader ConfigMap: $$s bytes (max $(CRD_CONFIGMAP_MAX_BYTES))"; test $$s -le $(CRD_CONFIGMAP_MAX_BYTES) || { echo "error: CRD ConfigMap is $$s bytes, over the $(CRD_CONFIGMAP_MAX_BYTES) limit; it must fit in a single ~1 MiB etcd object"; exit 1; }
 
 ##@ E2E
 

--- a/charts/karta/templates/_helpers.tpl
+++ b/charts/karta/templates/_helpers.tpl
@@ -41,3 +41,11 @@ Name of the ServiceAccount to use. When create=true the chart owns the name
 {{- required "serviceAccount.name is required when serviceAccount.create is false" .Values.serviceAccount.name -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Name for the CRD upgrader hook resources. Includes the release namespace and
+name so separate releases never share the cluster-scoped ClusterRole/Binding.
+*/}}
+{{- define "karta.crdUpgrader.name" -}}
+{{- printf "%s-crd-upgrader-%s-%s" (include "karta.fullname" .) .Release.Namespace .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/karta/templates/hooks/pre/crd-upgrader-configmap.yaml
+++ b/charts/karta/templates/hooks/pre/crd-upgrader-configmap.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "karta.fullname" . }}-crd-upgrader
+  name: {{ include "karta.crdUpgrader.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "karta.labels" . | nindent 4 }}

--- a/charts/karta/templates/hooks/pre/crd-upgrader-configmap.yaml
+++ b/charts/karta/templates/hooks/pre/crd-upgrader-configmap.yaml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+{{- if .Values.crdUpgrader.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "karta.fullname" . }}-crd-upgrader
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "karta.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+data:
+{{- range $path, $_ := .Files.Glob "crds/*.yaml" }}
+  {{ $path | base }}: |
+{{ $.Files.Get $path | indent 4 }}
+{{- end }}
+{{- end -}}

--- a/charts/karta/templates/hooks/pre/crd-upgrader-job.yaml
+++ b/charts/karta/templates/hooks/pre/crd-upgrader-job.yaml
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+{{- if .Values.crdUpgrader.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "karta.fullname" . }}-crd-upgrader
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "karta.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+spec:
+  backoffLimit: {{ .Values.crdUpgrader.backoffLimit }}
+  template:
+    metadata:
+      labels:
+        {{- include "karta.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "karta.fullname" . }}-crd-upgrader
+      restartPolicy: OnFailure
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.crdUpgrader.podSecurityContext | nindent 8 }}
+      containers:
+        - name: crd-upgrader
+          image: "{{ .Values.crdUpgrader.image.repository }}:{{ .Values.crdUpgrader.image.tag }}"
+          imagePullPolicy: {{ .Values.crdUpgrader.image.pullPolicy }}
+          args:
+            - apply
+            - --server-side
+            - --force-conflicts
+            - --field-manager=karta-crd-upgrader
+            - -f
+            - /crds/
+          env:
+            - name: KUBECACHEDIR
+              value: /tmp/kube-cache
+          volumeMounts:
+            - name: crds
+              mountPath: /crds
+              readOnly: true
+            - name: cache
+              mountPath: /tmp
+          resources:
+            {{- toYaml .Values.crdUpgrader.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.crdUpgrader.securityContext | nindent 12 }}
+      volumes:
+        - name: crds
+          configMap:
+            name: {{ include "karta.fullname" . }}-crd-upgrader
+        - name: cache
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end -}}

--- a/charts/karta/templates/hooks/pre/crd-upgrader-job.yaml
+++ b/charts/karta/templates/hooks/pre/crd-upgrader-job.yaml
@@ -4,7 +4,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "karta.fullname" . }}-crd-upgrader
+  name: {{ include "karta.crdUpgrader.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "karta.labels" . | nindent 4 }}
@@ -19,7 +19,7 @@ spec:
       labels:
         {{- include "karta.selectorLabels" . | nindent 8 }}
     spec:
-      serviceAccountName: {{ include "karta.fullname" . }}-crd-upgrader
+      serviceAccountName: {{ include "karta.crdUpgrader.name" . }}
       restartPolicy: OnFailure
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -54,7 +54,7 @@ spec:
       volumes:
         - name: crds
           configMap:
-            name: {{ include "karta.fullname" . }}-crd-upgrader
+            name: {{ include "karta.crdUpgrader.name" . }}
         - name: cache
           emptyDir: {}
       {{- with .Values.nodeSelector }}

--- a/charts/karta/templates/hooks/pre/crd-upgrader-rbac.yaml
+++ b/charts/karta/templates/hooks/pre/crd-upgrader-rbac.yaml
@@ -20,7 +20,7 @@ imagePullSecrets:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "karta.fullname" . }}-crd-upgrader
+  name: {{ include "karta.fullname" . }}-crd-upgrader-{{ .Release.Namespace }}
   labels:
     {{- include "karta.labels" . | nindent 4 }}
   annotations:
@@ -36,7 +36,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "karta.fullname" . }}-crd-upgrader
+  name: {{ include "karta.fullname" . }}-crd-upgrader-{{ .Release.Namespace }}
   labels:
     {{- include "karta.labels" . | nindent 4 }}
   annotations:
@@ -46,7 +46,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "karta.fullname" . }}-crd-upgrader
+  name: {{ include "karta.fullname" . }}-crd-upgrader-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "karta.fullname" . }}-crd-upgrader

--- a/charts/karta/templates/hooks/pre/crd-upgrader-rbac.yaml
+++ b/charts/karta/templates/hooks/pre/crd-upgrader-rbac.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "karta.fullname" . }}-crd-upgrader
+  name: {{ include "karta.crdUpgrader.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "karta.labels" . | nindent 4 }}
@@ -20,7 +20,7 @@ imagePullSecrets:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "karta.fullname" . }}-crd-upgrader-{{ .Release.Namespace }}
+  name: {{ include "karta.crdUpgrader.name" . }}
   labels:
     {{- include "karta.labels" . | nindent 4 }}
   annotations:
@@ -36,7 +36,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "karta.fullname" . }}-crd-upgrader-{{ .Release.Namespace }}
+  name: {{ include "karta.crdUpgrader.name" . }}
   labels:
     {{- include "karta.labels" . | nindent 4 }}
   annotations:
@@ -46,9 +46,9 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "karta.fullname" . }}-crd-upgrader-{{ .Release.Namespace }}
+  name: {{ include "karta.crdUpgrader.name" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "karta.fullname" . }}-crd-upgrader
+    name: {{ include "karta.crdUpgrader.name" . }}
     namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/charts/karta/templates/hooks/pre/crd-upgrader-rbac.yaml
+++ b/charts/karta/templates/hooks/pre/crd-upgrader-rbac.yaml
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+{{- if .Values.crdUpgrader.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "karta.fullname" . }}-crd-upgrader
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "karta.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "karta.fullname" . }}-crd-upgrader
+  labels:
+    {{- include "karta.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+rules:
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    resourceNames: ["kartas.run.ai"]
+    verbs: ["create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "karta.fullname" . }}-crd-upgrader
+  labels:
+    {{- include "karta.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "karta.fullname" . }}-crd-upgrader
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "karta.fullname" . }}-crd-upgrader
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/karta/values.yaml
+++ b/charts/karta/values.yaml
@@ -72,3 +72,32 @@ resources:
 nodeSelector: {}
 tolerations: []
 affinity: {}
+
+# A pre-install/pre-upgrade Job server-side-applies the bundled CRD, so
+# `helm upgrade` rolls the schema forward (Helm never upgrades crds/ itself).
+crdUpgrader:
+  enabled: true
+  image:
+    repository: registry.k8s.io/kubectl
+    tag: v1.34.0
+    pullPolicy: IfNotPresent
+  backoffLimit: 3
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    runAsGroup: 0
+    seccompProfile:
+      type: RuntimeDefault
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi


### PR DESCRIPTION
## What does this PR do?

Helm applies the CRD under `crds/` only on the first `helm install`, never on `helm upgrade`. So once the chart is installed, bumping the `kartas.run.ai` schema in a later release never reaches the cluster, and users hit a missing field with no error to explain it.

This adds a `pre-install,pre-upgrade` Job that runs `kubectl apply --server-side --force-conflicts` over the bundled CRD, so `helm upgrade` rolls the schema forward. `--force-conflicts` is there so the Job can take the field manager over from Helm's install-time apply. The CRD still ships in `crds/`, so a fresh install gets it up front, and since Helm never deletes `crds/` CRDs on uninstall, existing Kartas survive an uninstall without a `resource-policy: keep` annotation.

The Job reads the CRD from a ConfigMap (`.Files.Get`) and runs the stock `registry.k8s.io/kubectl` image, so there is no custom image to build or publish. `make helm-validate` (run in CI) fails if that ConfigMap grows past ~1MB, so a CRD that would outgrow the etcd object limit is caught in review instead of at install. RBAC is a ServiceAccount plus a ClusterRole scoped by `resourceNames` to `kartas.run.ai` with `create` and `patch`. Gated by `crdUpgrader.enabled` (default true), independent of `operator.enabled` so a CRD-only install still upgrades its CRD.

Same approach as KAI-Scheduler, which ships the same hook. It bakes the CRDs into a dedicated image because its CRDs are large; ours is one ~110KB CRD so a ConfigMap is enough:

https://github.com/NVIDIA/KAI-Scheduler/blob/main/deployments/kai-scheduler/templates/hooks/pre/crd-upgrader.yaml
- KAI's crd-upgrader Job and RBAC, the pattern this is modeled on

New files live under `charts/karta/templates/hooks/pre/`, plus the `crdUpgrader` block in `charts/karta/values.yaml`.

## Testing

Ran it on kind: fresh install, upgrade rolls the schema forward (with the hook off it stays stale, which is the bug), installed real Kartas from `docs/catalog/` and upgraded the CRD while they were live (they survive with the same uid, `storedVersions` unchanged), the `--skip-crds` create path, and uninstall keeps the CRD. `make check` passes.

## Related issue(s)

Fixes #43

## Checklist

- [x] All commits are signed off with DCO (`git commit -s`)
- [x] New/modified files have SPDX license and copyright headers
- [ ] Documentation updated (if applicable)
- [x] Tests pass (`make check`)
- [x] No proprietary or internal information included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional automatic CRD installation and upgrades during Helm installs and upgrades.
  - Added configurable upgrader settings, including image, retries, resource limits, security options, and scheduling preferences.
  - Added permissions and cleanup handling for the CRD upgrade process.

- **Bug Fixes**
  - Improved reliability of CRD application using server-side updates.

- **Chores**
  - Helm validation now reports CRD package size and fails when it exceeds the configured limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->