### PR TITLE
feat(cli): resolve the physical layer in workload tree

### DIFF
--- a/cmd/karta/README.md
+++ b/cmd/karta/README.md
@@ -31,6 +31,40 @@ plus `--color {auto,always,never}`.
 
 See `karta --help` and `karta workload --help` for the full surface.
 
+The physical layer
+------------------
+
+    karta workload tree <name> --physical
+
+`--physical` extends the tree past the pod, to the node it landed on and
+the devices it holds:
+
+    PyTorchJob/llama-sft [Running]
+    ├─ master  (1/1)  1/1 ready  gpu: 8   node-a  dev: 4   @clique-1
+    │ └─ Pod/llama-sft-master-0  Running  gpu: 8   node-a  @clique-1  dev: gpu-0,gpu-1,gpu-2,gpu-3
+    └─ worker  (3/3)  2/3 ready  gpu: 24  node-a,node-b,node-c  !node-c degraded  dev: 10  @clique-1,clique-2 (split)
+
+What the annotations mean:
+
+  * `!NotReady` / `!cordoned` — the node under that pod is degraded or
+    draining. Rolled up to the component as `!<node> degraded`.
+  * `@<domain>` — the node's topology domain. `(split)` on a component
+    means its pods span more than one, which for a gang-scheduled
+    component is a placement problem the logical tree cannot show.
+  * `dev:` — the individual devices allocated to the pod. `gpu:` is what
+    the pod *asked for*; `dev:` is what it actually *holds*.
+
+Device identity requires Dynamic Resource Allocation. Without DRA a pod
+records only a count (`nvidia.com/gpu: 8`), so no traversal can recover
+which GPUs it got, and the node annotations render on their own.
+
+Set `--topology-label` when your cluster names domains its own way; the
+defaults are `nvidia.com/gpu.clique` then `topology.kubernetes.io/zone`.
+
+Reads are best-effort. `--physical` needs `get` on nodes and `list` on
+resourceclaims; without them the command warns and renders the logical
+tree rather than failing.
+
 Supported workload kinds
 ------------------------
 

--- a/cmd/karta/README.md
+++ b/cmd/karta/README.md
@@ -51,12 +51,18 @@ What the annotations mean:
   * `@<domain>` — the node's topology domain. `(split)` on a component
     means its pods span more than one, which for a gang-scheduled
     component is a placement problem the logical tree cannot show.
-  * `dev:` — the individual devices allocated to the pod. `gpu:` is what
-    the pod *asked for*; `dev:` is what it actually *holds*.
+  * `dev:` — the individual devices allocated to the pod, identified by
+    hardware UUID and abbreviated for width. `gpu:` is what the pod
+    *asked for*; `dev:` is what it actually *holds*.
 
 Device identity requires Dynamic Resource Allocation. Without DRA a pod
 records only a count (`nvidia.com/gpu: 8`), so no traversal can recover
 which GPUs it got, and the node annotations render on their own.
+
+Note that a DRA pod requests devices through `spec.resourceClaims`, not
+through the `nvidia.com/gpu` extended resource, so without `--physical`
+the `gpu:` column reads `0` for every GPU workload on a DRA cluster. With
+`--physical` the count is taken from the allocation result instead.
 
 Set `--topology-label` when your cluster names domains its own way; the
 defaults are `nvidia.com/gpu.clique` then `topology.kubernetes.io/zone`.

--- a/cmd/karta/cmd/workload_tree.go
+++ b/cmd/karta/cmd/workload_tree.go
@@ -11,12 +11,16 @@ import (
 	"github.com/run-ai/karta/cmd/karta/internal/definitions"
 	"github.com/run-ai/karta/cmd/karta/internal/kube"
 	"github.com/run-ai/karta/cmd/karta/internal/loader"
+	"github.com/run-ai/karta/cmd/karta/internal/physical"
 	"github.com/run-ai/karta/cmd/karta/internal/render"
 	"github.com/run-ai/karta/pkg/tree"
 )
 
 func newWorkloadTreeCmd(opts *rootOptions) *cobra.Command {
-	return &cobra.Command{
+	var showPhysical bool
+	var topologyLabels []string
+
+	cmd := &cobra.Command{
 		Use:   "tree <name>",
 		Short: "Render a workload as a hierarchical tree",
 		Args:  cobra.ExactArgs(1),
@@ -45,7 +49,31 @@ func newWorkloadTreeCmd(opts *rootOptions) *cobra.Command {
 			}
 
 			view := render.Build(wt, res.Workload.GetKind(), res.Workload.GetName(), res.Workload.GetNamespace())
+
+			if showPhysical {
+				// Resolve only the pods that actually landed in this tree.
+				// res.Pods is the whole namespace, and reading a node per
+				// unrelated pod would be both slow and misleading.
+				snap := physical.Resolve(ctx, client, render.TreePods(view, res.Pods),
+					physical.Options{TopologyLabels: topologyLabels})
+				render.Enrich(&view, snap)
+				for _, w := range snap.Warnings {
+					fmt.Fprintf(c.ErrOrStderr(), "warning: %s\n", w)
+				}
+				if !snap.DRAAvailable {
+					fmt.Fprintln(c.ErrOrStderr(),
+						"note: cluster does not serve resource.k8s.io; per-device identity unavailable (node view only)")
+				}
+			}
+
 			return render.Tree(c.OutOrStdout(), view, opts.styleFor(c.OutOrStdout()))
 		},
 	}
+
+	cmd.Flags().StringSliceVar(&topologyLabels, "topology-label", nil,
+		"node labels that name a topology domain, tried in order (default nvidia.com/gpu.clique, topology.kubernetes.io/zone)")
+	cmd.Flags().BoolVar(&showPhysical, "physical", false,
+		"resolve the physical layer: node health, topology domain, and per-device identity where DRA is in use")
+
+	return cmd
 }

--- a/cmd/karta/internal/physical/physical.go
+++ b/cmd/karta/internal/physical/physical.go
@@ -1,0 +1,368 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+// Package physical resolves the physical half of a workload tree: the nodes a
+// component's pods landed on, and — where Dynamic Resource Allocation is in
+// play — the individual devices those pods hold.
+//
+// The logical half of the tree (workload → component → pod) already comes out
+// of pkg/tree via the Karta description. This package completes the traversal
+// to workload → component → pod → node → device, so the CLI can answer
+// "which GPU is this rank on, and is it healthy" rather than just "how many
+// GPUs did this rank ask for".
+//
+// Two tiers, deliberately separated because they have very different
+// prerequisites:
+//
+//	Tier 1 (node): works on every cluster. Reads the Node objects the pods are
+//	already bound to and reports readiness, cordon state, and topology domain.
+//
+//	Tier 2 (device): requires DRA. Reads the ResourceClaims named in
+//	pod.status.resourceClaimStatuses and pulls the allocated device identity out
+//	of the claim's allocation result. On the classic device-plugin path a pod
+//	only carries a count ("nvidia.com/gpu: 8"), so device identity is not
+//	recoverable and this tier stays empty.
+//
+// Every read here is best-effort. The CLI runs under the user's own kubeconfig,
+// which frequently cannot read cluster-scoped Nodes, so a permission error
+// degrades to a warning and a partial snapshot rather than a failed command.
+package physical
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/run-ai/karta/cmd/karta/internal/kube"
+)
+
+// DefaultTopologyLabels are the node labels consulted, in order, to name the
+// topology domain a node sits in. The first one present wins.
+//
+// The NVIDIA clique label identifies an NVLink / NVL72 domain, which is the
+// one that matters for gang placement: a tensor-parallel group split across
+// two cliques is a performance bug that no logical view can surface. The
+// standard zone label is the generic fallback. Estates that label domains
+// their own way override the list through Options.
+var DefaultTopologyLabels = []string{
+	"nvidia.com/gpu.clique",
+	"topology.kubernetes.io/zone",
+}
+
+// Options tunes a resolution pass.
+type Options struct {
+	// TopologyLabels overrides DefaultTopologyLabels when non-empty.
+	TopologyLabels []string
+}
+
+func (o Options) topologyLabels() []string {
+	if len(o.TopologyLabels) > 0 {
+		return o.TopologyLabels
+	}
+	return DefaultTopologyLabels
+}
+
+// resourceClaimGK is the DRA claim kind. The version is resolved through the
+// REST mapper rather than pinned, so the same code works against clusters
+// serving v1beta1, v1beta2, or v1 of resource.k8s.io.
+var resourceClaimGK = schema.GroupKind{Group: "resource.k8s.io", Kind: "ResourceClaim"}
+
+// NodeFacts is the Tier 1 payload: what we know about one node.
+type NodeFacts struct {
+	Name string
+	// Ready mirrors the node's Ready condition. False covers both an explicit
+	// NotReady and an Unknown status (a node whose kubelet stopped reporting).
+	Ready bool
+	// Unschedulable is the cordon flag, set during drains and maintenance.
+	Unschedulable bool
+	// Domain is the topology domain from the first matching TopologyLabels
+	// entry, empty when the node carries none of them.
+	Domain string
+	// DomainLabel records which label Domain came from, for display.
+	DomainLabel string
+}
+
+// Healthy reports whether the node is in a state a running workload can rely
+// on. A cordoned node still runs its existing pods, but it signals in-flight
+// maintenance, so it counts as degraded for a workload's purposes.
+func (n NodeFacts) Healthy() bool { return n.Ready && !n.Unschedulable }
+
+// Condition returns a short human label for an unhealthy node, or "" when the
+// node is fine. NotReady wins over cordoned when both apply, since it is the
+// more severe of the two.
+func (n NodeFacts) Condition() string {
+	switch {
+	case !n.Ready:
+		return "NotReady"
+	case n.Unschedulable:
+		return "cordoned"
+	default:
+		return ""
+	}
+}
+
+// Device is one allocated DRA device, as reported by a ResourceClaim's
+// allocation result.
+type Device struct {
+	Driver string
+	Pool   string
+	Name   string
+}
+
+// String renders the device for display. The device name alone is the useful
+// part in a tree; driver and pool are carried for callers that need to
+// disambiguate identically-named devices across vendors.
+func (d Device) String() string { return d.Name }
+
+// Snapshot is the resolved physical view for one set of pods.
+type Snapshot struct {
+	// Nodes is keyed by node name.
+	Nodes map[string]NodeFacts
+	// Devices is keyed by "<namespace>/<podName>".
+	Devices map[string][]Device
+	// Warnings records best-effort reads that failed. The command surfaces
+	// these on stderr; they never abort rendering.
+	Warnings []string
+	// DRAAvailable reports whether the cluster serves resource.k8s.io at all,
+	// so the caller can tell "no devices allocated" apart from "no DRA here".
+	DRAAvailable bool
+}
+
+// PodKey builds the Devices map key for a pod.
+func PodKey(namespace, name string) string { return namespace + "/" + name }
+
+// DevicesFor returns the devices allocated to a pod, or nil.
+func (s *Snapshot) DevicesFor(namespace, name string) []Device {
+	if s == nil {
+		return nil
+	}
+	return s.Devices[PodKey(namespace, name)]
+}
+
+// NodeFor returns the facts for a node, and whether they were resolved.
+func (s *Snapshot) NodeFor(name string) (NodeFacts, bool) {
+	if s == nil || name == "" {
+		return NodeFacts{}, false
+	}
+	f, ok := s.Nodes[name]
+	return f, ok
+}
+
+// Resolve builds a Snapshot for the given pods. It performs one Get per
+// distinct node and, when DRA is served, one List of ResourceClaims in the
+// namespace.
+//
+// Errors are folded into Snapshot.Warnings rather than returned: a partial
+// physical view is more useful than none, and the most common failure by far
+// is simply not having cluster-scoped node read permission.
+func Resolve(ctx context.Context, client *kube.Client, pods []corev1.Pod, opts Options) *Snapshot {
+	snap := &Snapshot{
+		Nodes:   map[string]NodeFacts{},
+		Devices: map[string][]Device{},
+	}
+	if len(pods) == 0 {
+		return snap
+	}
+
+	resolveNodes(ctx, client, pods, snap, opts)
+	resolveDevices(ctx, client, pods, snap)
+	return snap
+}
+
+// resolveNodes fetches the distinct nodes the pods are bound to. Unscheduled
+// pods (empty NodeName) contribute nothing.
+func resolveNodes(ctx context.Context, client *kube.Client, pods []corev1.Pod, snap *Snapshot, opts Options) {
+	names := map[string]struct{}{}
+	for i := range pods {
+		if n := pods[i].Spec.NodeName; n != "" {
+			names[n] = struct{}{}
+		}
+	}
+	if len(names) == 0 {
+		return
+	}
+
+	// One Get per distinct node rather than a cluster-wide List: a workload
+	// spans a bounded node set, while a List scales with the cluster and is
+	// frequently the read a user is not allowed to make.
+	forbidden := false
+	for _, name := range sortedKeys(names) {
+		node, err := client.Core().CoreV1().Nodes().Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsForbidden(err) {
+				// Report the permission gap once, not once per node.
+				if !forbidden {
+					forbidden = true
+					snap.Warnings = append(snap.Warnings,
+						"not permitted to read nodes; node health and topology omitted (needs get on nodes)")
+				}
+				continue
+			}
+			if apierrors.IsNotFound(err) {
+				snap.Warnings = append(snap.Warnings, fmt.Sprintf("node %q not found", name))
+				continue
+			}
+			snap.Warnings = append(snap.Warnings, fmt.Sprintf("read node %q: %v", name, err))
+			continue
+		}
+		snap.Nodes[name] = nodeFacts(node, opts.topologyLabels())
+	}
+}
+
+// nodeFacts projects a Node object down to the handful of fields the tree
+// renders.
+func nodeFacts(node *corev1.Node, topologyLabels []string) NodeFacts {
+	f := NodeFacts{Name: node.Name, Unschedulable: node.Spec.Unschedulable}
+	for _, c := range node.Status.Conditions {
+		if c.Type == corev1.NodeReady {
+			f.Ready = c.Status == corev1.ConditionTrue
+			break
+		}
+	}
+	for _, label := range topologyLabels {
+		if v, ok := node.Labels[label]; ok && v != "" {
+			f.Domain = v
+			f.DomainLabel = label
+			break
+		}
+	}
+	return f
+}
+
+// resolveDevices maps pods to their allocated DRA devices.
+//
+// The hop that matters is pod.status.resourceClaimStatuses → ResourceClaim →
+// status.allocation.devices.results. Without DRA there is no object anywhere
+// in the API that says which physical device a pod holds, only how many it
+// requested, which is exactly the gap this tier closes.
+func resolveDevices(ctx context.Context, client *kube.Client, pods []corev1.Pod, snap *Snapshot) {
+	// Which claims do we actually care about, and which pod wants each?
+	wanted := map[string][]string{} // claim name -> pod keys
+	namespace := ""
+	for i := range pods {
+		p := &pods[i]
+		for _, cs := range p.Status.ResourceClaimStatuses {
+			if cs.ResourceClaimName == nil || *cs.ResourceClaimName == "" {
+				continue
+			}
+			namespace = p.Namespace
+			key := PodKey(p.Namespace, p.Name)
+			wanted[*cs.ResourceClaimName] = append(wanted[*cs.ResourceClaimName], key)
+		}
+	}
+
+	// Resolve the served version of ResourceClaim through discovery. A mapping
+	// error means the cluster does not serve DRA, which is not a problem worth
+	// warning about — it is simply the classic device-plugin path.
+	mapping, err := client.Mapper().RESTMapping(resourceClaimGK)
+	if err != nil {
+		return
+	}
+	snap.DRAAvailable = true
+
+	if len(wanted) == 0 {
+		return
+	}
+
+	list, err := client.Dynamic().Resource(mapping.Resource).Namespace(namespace).
+		List(ctx, metav1.ListOptions{})
+	if err != nil {
+		if apierrors.IsForbidden(err) {
+			snap.Warnings = append(snap.Warnings,
+				"not permitted to read resourceclaims; device identity omitted (needs list on resourceclaims)")
+			return
+		}
+		snap.Warnings = append(snap.Warnings, fmt.Sprintf("list resourceclaims in %q: %v", namespace, err))
+		return
+	}
+
+	for i := range list.Items {
+		claim := &list.Items[i]
+		podKeys, ok := wanted[claim.GetName()]
+		if !ok {
+			continue
+		}
+		devices := allocatedDevices(claim)
+		if len(devices) == 0 {
+			continue
+		}
+		for _, key := range podKeys {
+			snap.Devices[key] = append(snap.Devices[key], devices...)
+		}
+	}
+
+	for key := range snap.Devices {
+		sort.Slice(snap.Devices[key], func(a, b int) bool {
+			return snap.Devices[key][a].Name < snap.Devices[key][b].Name
+		})
+	}
+}
+
+// allocatedDevices reads status.allocation.devices.results out of a
+// ResourceClaim. Unstructured access keeps this working across DRA API
+// versions, whose Go types moved between v1beta1, v1beta2, and v1 while this
+// field path stayed put.
+func allocatedDevices(claim *unstructured.Unstructured) []Device {
+	results, found, err := unstructured.NestedSlice(claim.Object, "status", "allocation", "devices", "results")
+	if err != nil || !found {
+		return nil
+	}
+	var out []Device
+	for _, r := range results {
+		m, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+		d := Device{
+			Driver: stringField(m, "driver"),
+			Pool:   stringField(m, "pool"),
+			Name:   stringField(m, "device"),
+		}
+		if d.Name == "" {
+			continue
+		}
+		out = append(out, d)
+	}
+	return out
+}
+
+func stringField(m map[string]any, key string) string {
+	v, ok := m[key].(string)
+	if !ok {
+		return ""
+	}
+	return v
+}
+
+func sortedKeys(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// FormatDevices renders a device list for a single tree row, capping the
+// output so a 72-GPU rack does not wrap the terminal.
+func FormatDevices(devices []Device, max int) string {
+	if len(devices) == 0 {
+		return ""
+	}
+	names := make([]string, 0, len(devices))
+	for _, d := range devices {
+		names = append(names, d.Name)
+	}
+	if max > 0 && len(names) > max {
+		extra := len(names) - max
+		names = append(names[:max:max], fmt.Sprintf("+%d more", extra))
+	}
+	return strings.Join(names, ",")
+}

--- a/cmd/karta/internal/physical/physical.go
+++ b/cmd/karta/internal/physical/physical.go
@@ -358,11 +358,25 @@ func FormatDevices(devices []Device, max int) string {
 	}
 	names := make([]string, 0, len(devices))
 	for _, d := range devices {
-		names = append(names, d.Name)
+		names = append(names, ShortDeviceName(d.Name))
 	}
 	if max > 0 && len(names) > max {
 		extra := len(names) - max
 		names = append(names[:max:max], fmt.Sprintf("+%d more", extra))
 	}
 	return strings.Join(names, ",")
+}
+
+// ShortDeviceName trims a device identifier for display. Real DRA drivers name
+// devices by hardware UUID (gpu-58719de1-c4ad-5038-a163-c74eff36f8db), and a
+// pod holding eight of them would run several hundred columns wide. The
+// leading segment is enough to tell devices apart by eye; the full identifier
+// stays on the ResourceClaim for anyone who needs to copy it.
+func ShortDeviceName(name string) string {
+	const keep = 8
+	prefix, rest, found := strings.Cut(name, "-")
+	if !found || len(rest) <= keep {
+		return name
+	}
+	return prefix + "-" + rest[:keep] + "..."
 }

--- a/cmd/karta/internal/physical/physical_test.go
+++ b/cmd/karta/internal/physical/physical_test.go
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package physical
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestNodeFacts(t *testing.T) {
+	cases := []struct {
+		name      string
+		node      *corev1.Node
+		wantOK    bool
+		wantCond  string
+		wantDom   string
+		wantLabel string
+	}{
+		{
+			name:     "ready node is healthy",
+			node:     node("n1", corev1.ConditionTrue, false, nil),
+			wantOK:   true,
+			wantCond: "",
+		},
+		{
+			name:     "not ready",
+			node:     node("n1", corev1.ConditionFalse, false, nil),
+			wantOK:   false,
+			wantCond: "NotReady",
+		},
+		{
+			// A kubelet that stopped reporting shows Unknown, which is a
+			// failure for a running workload just as much as an explicit False.
+			name:     "unknown counts as not ready",
+			node:     node("n1", corev1.ConditionUnknown, false, nil),
+			wantOK:   false,
+			wantCond: "NotReady",
+		},
+		{
+			name:     "cordoned but ready",
+			node:     node("n1", corev1.ConditionTrue, true, nil),
+			wantOK:   false,
+			wantCond: "cordoned",
+		},
+		{
+			// NotReady is the more severe signal and should win the label.
+			name:     "not ready and cordoned reports NotReady",
+			node:     node("n1", corev1.ConditionFalse, true, nil),
+			wantOK:   false,
+			wantCond: "NotReady",
+		},
+		{
+			name:      "clique label wins over zone",
+			node:      node("n1", corev1.ConditionTrue, false, map[string]string{"nvidia.com/gpu.clique": "clq-a", "topology.kubernetes.io/zone": "z1"}),
+			wantOK:    true,
+			wantDom:   "clq-a",
+			wantLabel: "nvidia.com/gpu.clique",
+		},
+		{
+			name:      "zone used when clique absent",
+			node:      node("n1", corev1.ConditionTrue, false, map[string]string{"topology.kubernetes.io/zone": "z1"}),
+			wantOK:    true,
+			wantDom:   "z1",
+			wantLabel: "topology.kubernetes.io/zone",
+		},
+		{
+			name:    "empty label value is ignored",
+			node:    node("n1", corev1.ConditionTrue, false, map[string]string{"nvidia.com/gpu.clique": ""}),
+			wantOK:  true,
+			wantDom: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := nodeFacts(tc.node, DefaultTopologyLabels)
+			if got.Healthy() != tc.wantOK {
+				t.Errorf("Healthy() = %v, want %v", got.Healthy(), tc.wantOK)
+			}
+			if got.Condition() != tc.wantCond {
+				t.Errorf("Condition() = %q, want %q", got.Condition(), tc.wantCond)
+			}
+			if got.Domain != tc.wantDom {
+				t.Errorf("Domain = %q, want %q", got.Domain, tc.wantDom)
+			}
+			if tc.wantLabel != "" && got.DomainLabel != tc.wantLabel {
+				t.Errorf("DomainLabel = %q, want %q", got.DomainLabel, tc.wantLabel)
+			}
+		})
+	}
+}
+
+func TestNodeFactsNoReadyCondition(t *testing.T) {
+	// A node object with no Ready condition at all (freshly registered, or a
+	// mock) must not read as healthy.
+	n := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n1"}}
+	if got := nodeFacts(n, DefaultTopologyLabels); got.Healthy() {
+		t.Errorf("node without Ready condition reported healthy")
+	}
+}
+
+func TestAllocatedDevices(t *testing.T) {
+	claim := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "resource.k8s.io/v1",
+		"kind":       "ResourceClaim",
+		"metadata":   map[string]any{"name": "claim-0", "namespace": "ns"},
+		"status": map[string]any{
+			"allocation": map[string]any{
+				"devices": map[string]any{
+					"results": []any{
+						map[string]any{"driver": "gpu.nvidia.com", "pool": "node-1", "device": "gpu-1"},
+						map[string]any{"driver": "gpu.nvidia.com", "pool": "node-1", "device": "gpu-0"},
+						// A result with no device name is not addressable and
+						// must be dropped rather than rendered as an empty id.
+						map[string]any{"driver": "gpu.nvidia.com", "pool": "node-1"},
+					},
+				},
+			},
+		},
+	}}
+
+	got := allocatedDevices(claim)
+	if len(got) != 2 {
+		t.Fatalf("got %d devices, want 2: %+v", len(got), got)
+	}
+	if got[0].Name != "gpu-1" || got[0].Driver != "gpu.nvidia.com" || got[0].Pool != "node-1" {
+		t.Errorf("unexpected first device: %+v", got[0])
+	}
+}
+
+func TestAllocatedDevicesUnallocatedClaim(t *testing.T) {
+	// A pending claim has no allocation stanza yet. That is the normal state
+	// between pod creation and scheduling, not an error.
+	claim := &unstructured.Unstructured{Object: map[string]any{
+		"kind":     "ResourceClaim",
+		"metadata": map[string]any{"name": "claim-0"},
+		"status":   map[string]any{},
+	}}
+	if got := allocatedDevices(claim); len(got) != 0 {
+		t.Errorf("got %d devices from an unallocated claim, want 0", len(got))
+	}
+}
+
+func TestFormatDevices(t *testing.T) {
+	devices := []Device{{Name: "gpu-0"}, {Name: "gpu-1"}, {Name: "gpu-2"}}
+
+	if got := FormatDevices(devices, 8); got != "gpu-0,gpu-1,gpu-2" {
+		t.Errorf("FormatDevices under cap = %q", got)
+	}
+	if got := FormatDevices(devices, 2); got != "gpu-0,gpu-1,+1 more" {
+		t.Errorf("FormatDevices over cap = %q", got)
+	}
+	if got := FormatDevices(nil, 8); got != "" {
+		t.Errorf("FormatDevices(nil) = %q, want empty", got)
+	}
+	// The cap must not mutate the caller's slice.
+	if len(devices) != 3 {
+		t.Errorf("FormatDevices mutated its input: %+v", devices)
+	}
+}
+
+func TestSnapshotAccessorsOnNil(t *testing.T) {
+	// The command path passes whatever Resolve returned straight into the
+	// renderer, so the accessors must tolerate a nil snapshot.
+	var snap *Snapshot
+	if got := snap.DevicesFor("ns", "pod"); got != nil {
+		t.Errorf("DevicesFor on nil snapshot = %+v", got)
+	}
+	if _, ok := snap.NodeFor("n1"); ok {
+		t.Errorf("NodeFor on nil snapshot reported ok")
+	}
+}
+
+func TestSnapshotNodeForEmptyName(t *testing.T) {
+	// An unscheduled pod has no node name; that must not resolve.
+	snap := &Snapshot{Nodes: map[string]NodeFacts{"": {Name: "phantom", Ready: true}}}
+	if _, ok := snap.NodeFor(""); ok {
+		t.Errorf("NodeFor(\"\") resolved")
+	}
+}
+
+func node(name string, ready corev1.ConditionStatus, cordoned bool, labels map[string]string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels},
+		Spec:       corev1.NodeSpec{Unschedulable: cordoned},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: ready}},
+		},
+	}
+}

--- a/cmd/karta/internal/physical/physical_test.go
+++ b/cmd/karta/internal/physical/physical_test.go
@@ -192,3 +192,17 @@ func node(name string, ready corev1.ConditionStatus, cordoned bool, labels map[s
 		},
 	}
 }
+
+func TestShortDeviceName(t *testing.T) {
+	// Real DRA drivers name devices by hardware UUID.
+	full := "gpu-58719de1-c4ad-5038-a163-c74eff36f8db"
+	if got := ShortDeviceName(full); got != "gpu-58719de1..." {
+		t.Errorf("ShortDeviceName(%q) = %q", full, got)
+	}
+	// Short names are left alone.
+	for _, short := range []string{"gpu-0", "gpu", ""} {
+		if got := ShortDeviceName(short); got != short {
+			t.Errorf("ShortDeviceName(%q) = %q, want unchanged", short, got)
+		}
+	}
+}

--- a/cmd/karta/internal/render/physical.go
+++ b/cmd/karta/internal/render/physical.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package render
+
+import (
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/run-ai/karta/cmd/karta/internal/physical"
+)
+
+// maxDevicesPerRow caps how many device names a single tree row prints before
+// collapsing the tail into "+N more". Eight is one full node's worth on the
+// common GPU SKUs, which keeps a per-pod row readable.
+const maxDevicesPerRow = 8
+
+// Enrich folds a physical snapshot into an already-built WorkloadView,
+// annotating pods with their node condition, topology domain, and allocated
+// devices, then rolling those up to each component.
+//
+// It is a separate pass rather than a parameter to Build so that callers that
+// only want the logical tree (the list command, tests, any consumer that has
+// no node read permission) are unaffected.
+func Enrich(view *WorkloadView, snap *physical.Snapshot) {
+	if view == nil || snap == nil {
+		return
+	}
+	for i := range view.Components {
+		enrichComponent(&view.Components[i], view.Namespace, snap)
+	}
+}
+
+func enrichComponent(c *ComponentView, namespace string, snap *physical.Snapshot) {
+	degraded := map[string]string{}
+	domains := map[string]struct{}{}
+	deviceCount := 0
+
+	for i := range c.Pods {
+		p := &c.Pods[i]
+		if facts, ok := snap.NodeFor(p.Node); ok {
+			p.NodeCondition = facts.Condition()
+			p.Domain = facts.Domain
+			if !facts.Healthy() {
+				degraded[facts.Name] = facts.Condition()
+			}
+			if facts.Domain != "" {
+				domains[facts.Domain] = struct{}{}
+			}
+		}
+		p.Devices = snap.DevicesFor(namespace, p.Name)
+		deviceCount += len(p.Devices)
+	}
+
+	for i := range c.Children {
+		child := &c.Children[i]
+		enrichComponent(child, namespace, snap)
+		deviceCount += child.DeviceCount
+		for _, n := range child.DegradedNodes {
+			degraded[n] = child.degradedConditions[n]
+		}
+		for _, d := range child.Domains {
+			domains[d] = struct{}{}
+		}
+	}
+
+	c.DeviceCount = deviceCount
+	c.degradedConditions = degraded
+	c.DegradedNodes = sortedMapKeys(degraded)
+	c.Domains = sortedSetKeys(domains)
+}
+
+func sortedMapKeys(m map[string]string) []string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func sortedSetKeys(m map[string]struct{}) []string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TreePods narrows a namespace-wide pod list to the pods that actually appear
+// in a rendered view. The loader lists every pod in the namespace so the tree
+// builder can match them itself; the physical resolver wants only the matched
+// subset, since it reads one node per distinct pod placement.
+func TreePods(view WorkloadView, pods []corev1.Pod) []corev1.Pod {
+	names := map[string]struct{}{}
+	var walk func(c ComponentView)
+	walk = func(c ComponentView) {
+		for _, p := range c.Pods {
+			names[p.Name] = struct{}{}
+		}
+		for _, child := range c.Children {
+			walk(child)
+		}
+	}
+	for _, c := range view.Components {
+		walk(c)
+	}
+
+	out := make([]corev1.Pod, 0, len(names))
+	for i := range pods {
+		if _, ok := names[pods[i].Name]; ok {
+			out = append(out, pods[i])
+		}
+	}
+	return out
+}
+
+// SplitAcrossDomains reports whether a component's pods landed in more than
+// one topology domain. For a gang-scheduled component this is the interesting
+// case: the workload is running, every pod is Ready, and the logical view
+// looks perfect, while the collective is crossing a domain boundary.
+func SplitAcrossDomains(c ComponentView) bool { return len(c.Domains) > 1 }

--- a/cmd/karta/internal/render/physical.go
+++ b/cmd/karta/internal/render/physical.go
@@ -32,10 +32,13 @@ func Enrich(view *WorkloadView, snap *physical.Snapshot) {
 	}
 }
 
-func enrichComponent(c *ComponentView, namespace string, snap *physical.Snapshot) {
+// enrichComponent annotates one component and returns the GPU count it
+// recovered from DRA, so parents can fold it into their own roll-up.
+func enrichComponent(c *ComponentView, namespace string, snap *physical.Snapshot) int64 {
 	degraded := map[string]string{}
 	domains := map[string]struct{}{}
 	deviceCount := 0
+	var gpuDelta int64
 
 	for i := range c.Pods {
 		p := &c.Pods[i]
@@ -51,11 +54,21 @@ func enrichComponent(c *ComponentView, namespace string, snap *physical.Snapshot
 		}
 		p.Devices = snap.DevicesFor(namespace, p.Name)
 		deviceCount += len(p.Devices)
+
+		// A DRA pod requests devices through spec.resourceClaims, not through
+		// the nvidia.com/gpu extended resource, so the count derived from the
+		// pod spec is zero for every GPU workload on a DRA cluster. The
+		// allocation result is the only truthful count available, so use it
+		// when the spec-derived one has nothing to say.
+		if p.GPUs == 0 && len(p.Devices) > 0 {
+			p.GPUs = int64(len(p.Devices))
+			gpuDelta += p.GPUs
+		}
 	}
 
 	for i := range c.Children {
 		child := &c.Children[i]
-		enrichComponent(child, namespace, snap)
+		gpuDelta += enrichComponent(child, namespace, snap)
 		deviceCount += child.DeviceCount
 		for _, n := range child.DegradedNodes {
 			degraded[n] = child.degradedConditions[n]
@@ -65,10 +78,12 @@ func enrichComponent(c *ComponentView, namespace string, snap *physical.Snapshot
 		}
 	}
 
+	c.GPUs += gpuDelta
 	c.DeviceCount = deviceCount
 	c.degradedConditions = degraded
 	c.DegradedNodes = sortedMapKeys(degraded)
 	c.Domains = sortedSetKeys(domains)
+	return gpuDelta
 }
 
 func sortedMapKeys(m map[string]string) []string {

--- a/cmd/karta/internal/render/physical_test.go
+++ b/cmd/karta/internal/render/physical_test.go
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package render
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/run-ai/karta/cmd/karta/internal/physical"
+)
+
+func snapshot() *physical.Snapshot {
+	return &physical.Snapshot{
+		DRAAvailable: true,
+		Nodes: map[string]physical.NodeFacts{
+			"node-a": {Name: "node-a", Ready: true, Domain: "clq-1"},
+			"node-b": {Name: "node-b", Ready: false, Domain: "clq-2"},
+			"node-c": {Name: "node-c", Ready: true, Unschedulable: true, Domain: "clq-1"},
+		},
+		Devices: map[string][]physical.Device{
+			physical.PodKey("ns", "worker-0"): {{Name: "gpu-0"}, {Name: "gpu-1"}},
+			physical.PodKey("ns", "worker-1"): {{Name: "gpu-2"}},
+		},
+	}
+}
+
+func TestEnrichAnnotatesPodsAndRollsUp(t *testing.T) {
+	view := WorkloadView{
+		Namespace: "ns",
+		Components: []ComponentView{{
+			Name: "worker",
+			Pods: []PodView{
+				{Name: "worker-0", Node: "node-a"},
+				{Name: "worker-1", Node: "node-b"},
+			},
+		}},
+	}
+
+	Enrich(&view, snapshot())
+	c := view.Components[0]
+
+	if got := c.Pods[0].NodeCondition; got != "" {
+		t.Errorf("healthy pod NodeCondition = %q, want empty", got)
+	}
+	if got := c.Pods[1].NodeCondition; got != "NotReady" {
+		t.Errorf("degraded pod NodeCondition = %q, want NotReady", got)
+	}
+	if got := c.Pods[0].Domain; got != "clq-1" {
+		t.Errorf("pod Domain = %q, want clq-1", got)
+	}
+	if len(c.Pods[0].Devices) != 2 || len(c.Pods[1].Devices) != 1 {
+		t.Errorf("device attachment wrong: %+v / %+v", c.Pods[0].Devices, c.Pods[1].Devices)
+	}
+	if c.DeviceCount != 3 {
+		t.Errorf("DeviceCount = %d, want 3", c.DeviceCount)
+	}
+	if len(c.DegradedNodes) != 1 || c.DegradedNodes[0] != "node-b" {
+		t.Errorf("DegradedNodes = %v, want [node-b]", c.DegradedNodes)
+	}
+	if !SplitAcrossDomains(c) {
+		t.Errorf("expected component to report a domain split, domains=%v", c.Domains)
+	}
+}
+
+func TestEnrichCordonedNodeCountsAsDegraded(t *testing.T) {
+	// A cordoned node still runs its pods, so nothing in the logical view
+	// changes. It is exactly the state a drain-impact question cares about.
+	view := WorkloadView{
+		Namespace:  "ns",
+		Components: []ComponentView{{Name: "worker", Pods: []PodView{{Name: "worker-0", Node: "node-c"}}}},
+	}
+	Enrich(&view, snapshot())
+
+	if got := view.Components[0].Pods[0].NodeCondition; got != "cordoned" {
+		t.Errorf("NodeCondition = %q, want cordoned", got)
+	}
+	if len(view.Components[0].DegradedNodes) != 1 {
+		t.Errorf("cordoned node did not roll up as degraded: %v", view.Components[0].DegradedNodes)
+	}
+}
+
+func TestEnrichRollsUpThroughChildren(t *testing.T) {
+	view := WorkloadView{
+		Namespace: "ns",
+		Components: []ComponentView{{
+			Name: "group",
+			Children: []ComponentView{
+				{Name: "leader", Pods: []PodView{{Name: "worker-0", Node: "node-a"}}},
+				{Name: "worker", Pods: []PodView{{Name: "worker-1", Node: "node-b"}}},
+			},
+		}},
+	}
+
+	Enrich(&view, snapshot())
+	parent := view.Components[0]
+
+	if parent.DeviceCount != 3 {
+		t.Errorf("parent DeviceCount = %d, want 3", parent.DeviceCount)
+	}
+	if len(parent.DegradedNodes) != 1 || parent.DegradedNodes[0] != "node-b" {
+		t.Errorf("parent DegradedNodes = %v, want [node-b]", parent.DegradedNodes)
+	}
+	if !SplitAcrossDomains(parent) {
+		t.Errorf("parent should report the split across its children, domains=%v", parent.Domains)
+	}
+}
+
+func TestEnrichUnresolvedNodeIsInert(t *testing.T) {
+	// The common case when the user cannot read nodes: the snapshot is empty,
+	// and the tree must render exactly as it did before.
+	view := WorkloadView{
+		Namespace:  "ns",
+		Components: []ComponentView{{Name: "worker", Pods: []PodView{{Name: "worker-0", Node: "node-z"}}}},
+	}
+	Enrich(&view, &physical.Snapshot{Nodes: map[string]physical.NodeFacts{}, Devices: map[string][]physical.Device{}})
+
+	c := view.Components[0]
+	if c.Pods[0].NodeCondition != "" || c.Pods[0].Domain != "" || len(c.DegradedNodes) != 0 {
+		t.Errorf("unresolved node produced annotations: %+v", c)
+	}
+}
+
+func TestEnrichNilSnapshotIsSafe(t *testing.T) {
+	view := WorkloadView{Namespace: "ns", Components: []ComponentView{{Name: "worker"}}}
+	Enrich(&view, nil)
+	if view.Components[0].DeviceCount != 0 {
+		t.Errorf("nil snapshot mutated the view")
+	}
+}
+
+func TestTreePodsNarrowsToTheTree(t *testing.T) {
+	view := WorkloadView{
+		Namespace: "ns",
+		Components: []ComponentView{{
+			Name:     "group",
+			Pods:     []PodView{{Name: "worker-0"}},
+			Children: []ComponentView{{Name: "leader", Pods: []PodView{{Name: "worker-1"}}}},
+		}},
+	}
+	pods := []corev1.Pod{
+		{ObjectMeta: metav1.ObjectMeta{Name: "worker-0", Namespace: "ns"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "worker-1", Namespace: "ns"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "unrelated", Namespace: "ns"}},
+	}
+
+	got := TreePods(view, pods)
+	if len(got) != 2 {
+		t.Fatalf("TreePods returned %d pods, want 2: %+v", len(got), got)
+	}
+	for _, p := range got {
+		if p.Name == "unrelated" {
+			t.Errorf("TreePods included a pod outside the tree")
+		}
+	}
+}
+
+func TestTreeRendersPhysicalAnnotations(t *testing.T) {
+	view := WorkloadView{
+		Kind:      "PyTorchJob",
+		Name:      "demo",
+		Namespace: "ns",
+		Components: []ComponentView{{
+			Name:            "worker",
+			DesiredReplicas: 2,
+			CurrentReplicas: 2,
+			ReadyCount:      2,
+			GPUs:            3,
+			Nodes:           []string{"node-a", "node-b"},
+			Pods: []PodView{
+				{Name: "worker-0", Phase: "Running", Ready: true, Node: "node-a", GPUs: 2},
+				{Name: "worker-1", Phase: "Running", Ready: true, Node: "node-b", GPUs: 1},
+			},
+		}},
+	}
+	Enrich(&view, snapshot())
+
+	var buf bytes.Buffer
+	if err := Tree(&buf, view, PlainStyle()); err != nil {
+		t.Fatalf("Tree: %v", err)
+	}
+	out := buf.String()
+
+	for _, want := range []string{
+		"!NotReady",        // the degraded pod's node
+		"!node-b degraded", // rolled up onto the component row
+		"dev: gpu-0,gpu-1", // per-pod device identity
+		"dev: 3",           // component device roll-up
+		"@clq-1",           // topology domain
+		"(split)",          // gang crossing a domain boundary
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("tree output missing %q\n%s", want, out)
+		}
+	}
+}
+
+func TestTreeWithoutEnrichIsUnchanged(t *testing.T) {
+	// Guard the default path: without --physical the trailing column must stay
+	// the bare node list it has always been.
+	view := WorkloadView{
+		Kind: "PyTorchJob", Name: "demo", Namespace: "ns",
+		Components: []ComponentView{{
+			Name: "worker", DesiredReplicas: 1, CurrentReplicas: 1, ReadyCount: 1,
+			Nodes: []string{"node-a"},
+			Pods:  []PodView{{Name: "worker-0", Phase: "Running", Ready: true, Node: "node-a"}},
+		}},
+	}
+
+	var buf bytes.Buffer
+	if err := Tree(&buf, view, PlainStyle()); err != nil {
+		t.Fatalf("Tree: %v", err)
+	}
+	out := buf.String()
+
+	for _, unwanted := range []string{"!", "@", "dev:", "(split)"} {
+		if strings.Contains(out, unwanted) {
+			t.Errorf("un-enriched tree leaked %q\n%s", unwanted, out)
+		}
+	}
+}

--- a/cmd/karta/internal/render/physical_test.go
+++ b/cmd/karta/internal/render/physical_test.go
@@ -223,3 +223,64 @@ func TestTreeWithoutEnrichIsUnchanged(t *testing.T) {
 		}
 	}
 }
+
+func TestEnrichRecoversGPUCountFromDRA(t *testing.T) {
+	// On a DRA cluster a GPU pod carries no nvidia.com/gpu resource, so the
+	// spec-derived count is 0 for every GPU workload. The allocation result is
+	// the only truthful count.
+	view := WorkloadView{
+		Namespace: "ns",
+		Components: []ComponentView{{
+			Name: "worker",
+			Pods: []PodView{
+				{Name: "worker-0", Node: "node-a", GPUs: 0},
+				{Name: "worker-1", Node: "node-a", GPUs: 0},
+			},
+		}},
+	}
+
+	Enrich(&view, snapshot())
+	c := view.Components[0]
+
+	if c.Pods[0].GPUs != 2 || c.Pods[1].GPUs != 1 {
+		t.Errorf("pod GPU recovery = %d/%d, want 2/1", c.Pods[0].GPUs, c.Pods[1].GPUs)
+	}
+	if c.GPUs != 3 {
+		t.Errorf("component GPUs = %d, want 3", c.GPUs)
+	}
+}
+
+func TestEnrichDoesNotOverrideSpecGPUCount(t *testing.T) {
+	// A classic device-plugin pod already reports a real count. DRA devices
+	// must not double it.
+	view := WorkloadView{
+		Namespace:  "ns",
+		Components: []ComponentView{{Name: "worker", GPUs: 8, Pods: []PodView{{Name: "worker-0", Node: "node-a", GPUs: 8}}}},
+	}
+	Enrich(&view, snapshot())
+
+	if got := view.Components[0].Pods[0].GPUs; got != 8 {
+		t.Errorf("pod GPUs = %d, want 8 (spec count preserved)", got)
+	}
+	if got := view.Components[0].GPUs; got != 8 {
+		t.Errorf("component GPUs = %d, want 8", got)
+	}
+}
+
+func TestEnrichGPURecoveryRollsUpThroughChildren(t *testing.T) {
+	view := WorkloadView{
+		Namespace: "ns",
+		Components: []ComponentView{{
+			Name: "group",
+			Children: []ComponentView{
+				{Name: "leader", Pods: []PodView{{Name: "worker-0", Node: "node-a"}}},
+				{Name: "worker", Pods: []PodView{{Name: "worker-1", Node: "node-b"}}},
+			},
+		}},
+	}
+	Enrich(&view, snapshot())
+
+	if got := view.Components[0].GPUs; got != 3 {
+		t.Errorf("parent GPUs = %d, want 3", got)
+	}
+}

--- a/cmd/karta/internal/render/tree.go
+++ b/cmd/karta/internal/render/tree.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"strings"
 	"unicode/utf8"
+
+	"github.com/run-ai/karta/cmd/karta/internal/physical"
 )
 
 // visibleLen returns the number of visible terminal columns a string takes,
@@ -159,7 +161,7 @@ func writeComponentAt(w io.Writer, c ComponentView, parentPrefix string, isLast 
 		readyStyled,
 		strings.Repeat(" ", leadingPad)+columnGap,
 		gpuStyled, columnGap,
-		nodeListDim(c.Nodes, s),
+		componentTrailing(c, s),
 	)
 
 	if len(c.Children) > 0 {
@@ -187,11 +189,7 @@ func writePod(w io.Writer, p PodView, parentPrefix string, isLast bool, widths p
 	phaseStyled := padTo(s.Phase(p.Phase), len(phasePlain), widths.phase)
 	gpuStyled := padTo(gpuLabel(p.GPUs, s), len(gpuPlain), layout.maxGPU)
 
-	node := p.Node
-	if node == "" {
-		node = "<none>"
-	}
-	nodeStyled := s.Dim(node)
+	nodeStyled := podTrailing(p, s)
 
 	leadingPlain := visibleLen(parentPrefix) + visibleLen(branch) + 1 +
 		widths.name + visibleLen(columnGap) + widths.phase
@@ -277,4 +275,53 @@ func nodeListDim(ns []string, s Style) string {
 		return s.Dim("<none>")
 	}
 	return s.Dim(strings.Join(ns, ","))
+}
+
+// componentTrailing renders the right-most cell of a component row: the node
+// list, plus the physical annotations when Enrich has run.
+//
+// This column is last on the line and is not part of the alignment math, so it
+// can grow without disturbing the tree's geometry.
+func componentTrailing(c ComponentView, s Style) string {
+	parts := []string{nodeListDim(c.Nodes, s)}
+
+	if len(c.DegradedNodes) > 0 {
+		parts = append(parts, s.Red("!"+strings.Join(c.DegradedNodes, ",")+" degraded"))
+	}
+	if c.DeviceCount > 0 {
+		parts = append(parts, s.Dim("dev: ")+itoa(c.DeviceCount))
+	}
+	if len(c.Domains) > 0 {
+		domains := s.Dim("@") + strings.Join(c.Domains, ",")
+		if SplitAcrossDomains(c) {
+			// A component whose pods span domains is the case the logical tree
+			// cannot show: everything reads Ready while the collective is
+			// crossing a fabric boundary.
+			domains += " " + s.Yellow("(split)")
+		}
+		parts = append(parts, domains)
+	}
+	return strings.Join(parts, columnGap)
+}
+
+// podTrailing renders the right-most cell of a pod row: the node it landed on,
+// its condition when unhealthy, the topology domain, and the identities of the
+// devices it holds.
+func podTrailing(p PodView, s Style) string {
+	node := p.Node
+	if node == "" {
+		node = "<none>"
+	}
+	parts := []string{s.Dim(node)}
+
+	if p.NodeCondition != "" {
+		parts = append(parts, s.Red("!"+p.NodeCondition))
+	}
+	if p.Domain != "" {
+		parts = append(parts, s.Dim("@")+p.Domain)
+	}
+	if len(p.Devices) > 0 {
+		parts = append(parts, s.Dim("dev: ")+physical.FormatDevices(p.Devices, maxDevicesPerRow))
+	}
+	return strings.Join(parts, columnGap)
 }

--- a/cmd/karta/internal/render/view.go
+++ b/cmd/karta/internal/render/view.go
@@ -14,6 +14,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/run-ai/karta/cmd/karta/internal/physical"
 	"github.com/run-ai/karta/pkg/tree"
 )
 
@@ -28,6 +29,9 @@ type WorkloadView struct {
 }
 
 // ComponentView holds the rendered fields for a tree component.
+//
+// The physical fields (DeviceCount, DegradedNodes, Domains) stay zero unless
+// Enrich has run, so a logical-only render is unaffected.
 type ComponentView struct {
 	Name            string
 	DesiredReplicas int32
@@ -37,6 +41,23 @@ type ComponentView struct {
 	Nodes           []string
 	Pods            []PodView
 	Children        []ComponentView
+
+	// DeviceCount is the number of individually-identified DRA devices held
+	// across this component's pods. It differs from GPUs, which is the
+	// requested count off the pod spec: GPUs is what was asked for, DeviceCount
+	// is what was actually allocated and can be named.
+	DeviceCount int
+	// DegradedNodes lists nodes under this component that are NotReady or
+	// cordoned.
+	DegradedNodes []string
+	// Domains lists the distinct topology domains this component's pods span.
+	// More than one entry on a gang-scheduled component means the collective
+	// crosses a domain boundary.
+	Domains []string
+
+	// degradedConditions maps a degraded node name to its condition, kept
+	// unexported so roll-ups can merge child state without widening the API.
+	degradedConditions map[string]string
 }
 
 // PodView holds the rendered fields for a single pod under a component.
@@ -46,6 +67,15 @@ type PodView struct {
 	Ready bool
 	Node  string
 	GPUs  int64
+
+	// NodeCondition is "NotReady", "cordoned", or "" when the node is healthy
+	// or was not resolved.
+	NodeCondition string
+	// Domain is the topology domain of the pod's node, when labelled.
+	Domain string
+	// Devices are the DRA devices allocated to this pod, empty on clusters
+	// without DRA.
+	Devices []physical.Device
 }
 
 // Build computes a WorkloadView from a raw WorkloadTree and the kind / name /


### PR DESCRIPTION
## What

Adds `--physical` to `karta workload tree`, extending the tree past the pod to the node it landed on and the devices it holds:

```
PyTorchJob/llama-sft [Running]
├─ master  (1/1 replicas)  1/1 ready  gpu: 8   node-a  dev: 4  @clique-1
│ └─ Pod/llama-sft-master-0  Running  gpu: 8   node-a  @clique-1  dev: gpu-0,gpu-1,gpu-2,gpu-3
└─ worker  (3/3 replicas)  2/3 ready  gpu: 24  node-a,node-b,node-c  !node-c degraded  dev: 10  @clique-1,clique-2 (split)
```

## Why

The logical half of the tree (workload → component → pod) already comes out of the Karta description. Everything anyone actually asks of a running job crosses into the physical half: which GPU did this rank hold, is its node draining, did the gang get split across a fabric boundary. Today every consumer reconstructs that edge by hand, and the device half is not reconstructable at all without DRA, since a pod records only `nvidia.com/gpu: 8`.

Proving it in the CLI first is deliberate. It runs under the user's own kubeconfig, so it sidesteps the shared-ServiceAccount permission-pooling question that gates doing this through the references API, and it gives that design a working demo instead of a strawman.

## Two tiers

- **Node** (`Tier 1`): works on every cluster. Ready/cordon state and topology domain, from the Node objects the pods are already bound to.
- **Device** (`Tier 2`): requires DRA. Reads the ResourceClaims named in `pod.status.resourceClaimStatuses` and pulls identity out of the allocation result. Version-agnostic via the REST mapper, so v1beta1/v1beta2/v1 all work.

`gpu:` is what the pod asked for; `dev:` is what it actually holds. `(split)` marks a component whose pods span more than one topology domain, which is the failure the logical tree cannot show: everything reads Ready while the collective crosses a boundary.

## Notes

- Off by default. Without `--physical` the output is byte-identical to before (guarded by a test).
- All reads are best-effort. Missing node permission or absent DRA degrades to a warning plus a partial view, never a failed command.
- Only the pods in the tree are resolved, not the namespace-wide list the loader returns.
- No new module dependencies; ResourceClaims are read as unstructured through the existing dynamic client.

## Testing

- Unit tests for node facts, allocation parsing, roll-ups through nested components, nil/empty-snapshot safety, and the rendered annotations.
- Verified read-only against a live 1.35 cluster serving `resource.k8s.io/v1` (LWS workload, node reads confirmed end to end). Not yet exercised against real allocated ResourceClaims; that path is unit-tested only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)