### PR TITLE
build(deps): track hack/imagelock go module in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,7 @@ updates:
       - "/"
       - "/cli"
       - "/operator"
+      - "/hack/imagelock"
       - "/docs/examples/*"
     schedule:
       interval: weekly


### PR DESCRIPTION
## Description

`hack/imagelock` is its own Go module (kept separate so its registry client stays out of Karta's shipped dependency and license graph). Add it to the Dependabot `gomod` directories so its dependencies (`go-containerregistry`, `sigs.k8s.io/yaml`) get the same weekly update PRs as the other modules.

One line: adds `- "/hack/imagelock"` to the `gomod` `directories` list.

## Kind

/kind dependency

## Checklist

- [x] PR title is clear and self-contained

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated dependency monitoring now includes the image-locking tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->