### PR TITLE
feat(operator): reject a duplicate Karta per group/kind in the webhook

### DIFF
--- a/operator/pkg/controller.go
+++ b/operator/pkg/controller.go
@@ -33,6 +33,12 @@ const (
 	// crdGroupKindIndexKey indexes CustomResourceDefinitions by group and kind so
 	// the reconciler can locate the CRD for a Karta root GVK directly.
 	crdGroupKindIndexKey = "spec.group+spec.names.kind"
+	// kartaGVKIndexKey indexes Kartas by their full root GVK (group/version/kind),
+	// read from the spec (not the metadata labels), so a lookup by workload type
+	// does not depend on the GVK index labels being stamped yet. The version is
+	// part of the key, so two Kartas for the same group/kind but different
+	// versions are distinct and both allowed.
+	kartaGVKIndexKey = "spec.rootComponent.gvk"
 )
 
 // Reconciler reconciles Karta CRs.
@@ -74,6 +80,11 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return fmt.Errorf("index CRDs by %s: %w", crdGroupKindIndexKey, err)
 	}
 
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(),
+		&kartav1alpha1.Karta{}, kartaGVKIndexKey, indexKartaByRootGVK); err != nil {
+		return fmt.Errorf("index Kartas by %s: %w", kartaGVKIndexKey, err)
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(ControllerName).
 		For(&kartav1alpha1.Karta{}).
@@ -83,6 +94,14 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
 		).
 		Complete(r)
+}
+
+func indexKartaByRootGVK(obj client.Object) []string {
+	gvk := rootGVK(obj.(*kartav1alpha1.Karta))
+	if gvk == nil {
+		return nil
+	}
+	return []string{gvk.String()}
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/operator/pkg/webhook.go
+++ b/operator/pkg/webhook.go
@@ -5,10 +5,12 @@ package pkg
 
 import (
 	"context"
+	"fmt"
 
 	kartav1alpha1 "github.com/run-ai/karta/pkg/api/runai/v1alpha1"
 
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -21,7 +23,7 @@ var _ admission.Defaulter[*kartav1alpha1.Karta] = (*KartaLabeler)(nil)
 func SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr, &kartav1alpha1.Karta{}).
 		WithDefaulter(&KartaLabeler{}).
-		WithValidator(&KartaValidator{}).
+		WithValidator(&KartaValidator{client: mgr.GetClient()}).
 		Complete()
 }
 
@@ -41,12 +43,44 @@ func (w *KartaLabeler) Default(_ context.Context, karta *kartav1alpha1.Karta) er
 
 // +kubebuilder:webhook:path=/validate-run-ai-v1alpha1-karta,mutating=false,failurePolicy=fail,sideEffects=None,groups=run.ai,resources=kartas,verbs=create;update,versions=v1alpha1,name=vkarta.run.ai,admissionReviewVersions=v1
 
-type KartaValidator struct{}
+type KartaValidator struct {
+	client client.Client
+}
 
 var _ admission.Validator[*kartav1alpha1.Karta] = (*KartaValidator)(nil)
 
-func (v *KartaValidator) ValidateCreate(_ context.Context, karta *kartav1alpha1.Karta) (admission.Warnings, error) {
-	return nil, kartav1alpha1.NewKartaValidator(karta).Validate()
+func (v *KartaValidator) ValidateCreate(ctx context.Context, karta *kartav1alpha1.Karta) (admission.Warnings, error) {
+	if err := kartav1alpha1.NewKartaValidator(karta).Validate(); err != nil {
+		return nil, err
+	}
+	return nil, v.checkUniqueRootGVK(ctx, karta)
+}
+
+// checkUniqueRootGVK rejects a Karta whose full root GVK (group/version/kind)
+// already has one; two Kartas for the same group/kind but different versions are
+// allowed. This is best-effort: two
+// Kartas created at the same time can both pass, because admission is not
+// serialized and neither List sees the other in-flight object. failurePolicy
+// does not change that. Guaranteed enforcement (reconcile-to-one in the
+// reconciler) is a follow-up; see #198.
+func (v *KartaValidator) checkUniqueRootGVK(ctx context.Context, karta *kartav1alpha1.Karta) error {
+	gvk := rootGVK(karta)
+	if gvk == nil {
+		return nil
+	}
+	list := &kartav1alpha1.KartaList{}
+	if err := v.client.List(ctx, list, client.MatchingFields{
+		kartaGVKIndexKey: gvk.String(),
+	}); err != nil {
+		return fmt.Errorf("check karta uniqueness: %w", err)
+	}
+	for i := range list.Items {
+		if list.Items[i].Name != karta.Name {
+			return fmt.Errorf("a Karta for group %q version %q kind %q already exists (%q); only one Karta per group/version/kind is allowed",
+				gvk.Group, gvk.Version, gvk.Kind, list.Items[i].Name)
+		}
+	}
+	return nil
 }
 
 func (v *KartaValidator) ValidateUpdate(_ context.Context, _, karta *kartav1alpha1.Karta) (admission.Warnings, error) {

--- a/operator/pkg/webhook.go
+++ b/operator/pkg/webhook.go
@@ -83,8 +83,11 @@ func (v *KartaValidator) checkUniqueRootGVK(ctx context.Context, karta *kartav1a
 	return nil
 }
 
-func (v *KartaValidator) ValidateUpdate(_ context.Context, _, karta *kartav1alpha1.Karta) (admission.Warnings, error) {
-	return nil, kartav1alpha1.NewKartaValidator(karta).Validate()
+func (v *KartaValidator) ValidateUpdate(ctx context.Context, _, karta *kartav1alpha1.Karta) (admission.Warnings, error) {
+	if err := kartav1alpha1.NewKartaValidator(karta).Validate(); err != nil {
+		return nil, err
+	}
+	return nil, v.checkUniqueRootGVK(ctx, karta)
 }
 
 func (v *KartaValidator) ValidateDelete(_ context.Context, _ *kartav1alpha1.Karta) (admission.Warnings, error) {

--- a/operator/pkg/webhook_test.go
+++ b/operator/pkg/webhook_test.go
@@ -140,6 +140,21 @@ var _ = Describe("KartaValidator", func() {
 		Expect(err).To(HaveOccurred())
 	})
 
+	It("rejects an update that changes the root GVK to one another Karta already has", func() {
+		jobGVK := &kartav1alpha1.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"}
+		v := newValidator(namedKarta("ray", rayGVK), namedKarta("job", jobGVK))
+		updated := namedKarta("job", rayGVK)
+		_, err := v.ValidateUpdate(ctx, namedKarta("job", jobGVK), updated)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(`already exists ("ray")`))
+	})
+
+	It("allows updating a Karta that keeps its own root GVK", func() {
+		v := newValidator(namedKarta("ray", rayGVK))
+		_, err := v.ValidateUpdate(ctx, namedKarta("ray", rayGVK), namedKarta("ray", rayGVK))
+		Expect(err).NotTo(HaveOccurred())
+	})
+
 	It("allows delete", func() {
 		_, err := newValidator().ValidateDelete(ctx, kartaWithRootKind(nil))
 		Expect(err).NotTo(HaveOccurred())

--- a/operator/pkg/webhook_test.go
+++ b/operator/pkg/webhook_test.go
@@ -11,6 +11,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func kartaWithRootKind(gvk *kartav1alpha1.GroupVersionKind) *kartav1alpha1.Karta {
@@ -80,34 +83,65 @@ var _ = Describe("ResolveNamespace", func() {
 })
 
 var _ = Describe("KartaValidator", func() {
-	var validator *KartaValidator
 	ctx := context.Background()
 
 	rayGVK := &kartav1alpha1.GroupVersionKind{Group: "ray.io", Version: "v1", Kind: "RayCluster"}
 
-	BeforeEach(func() {
-		validator = &KartaValidator{}
-	})
+	// newValidator builds a validator backed by a fake client holding the given
+	// Kartas, with the same root GVK field index the manager registers.
+	newValidator := func(existing ...*kartav1alpha1.Karta) *KartaValidator {
+		scheme := runtime.NewScheme()
+		_ = kartav1alpha1.AddToScheme(scheme)
+		objs := make([]client.Object, 0, len(existing))
+		for _, k := range existing {
+			objs = append(objs, k)
+		}
+		c := fake.NewClientBuilder().WithScheme(scheme).
+			WithIndex(&kartav1alpha1.Karta{}, kartaGVKIndexKey, indexKartaByRootGVK).
+			WithObjects(objs...).Build()
+		return &KartaValidator{client: c}
+	}
 
 	validKarta := func() *kartav1alpha1.Karta { return namedKarta("valid", rayGVK) }
 
 	It("accepts a valid Karta on create", func() {
-		_, err := validator.ValidateCreate(ctx, validKarta())
+		_, err := newValidator().ValidateCreate(ctx, validKarta())
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("rejects a Karta with no root component kind on create", func() {
-		_, err := validator.ValidateCreate(ctx, kartaWithRootKind(nil))
+		_, err := newValidator().ValidateCreate(ctx, kartaWithRootKind(nil))
 		Expect(err).To(HaveOccurred())
 	})
 
+	It("rejects a second Karta for the same root GVK", func() {
+		v := newValidator(namedKarta("first", rayGVK))
+		_, err := v.ValidateCreate(ctx, namedKarta("second", rayGVK))
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("already exists"))
+	})
+
+	It("allows a Karta for the same group/kind but a different version", func() {
+		v := newValidator(namedKarta("ray-v1", rayGVK))
+		rayV1alpha1 := &kartav1alpha1.GroupVersionKind{Group: "ray.io", Version: "v1alpha1", Kind: "RayCluster"}
+		_, err := v.ValidateCreate(ctx, namedKarta("ray-v1alpha1", rayV1alpha1))
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("allows a Karta for a group/kind that has none yet", func() {
+		v := newValidator(namedKarta("first", rayGVK))
+		jobGVK := &kartav1alpha1.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"}
+		_, err := v.ValidateCreate(ctx, namedKarta("second", jobGVK))
+		Expect(err).NotTo(HaveOccurred())
+	})
+
 	It("rejects an invalid Karta on update", func() {
-		_, err := validator.ValidateUpdate(ctx, validKarta(), kartaWithRootKind(nil))
+		_, err := newValidator().ValidateUpdate(ctx, validKarta(), kartaWithRootKind(nil))
 		Expect(err).To(HaveOccurred())
 	})
 
 	It("allows delete", func() {
-		_, err := validator.ValidateDelete(ctx, kartaWithRootKind(nil))
+		_, err := newValidator().ValidateDelete(ctx, kartaWithRootKind(nil))
 		Expect(err).NotTo(HaveOccurred())
 	})
 })


### PR DESCRIPTION
adds a uniqueness check to the karta validating webhook - on create it rejects a karta if one already exists for the same GVK (group/version/kind), so we get one karta per workload type. same group/kind but different version is allowed.

best-effort though - two created at the exact same time can both pass, since admission isnt serialized (failurePolicy doesnt change that). the real guarantee (reconcile-to-one in the reconciler) is a follow-up. part of #198.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation to prevent multiple Kartas from using the same root group, version, and kind combination.
  * Kartas with different versions or unrelated group/kind combinations can coexist.
  * Updates are allowed when preserving the current Karta’s own root identity.

* **Bug Fixes**
  * Improved handling of invalid or undefined root component identifiers.
  * Validation now reports errors when existing Karta checks cannot be completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->