### PR TITLE
fix(resource): parse numeric strings when extracting scale

### DIFF
--- a/docs/catalog/serving-knative-dev-service-v1.yaml
+++ b/docs/catalog/serving-knative-dev-service-v1.yaml
@@ -33,8 +33,8 @@ spec:
         specDefinition:
           podTemplateSpecPath: .spec.template
         scaleDefinition:
-          minReplicasPath: .spec.template.metadata.annotations["autoscaling.knative.dev/min-scale"] // 1
-          maxReplicasPath: .spec.template.metadata.annotations["autoscaling.knative.dev/max-scale"]
+          minReplicasPath: .spec.template.metadata.annotations["autoscaling.knative.dev/min-scale"] // 1 | tonumber
+          maxReplicasPath: .spec.template.metadata.annotations["autoscaling.knative.dev/max-scale"] | tonumber?
     additionalChildKinds:
       - group: apps
         version: v1

--- a/pkg/catalog/kartas/knative_serving.go
+++ b/pkg/catalog/kartas/knative_serving.go
@@ -42,8 +42,8 @@ func KnativeServing() *v1alpha1.Karta {
 							PodTemplateSpecPath: ptr.To(".spec.template"),
 						},
 						ScaleDefinition: &v1alpha1.ScaleDefinition{
-							MinReplicasPath: ptr.To(`.spec.template.metadata.annotations["autoscaling.knative.dev/min-scale"] // 1`),
-							MaxReplicasPath: ptr.To(`.spec.template.metadata.annotations["autoscaling.knative.dev/max-scale"]`),
+							MinReplicasPath: ptr.To(`.spec.template.metadata.annotations["autoscaling.knative.dev/min-scale"] // 1 | tonumber`),
+							MaxReplicasPath: ptr.To(`.spec.template.metadata.annotations["autoscaling.knative.dev/max-scale"] | tonumber?`),
 						},
 					},
 				},

--- a/pkg/resource/accessor.go
+++ b/pkg/resource/accessor.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"k8s.io/utils/ptr"
@@ -108,17 +109,17 @@ func (a *Accessor) ExtractScale(ctx context.Context, definition v1alpha1.Compone
 
 	scaleCount := 0
 
-	if err := extract(ctx, definition.ScaleDefinition.ReplicasPath, a.jqRunner, &replicas); err != nil {
+	if err := extractReplicas(ctx, definition.ScaleDefinition.ReplicasPath, a.jqRunner, &replicas); err != nil {
 		return nil, err
 	}
 	scaleCount = max(scaleCount, len(replicas))
 
-	if err := extract(ctx, definition.ScaleDefinition.MinReplicasPath, a.jqRunner, &minReplicas); err != nil {
+	if err := extractReplicas(ctx, definition.ScaleDefinition.MinReplicasPath, a.jqRunner, &minReplicas); err != nil {
 		return nil, err
 	}
 	scaleCount = max(scaleCount, len(minReplicas))
 
-	if err := extract(ctx, definition.ScaleDefinition.MaxReplicasPath, a.jqRunner, &maxReplicas); err != nil {
+	if err := extractReplicas(ctx, definition.ScaleDefinition.MaxReplicasPath, a.jqRunner, &maxReplicas); err != nil {
 		return nil, err
 	}
 	scaleCount = max(scaleCount, len(maxReplicas))
@@ -537,6 +538,46 @@ func extract[T any](ctx context.Context, path *string, accessor execution.Runner
 	}
 
 	converted, err := safeConvertSlice[T](results)
+	if err != nil {
+		return err
+	}
+
+	*out = converted
+	return nil
+}
+
+// extractReplicas extracts replica counts, accepting both numbers and numeric
+// strings. Scale paths often point at annotations or labels, whose values are
+// always strings in Kubernetes (e.g. autoscaling.knative.dev/min-scale: "2").
+func extractReplicas(ctx context.Context, path *string, runner execution.Runner, out *[]*int32) error {
+	if path == nil {
+		return nil
+	}
+
+	results, err := runner.Evaluate(ctx, *path)
+	if err != nil {
+		return err
+	}
+	if results == nil {
+		return nil
+	}
+
+	normalized := make([]any, len(results))
+	for i, object := range results {
+		str, ok := object.(string)
+		if !ok {
+			normalized[i] = object
+			continue
+		}
+
+		parsed, err := strconv.ParseInt(str, 10, 32)
+		if err != nil {
+			return fmt.Errorf("replicas value %q at index %d is not a number", str, i)
+		}
+		normalized[i] = parsed
+	}
+
+	converted, err := safeConvertSlice[*int32](normalized)
 	if err != nil {
 		return err
 	}

--- a/pkg/resource/accessor_test.go
+++ b/pkg/resource/accessor_test.go
@@ -15,6 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/ptr"
 
 	"github.com/run-ai/karta/pkg/api/runai/v1alpha1"
@@ -435,6 +436,66 @@ var _ = Describe("Accessor", func() {
 
 				// Verify we got the expected replica counts from all services
 				Expect(replicaCounts).To(ConsistOf(int32(3), int32(5), int32(1))) // api=3, worker=5, cache=1
+			})
+		})
+
+		Context("scale values stored as annotation strings", func() {
+			knativeAccessor := func(annotations map[string]any) *Accessor {
+				object := &unstructured.Unstructured{Object: map[string]any{
+					"apiVersion": "serving.knative.dev/v1",
+					"kind":       "Service",
+					"metadata":   map[string]any{"name": "inference"},
+					"spec": map[string]any{
+						"template": map[string]any{
+							"metadata": map[string]any{"annotations": annotations},
+						},
+					},
+				}}
+				return NewAccessor(execution.NewDefaultRunner(object))
+			}
+
+			definition := v1alpha1.ComponentDefinition{
+				Name: "revision",
+				ScaleDefinition: &v1alpha1.ScaleDefinition{
+					MinReplicasPath: ptr.To(`.spec.template.metadata.annotations["autoscaling.knative.dev/min-scale"] // 1`),
+					MaxReplicasPath: ptr.To(`.spec.template.metadata.annotations["autoscaling.knative.dev/max-scale"]`),
+				},
+			}
+
+			It("should parse numeric string annotations", func() {
+				accessor := knativeAccessor(map[string]any{
+					"autoscaling.knative.dev/min-scale": "2",
+					"autoscaling.knative.dev/max-scale": "3",
+				})
+
+				result, err := accessor.ExtractScale(ctx, definition)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(HaveLen(1))
+				Expect(*result[0].MinReplicas).To(Equal(int32(2)))
+				Expect(*result[0].MaxReplicas).To(Equal(int32(3)))
+			})
+
+			It("should apply the jq fallback when the annotation is missing", func() {
+				accessor := knativeAccessor(map[string]any{})
+
+				result, err := accessor.ExtractScale(ctx, definition)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(HaveLen(1))
+				Expect(*result[0].MinReplicas).To(Equal(int32(1)))
+				Expect(result[0].MaxReplicas).To(BeNil())
+			})
+
+			It("should return a clear error for a non-numeric string", func() {
+				accessor := knativeAccessor(map[string]any{
+					"autoscaling.knative.dev/min-scale": "abc",
+				})
+
+				_, err := accessor.ExtractScale(ctx, definition)
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(`replicas value "abc"`))
 			})
 		})
 


### PR DESCRIPTION
## What does this PR do?

Scale extraction fails when the scale path points at an annotation, because annotation values are always strings in Kubernetes. A Knative Service with `autoscaling.knative.dev/min-scale: "2"` fails with:

```
json: cannot unmarshal string into Go value of type int32
```

ExtractScale now parses numeric strings before converting to int32. A non-numeric value like `"abc"` returns a clear error instead of the json unmarshal one.

## Related issue(s)

Fixes #234

## Checklist

- [x] All commits are signed off with DCO (`git commit -s`)
- [x] New/modified files have SPDX license and copyright headers
- [ ] Documentation updated (if applicable)
- [x] Tests pass (`make check`)
- [x] No proprietary or internal information included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of replica, minimum-replica, and maximum-replica scaling values.
  - Numeric values provided as strings are now interpreted correctly.
  - Missing minimum-scale settings now use the appropriate fallback value.
  - Invalid, non-numeric scaling values now produce clear validation errors.

- **Tests**
  - Added coverage for annotation-based scaling, numeric-string parsing, fallback behavior, and invalid inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->