### PR TITLE
build(deps): track hack/imagelock go module in dependabot (v0.2)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,7 @@ updates:
     directories:
       - "/"
       - "/operator"
+      - "/hack/imagelock"
       - "/docs/examples/*"
     schedule:
       interval: weekly


### PR DESCRIPTION
## Description

Backport of the Dependabot change to `v0.2`. `hack/imagelock` (added to v0.2 in #237) is its own Go module; add it to the Dependabot `gomod` directories so its dependencies get weekly update PRs on the v0.2 line too.

One line: adds `- "/hack/imagelock"` to the `gomod` `directories` list.

## Kind

/kind dependency

## Checklist

- [x] PR title is clear and self-contained