### PR TITLE
feat(operator): make root component GVK immutable and protect its labels

### DIFF
--- a/operator/pkg/webhook.go
+++ b/operator/pkg/webhook.go
@@ -27,6 +27,9 @@ func SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
+// Default stamps the GVK index labels derived from the root component GVK. It
+// runs on create, so any labels a user supplies are normalized to match the GVK;
+// the validating webhook then rejects any edit or removal on update.
 func (w *KartaLabeler) Default(_ context.Context, karta *kartav1alpha1.Karta) error {
 	desired := desiredRootLabels(karta)
 	if desired == nil {
@@ -83,11 +86,37 @@ func (v *KartaValidator) checkUniqueRootGVK(ctx context.Context, karta *kartav1a
 	return nil
 }
 
-func (v *KartaValidator) ValidateUpdate(ctx context.Context, _, karta *kartav1alpha1.Karta) (admission.Warnings, error) {
+func (v *KartaValidator) ValidateUpdate(ctx context.Context, oldObj, karta *kartav1alpha1.Karta) (admission.Warnings, error) {
 	if err := kartav1alpha1.NewKartaValidator(karta).Validate(); err != nil {
 		return nil, err
 	}
+	// The root component GVK is immutable once the Karta is created (#224).
+	// It backs the GVK label index and the per-GVK uniqueness guarantee, so
+	// letting it change would leave stale labels and could smuggle in a
+	// duplicate that create-time validation already rejected.
+	oldGVK, newGVK := rootGVK(oldObj), rootGVK(karta)
+	switch {
+	case oldGVK == nil && newGVK == nil:
+	case oldGVK == nil || newGVK == nil || *oldGVK != *newGVK:
+		return nil, fmt.Errorf("the root component GVK is immutable and cannot be changed after creation")
+	}
+	if err := checkRootLabels(karta); err != nil {
+		return nil, err
+	}
 	return nil, v.checkUniqueRootGVK(ctx, karta)
+}
+
+// checkRootLabels rejects a Karta whose GVK index labels do not match the values
+// derived from the root component GVK. The mutating webhook stamps these labels on
+// create; because the GVK is immutable they must stay in sync, so an update that
+// edits or removes one is rejected.
+func checkRootLabels(karta *kartav1alpha1.Karta) error {
+	for k, want := range desiredRootLabels(karta) {
+		if got, ok := karta.Labels[k]; !ok || got != want {
+			return fmt.Errorf("label %q is managed by the operator and must equal %q; it cannot be edited or removed", k, want)
+		}
+	}
+	return nil
 }
 
 func (v *KartaValidator) ValidateDelete(_ context.Context, _ *kartav1alpha1.Karta) (admission.Warnings, error) {

--- a/operator/pkg/webhook.go
+++ b/operator/pkg/webhook.go
@@ -27,9 +27,6 @@ func SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-// Default stamps the GVK index labels derived from the root component GVK. It
-// runs on create, so any labels a user supplies are normalized to match the GVK;
-// the validating webhook then rejects any edit or removal on update.
 func (w *KartaLabeler) Default(_ context.Context, karta *kartav1alpha1.Karta) error {
 	desired := desiredRootLabels(karta)
 	if desired == nil {
@@ -90,10 +87,6 @@ func (v *KartaValidator) ValidateUpdate(ctx context.Context, oldObj, karta *kart
 	if err := kartav1alpha1.NewKartaValidator(karta).Validate(); err != nil {
 		return nil, err
 	}
-	// The root component GVK is immutable once the Karta is created. It backs the
-	// GVK label index and the per-GVK uniqueness guarantee, so letting it change
-	// would leave stale labels and could smuggle in a duplicate that create-time
-	// validation already rejected.
 	oldGVK, newGVK := rootGVK(oldObj), rootGVK(karta)
 	if oldGVK == nil || newGVK == nil || *oldGVK != *newGVK {
 		return nil, fmt.Errorf("the root component GVK is immutable and cannot be changed after creation")
@@ -104,10 +97,6 @@ func (v *KartaValidator) ValidateUpdate(ctx context.Context, oldObj, karta *kart
 	return nil, v.checkUniqueRootGVK(ctx, karta)
 }
 
-// checkRootLabels rejects a Karta whose GVK index labels do not match the values
-// derived from the root component GVK. The mutating webhook stamps these labels on
-// create; because the GVK is immutable they must stay in sync, so an update that
-// edits or removes one is rejected.
 func checkRootLabels(karta *kartav1alpha1.Karta) error {
 	for k, want := range desiredRootLabels(karta) {
 		if got, ok := karta.Labels[k]; !ok || got != want {

--- a/operator/pkg/webhook.go
+++ b/operator/pkg/webhook.go
@@ -90,14 +90,12 @@ func (v *KartaValidator) ValidateUpdate(ctx context.Context, oldObj, karta *kart
 	if err := kartav1alpha1.NewKartaValidator(karta).Validate(); err != nil {
 		return nil, err
 	}
-	// The root component GVK is immutable once the Karta is created (#224).
-	// It backs the GVK label index and the per-GVK uniqueness guarantee, so
-	// letting it change would leave stale labels and could smuggle in a
-	// duplicate that create-time validation already rejected.
+	// The root component GVK is immutable once the Karta is created. It backs the
+	// GVK label index and the per-GVK uniqueness guarantee, so letting it change
+	// would leave stale labels and could smuggle in a duplicate that create-time
+	// validation already rejected.
 	oldGVK, newGVK := rootGVK(oldObj), rootGVK(karta)
-	switch {
-	case oldGVK == nil && newGVK == nil:
-	case oldGVK == nil || newGVK == nil || *oldGVK != *newGVK:
+	if oldGVK == nil || newGVK == nil || *oldGVK != *newGVK {
 		return nil, fmt.Errorf("the root component GVK is immutable and cannot be changed after creation")
 	}
 	if err := checkRootLabels(karta); err != nil {

--- a/operator/pkg/webhook_test.go
+++ b/operator/pkg/webhook_test.go
@@ -29,11 +29,13 @@ func kartaWithRootKind(gvk *kartav1alpha1.GroupVersionKind) *kartav1alpha1.Karta
 	}
 }
 
-// namedKarta builds a spec-valid Karta with a name and root GVK.
+// namedKarta builds a spec-valid Karta with a name and root GVK, carrying the GVK
+// index labels the mutating webhook stamps on create so it mirrors a stored Karta.
 func namedKarta(name string, gvk *kartav1alpha1.GroupVersionKind) *kartav1alpha1.Karta {
 	k := kartaWithRootKind(gvk)
 	k.Name = name
 	k.Spec.StructureDefinition.RootComponent.StatusDefinition = &kartav1alpha1.StatusDefinition{}
+	k.Labels = desiredRootLabels(k)
 	return k
 }
 
@@ -64,6 +66,22 @@ var _ = Describe("KartaLabeler.Default", func() {
 		karta.ObjectMeta = metav1.ObjectMeta{Labels: map[string]string{"team": "ml"}}
 		Expect(labeler.Default(ctx, karta)).To(Succeed())
 		Expect(karta.Labels).To(HaveKeyWithValue("team", "ml"))
+		Expect(karta.Labels).To(HaveKeyWithValue(kartav1alpha1.LabelRootKind, "RayCluster"))
+	})
+
+	It("restores an edited GVK label back to the value derived from the GVK", func() {
+		karta := kartaWithRootKind(&kartav1alpha1.GroupVersionKind{Group: "ray.io", Version: "v1", Kind: "RayCluster"})
+		karta.ObjectMeta = metav1.ObjectMeta{Labels: map[string]string{kartav1alpha1.LabelRootKind: "Tampered"}}
+		Expect(labeler.Default(ctx, karta)).To(Succeed())
+		Expect(karta.Labels).To(HaveKeyWithValue(kartav1alpha1.LabelRootKind, "RayCluster"))
+	})
+
+	It("re-adds a deleted GVK label", func() {
+		karta := kartaWithRootKind(&kartav1alpha1.GroupVersionKind{Group: "ray.io", Version: "v1", Kind: "RayCluster"})
+		karta.ObjectMeta = metav1.ObjectMeta{Labels: map[string]string{"team": "ml"}}
+		Expect(labeler.Default(ctx, karta)).To(Succeed())
+		Expect(karta.Labels).To(HaveKeyWithValue(kartav1alpha1.LabelRootGroup, "ray.io"))
+		Expect(karta.Labels).To(HaveKeyWithValue(kartav1alpha1.LabelRootVersion, "v1"))
 		Expect(karta.Labels).To(HaveKeyWithValue(kartav1alpha1.LabelRootKind, "RayCluster"))
 	})
 
@@ -140,18 +158,58 @@ var _ = Describe("KartaValidator", func() {
 		Expect(err).To(HaveOccurred())
 	})
 
+	It("rejects an update that changes the root GVK version", func() {
+		v := newValidator(namedKarta("ray", rayGVK))
+		rayV1alpha1 := &kartav1alpha1.GroupVersionKind{Group: "ray.io", Version: "v1alpha1", Kind: "RayCluster"}
+		_, err := v.ValidateUpdate(ctx, namedKarta("ray", rayGVK), namedKarta("ray", rayV1alpha1))
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("immutable"))
+	})
+
 	It("rejects an update that changes the root GVK to one another Karta already has", func() {
 		jobGVK := &kartav1alpha1.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"}
 		v := newValidator(namedKarta("ray", rayGVK), namedKarta("job", jobGVK))
-		updated := namedKarta("job", rayGVK)
-		_, err := v.ValidateUpdate(ctx, namedKarta("job", jobGVK), updated)
+		_, err := v.ValidateUpdate(ctx, namedKarta("job", jobGVK), namedKarta("job", rayGVK))
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring(`already exists ("ray")`))
+		Expect(err.Error()).To(ContainSubstring("immutable"))
+	})
+
+	It("rejects an update that adds a root GVK where there was none", func() {
+		v := newValidator()
+		_, err := v.ValidateUpdate(ctx, namedKarta("ray", nil), namedKarta("ray", rayGVK))
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("immutable"))
 	})
 
 	It("allows updating a Karta that keeps its own root GVK", func() {
 		v := newValidator(namedKarta("ray", rayGVK))
 		_, err := v.ValidateUpdate(ctx, namedKarta("ray", rayGVK), namedKarta("ray", rayGVK))
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("rejects an update that edits a managed GVK label", func() {
+		v := newValidator(namedKarta("ray", rayGVK))
+		tampered := namedKarta("ray", rayGVK)
+		tampered.Labels[kartav1alpha1.LabelRootKind] = "Tampered"
+		_, err := v.ValidateUpdate(ctx, namedKarta("ray", rayGVK), tampered)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("managed by the operator"))
+	})
+
+	It("rejects an update that deletes a managed GVK label", func() {
+		v := newValidator(namedKarta("ray", rayGVK))
+		tampered := namedKarta("ray", rayGVK)
+		delete(tampered.Labels, kartav1alpha1.LabelRootVersion)
+		_, err := v.ValidateUpdate(ctx, namedKarta("ray", rayGVK), tampered)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("managed by the operator"))
+	})
+
+	It("allows an update that adds an unrelated label", func() {
+		v := newValidator(namedKarta("ray", rayGVK))
+		updated := namedKarta("ray", rayGVK)
+		updated.Labels["team"] = "ml"
+		_, err := v.ValidateUpdate(ctx, namedKarta("ray", rayGVK), updated)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/operator/pkg/webhook_test.go
+++ b/operator/pkg/webhook_test.go
@@ -29,8 +29,7 @@ func kartaWithRootKind(gvk *kartav1alpha1.GroupVersionKind) *kartav1alpha1.Karta
 	}
 }
 
-// namedKarta builds a spec-valid Karta with a name and root GVK, carrying the GVK
-// index labels the mutating webhook stamps on create so it mirrors a stored Karta.
+// namedKarta builds a spec-valid Karta with a name and root GVK.
 func namedKarta(name string, gvk *kartav1alpha1.GroupVersionKind) *kartav1alpha1.Karta {
 	k := kartaWithRootKind(gvk)
 	k.Name = name


### PR DESCRIPTION
## What does this PR do?

Two related guards in the Karta webhooks, both tied to the root component GVK (`spec.structureDefinition.rootComponent.kind`):

1. The root GVK is immutable. Any update that changes, adds, or removes it is rejected by the validating webhook. It is fixed at creation.
2. The three GVK index labels (`karta.run.ai/group|version|kind`) are derived from that immutable GVK. The mutating webhook stamps them on create; the validating webhook now rejects any update that edits or removes one, so they cannot be tampered with and stay in sync with the GVK.

The root GVK and its labels back the GVK label index and the per-GVK uniqueness guarantee, so letting either drift would leave a stale index and could smuggle in a duplicate that create-time validation already rejects.

## How it was tested

Unit tests in `webhook_test.go`: GVK version change, GVK kind change onto an existing GVK, adding a GVK where there was none, an update that keeps the same GVK, editing a managed label, deleting a managed label, and adding an unrelated label.

Also verified end to end on a kind cluster with the chart installed (cert-manager, real `vkarta.run.ai` webhook):

- Change kind `RayCluster` -> `Job`: denied (`the root component GVK is immutable and cannot be changed after creation`).
- Change version `v1` -> `v1alpha1` only: denied, same message.
- Edit `karta.run.ai/kind`: denied (`label "karta.run.ai/kind" is managed by the operator and must equal "Job"; it cannot be edited or removed`).
- Delete `karta.run.ai/version`: denied, same style of message.
- Add an unrelated label (`team=ml`): accepted, managed labels intact.

## Related issue(s)

Fixes #224

## Checklist

- [x] All commits are signed off with DCO (`git commit -s`)
- [x] New/modified files have SPDX license and copyright headers
- [ ] Documentation updated (if applicable)
- [x] Tests pass (`make check`)
- [x] No proprietary or internal information included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalized root component identity labels when resources are created.
  * Prevented updates from changing, adding, or removing an existing resource’s root component identity.
  * Protected managed component labels from unauthorized changes or deletion.
  * Automatically restored missing managed labels when applicable.
  * Existing schema validation and duplicate checks continue to apply.
  * Updates with an unchanged root component identity and unrelated label changes remain valid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->