### PR TITLE
ci: track the cli Go module in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
   - package-ecosystem: gomod
     directories:
       - "/"
+      - "/cli"
       - "/operator"
       - "/docs/examples/*"
     schedule:


### PR DESCRIPTION
Closes #231 
When merged run `@dependabot recreate` in PR https://github.com/run-ai/karta/pull/230

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded automated dependency update coverage to include the CLI module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->