### PR TITLE
docs: add CHANGELOG.md for releases tagged from main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 
 # Changelog
 
-Notable changes per release. [GitHub Releases](https://github.com/run-ai/karta/releases) are the canonical record and carry the full notes and artifacts; this file is the in-repo summary. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) loosely. Versioning is pre-1.0: minor versions may include breaking changes, see each entry.
+Notable changes per release. This file is the in-repo source of record: a release's entry is added here before the tag is pushed (see [RELEASE.md](RELEASE.md)), and the [GitHub Release](https://github.com/run-ai/karta/releases) body is written from it, so tagged source archives carry their own entry. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) loosely. Versioning is pre-1.0: minor versions may include breaking changes, see each entry.
+
+Entries through v0.2.3 were backfilled from the published GitHub release notes when this file was introduced.
 
 ## v0.2.3 - 2026-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 Notable changes per release. [GitHub Releases](https://github.com/run-ai/karta/releases) are the canonical record and carry the full notes and artifacts; this file is the in-repo summary. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) loosely. Versioning is pre-1.0: minor versions may include breaking changes, see each entry.
 
-## [v0.2.3] - 2026-08-17
+## v0.2.3 - 2026-08-17
 
 ### Added
 
@@ -13,7 +13,7 @@ Notable changes per release. [GitHub Releases](https://github.com/run-ai/karta/r
 
 [Full changelog](https://github.com/run-ai/karta/compare/v0.2.2...v0.2.3)
 
-## [v0.2.2] - 2026-07-23
+## v0.2.2 - 2026-07-23
 
 ### Fixed
 
@@ -21,7 +21,7 @@ Notable changes per release. [GitHub Releases](https://github.com/run-ai/karta/r
 
 [Full changelog](https://github.com/run-ai/karta/compare/v0.2.1...v0.2.2)
 
-## [v0.2.1] - 2026-07-20
+## v0.2.1 - 2026-07-20
 
 ### Fixed
 
@@ -29,7 +29,7 @@ Notable changes per release. [GitHub Releases](https://github.com/run-ai/karta/r
 
 [Full changelog](https://github.com/run-ai/karta/compare/v0.2.0...v0.2.1)
 
-## [v0.2.0] - 2026-07-15
+## v0.2.0 - 2026-07-15
 
 Extends Karta from a CRD and Go library into an optional runnable system. No breaking API changes.
 
@@ -38,7 +38,7 @@ Extends Karta from a CRD and Go library into an optional runnable system. No bre
 - Controller/operator: reconcile core, operator Helm chart, and container images. Karta can now run as a controller rather than only being a CRD plus library (#77, #97, #91).
 - `WorkloadTree`: the raw component hierarchy of a workload (desired structure, scale, specs, status) produced by the library, giving clients a single shared tree to traverse and render (#87).
 - New pod-grouping API: `gangScheduling.podGroup` with subgroups and topology constraints for scheduler integrations (#145).
-- Larger catalog of built-in workload definitions under `docs/catalog/`.
+- Larger catalog of built-in workload definitions under `docs/catalog/` (#155).
 
 ### Deprecated
 
@@ -46,7 +46,7 @@ Extends Karta from a CRD and Go library into an optional runnable system. No bre
 
 [Full changelog](https://github.com/run-ai/karta/compare/v0.1.1...v0.2.0)
 
-## [v0.1.1] - 2026-06-01
+## v0.1.1 - 2026-06-01
 
 ### Changed
 
@@ -54,7 +54,7 @@ Extends Karta from a CRD and Go library into an optional runnable system. No bre
 
 [Full changelog](https://github.com/run-ai/karta/compare/v0.1.0...v0.1.1)
 
-## [v0.1.0] - 2026-05-12
+## v0.1.0 - 2026-05-12
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,72 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright (c) 2026 NVIDIA Corporation -->
+
+# Changelog
+
+Notable changes per release. [GitHub Releases](https://github.com/run-ai/karta/releases) are the canonical record and carry the full notes and artifacts; this file is the in-repo summary. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) loosely. Versioning is pre-1.0: minor versions may include breaking changes, see each entry.
+
+## [v0.2.3] - 2026-08-17
+
+### Added
+
+- Digest-pinned air-gap image locks per release: per-platform `ImageLock` YAML assets (linux/amd64, linux/arm64) listing the exact image digests needed for air-gapped installs (#237).
+
+[Full changelog](https://github.com/run-ai/karta/compare/v0.2.2...v0.2.3)
+
+## [v0.2.2] - 2026-07-23
+
+### Fixed
+
+- CRD cache transform fix for the v0.2 controller (#177).
+
+[Full changelog](https://github.com/run-ai/karta/compare/v0.2.1...v0.2.2)
+
+## [v0.2.1] - 2026-07-20
+
+### Fixed
+
+- Helm chart: operator memory limit raised to 256Mi (#164).
+
+[Full changelog](https://github.com/run-ai/karta/compare/v0.2.0...v0.2.1)
+
+## [v0.2.0] - 2026-07-15
+
+Extends Karta from a CRD and Go library into an optional runnable system. No breaking API changes.
+
+### Added
+
+- Controller/operator: reconcile core, operator Helm chart, and container images. Karta can now run as a controller rather than only being a CRD plus library (#77, #97, #91).
+- `WorkloadTree`: the raw component hierarchy of a workload (desired structure, scale, specs, status) produced by the library, giving clients a single shared tree to traverse and render (#87).
+- New pod-grouping API: `gangScheduling.podGroup` with subgroups and topology constraints for scheduler integrations (#145).
+- Larger catalog of built-in workload definitions under `docs/catalog/`.
+
+### Deprecated
+
+- The previous `gangScheduling.podGroups` grouping format. Still honored; migrate to `gangScheduling.podGroup`.
+
+[Full changelog](https://github.com/run-ai/karta/compare/v0.1.1...v0.2.0)
+
+## [v0.1.1] - 2026-06-01
+
+### Changed
+
+- Go toolchain bumped to 1.26.3; dependencies updated (#82).
+
+[Full changelog](https://github.com/run-ai/karta/compare/v0.1.0...v0.1.1)
+
+## [v0.1.0] - 2026-05-12
+
+### Changed
+
+- Breaking: project renamed from `ri`/`krt` to karta. API group is `run.ai/v1alpha1`, the CRD kind is `Karta`, and the Helm chart is named `karta` (#42, #50).
+- The library no longer imports `sigs.k8s.io/controller-runtime`. Consumers that only need the CRD types or resource helpers no longer inherit it transitively (#62).
+
+### Added
+
+- Suspend/resume support: new `SuspendDefinition` field on the CRD and new resource statuses `Suspended`, `Suspending`, `Resuming` (#56).
+
+[Full changelog](https://github.com/run-ai/karta/compare/v0.0.12...v0.1.0)
+
+## v0.0.1 through v0.0.12 - 2025-09-03 to 2026-04-14
+
+Pre-rename development releases under the earlier project name. See the [release list](https://github.com/run-ai/karta/releases) for individual notes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,31 +5,9 @@
 
 Notable changes per release. This file is the in-repo source of record: a release's entry is added here before the tag is pushed (see [RELEASE.md](RELEASE.md)), and the [GitHub Release](https://github.com/run-ai/karta/releases) body is written from it, so tagged source archives carry their own entry. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) loosely. Versioning is pre-1.0: minor versions may include breaking changes, see each entry.
 
-Entries through v0.2.3 were backfilled from the published GitHub release notes when this file was introduced.
+Scope: this file covers minor and major releases. Patch releases are cut from their release branch (`v0.1`, `v0.2`) and their entries live on that branch, so this file stays a readable history of the line rather than a log of every tag.
 
-## v0.2.3 - 2026-08-17
-
-### Added
-
-- Digest-pinned air-gap image locks per release: per-platform `ImageLock` YAML assets (linux/amd64, linux/arm64) listing the exact image digests needed for air-gapped installs (#237).
-
-[Full changelog](https://github.com/run-ai/karta/compare/v0.2.2...v0.2.3)
-
-## v0.2.2 - 2026-07-23
-
-### Fixed
-
-- CRD cache transform fix for the v0.2 controller (#177).
-
-[Full changelog](https://github.com/run-ai/karta/compare/v0.2.1...v0.2.2)
-
-## v0.2.1 - 2026-07-20
-
-### Fixed
-
-- Helm chart: operator memory limit raised to 256Mi (#164).
-
-[Full changelog](https://github.com/run-ai/karta/compare/v0.2.0...v0.2.1)
+Entries here were backfilled from the published GitHub release notes when this file was introduced.
 
 ## v0.2.0 - 2026-07-15
 
@@ -37,24 +15,49 @@ Extends Karta from a CRD and Go library into an optional runnable system. No bre
 
 ### Added
 
-- Controller/operator: reconcile core, operator Helm chart, and container images. Karta can now run as a controller rather than only being a CRD plus library (#77, #97, #91).
+- Controller/operator: reconcile core, operator Helm chart, operator container images, and build/run Makefile targets. Karta can now run as a controller rather than only being a CRD plus library (#77, #97, #91, #96).
 - `WorkloadTree`: the raw component hierarchy of a workload (desired structure, scale, specs, status) produced by the library, giving clients a single shared tree to traverse and render (#87).
 - New pod-grouping API: `gangScheduling.podGroup` with subgroups and topology constraints for scheduler integrations (#145).
-- Larger catalog of built-in workload definitions under `docs/catalog/` (#155).
-
-### Deprecated
-
-- The previous `gangScheduling.podGroups` grouping format. Still honored; migrate to `gangScheduling.podGroup`.
-
-[Full changelog](https://github.com/run-ai/karta/compare/v0.1.1...v0.2.0)
-
-## v0.1.1 - 2026-06-01
+- `karta` CLI: entrypoint and Cobra root command (#127).
+- Kind-based e2e provisioner: `hack/e2e` spins up a kind cluster for end-to-end tests (#144).
+- Larger catalog of built-in workload definitions under `docs/catalog/`, spanning core, batch, training, serving, and Ray workloads (#155).
+- Additional samples: Grove `PodCliqueSet` (#66), Milvus (#103), a worked controller example over LeaderWorkerSet (#92), and a minimal quickstart controller (#84).
 
 ### Changed
 
-- Go toolchain bumped to 1.26.3; dependencies updated (#82).
+- Go toolchain `1.25.9` to `1.26.3`; `k8s.io/api` `v0.35.1` to `v0.36.2` (#75, #93).
 
-[Full changelog](https://github.com/run-ai/karta/compare/v0.1.0...v0.1.1)
+### Deprecated
+
+- The previous `gangScheduling.podGroups` grouping format. Still honored; migrate to `gangScheduling.podGroup`:
+
+  ```diff
+    optimizationInstructions:
+      gangScheduling:
+  -     podGroups:
+  -       - name: job
+  -         members:
+  -           - componentName: launcher
+  -             groupByKeyPaths:
+  -               - .metadata.labels["training.kubeflow.org/job-name"]
+  -           - componentName: worker
+  -             groupByKeyPaths:
+  -               - .metadata.labels["training.kubeflow.org/job-name"]
+  +     podGroup:
+  +       name: job
+  +       subGroups:
+  +         - componentName: launcher
+  +         - componentName: worker
+  ```
+
+### Fixed
+
+- Native resource discovery (#132).
+- Append aliasing of caller-owned component slices (#129).
+- RayJob worker `instanceIdPath` nesting in the sample (#133).
+- Dependabot missing code generation failing CI (#150).
+
+[Full changelog](https://github.com/run-ai/karta/compare/v0.1.0...v0.2.0)
 
 ## v0.1.0 - 2026-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,75 +3,321 @@
 
 # Changelog
 
-Notable changes per release. This file is the in-repo source of record: a release's entry is added here before the tag is pushed (see [RELEASE.md](RELEASE.md)), and the [GitHub Release](https://github.com/run-ai/karta/releases) body is written from it, so tagged source archives carry their own entry. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) loosely. Versioning is pre-1.0: minor versions may include breaking changes, see each entry.
+Notable changes per release. This file is the in-repo source of record: a release's entry is added here before the tag is pushed (see [RELEASE.md](RELEASE.md)), and the [GitHub Release](https://github.com/run-ai/karta/releases) body is the same text, so tagged source archives carry their own entry.
 
-Scope: this file covers minor and major releases. Patch releases are cut from their release branch (`v0.1`, `v0.2`) and their entries live on that branch, so this file stays a readable history of the line rather than a log of every tag.
+Scope: this file covers minor and major releases, which are tagged from `main`. Patch releases are tagged from their release branch (`v0.1`, `v0.2`) and their entries live in that branch's changelog.
 
 Entries here were backfilled from the published GitHub release notes when this file was introduced.
 
 ## v0.2.0 - 2026-07-15
 
-Extends Karta from a CRD and Go library into an optional runnable system. No breaking API changes.
+This release extends Karta from a CRD and Go library into an optional runnable system. It lands the controller / operator (reconcile core, workload-tree model, Helm chart, container images), and a new pod-grouping API for better schedulers integration, alongside a much larger catalog of built-in workload samples. There are no breaking API changes; the previous grouping format is deprecated but still works. See [Deprecations](#%EF%B8%8F-deprecations) for the recommended migration.
 
-### Added
+---
 
-- Controller/operator: reconcile core, operator Helm chart, operator container images, and build/run Makefile targets. Karta can now run as a controller rather than only being a CRD plus library (#77, #97, #91, #96).
-- `WorkloadTree`: the raw component hierarchy of a workload (desired structure, scale, specs, status) produced by the library, giving clients a single shared tree to traverse and render (#87).
-- New pod-grouping API: `gangScheduling.podGroup` with subgroups and topology constraints for scheduler integrations (#145).
-- `karta` CLI: entrypoint and Cobra root command (#127).
-- Kind-based e2e provisioner: `hack/e2e` spins up a kind cluster for end-to-end tests (#144).
-- Larger catalog of built-in workload definitions under `docs/catalog/`, spanning core, batch, training, serving, and Ray workloads (#155).
-- Additional samples: Grove `PodCliqueSet` (#66), Milvus (#103), a worked controller example over LeaderWorkerSet (#92), and a minimal quickstart controller (#84).
+### 🌟 Highlights
 
-### Changed
+| | |
+|---|---|
+| 🚀 **Controller / operator** | The reconcile core, an operator Helm chart, and container images all land, so Karta can now run as a controller rather than only being a CRD plus library. ([#77](https://github.com/run-ai/karta/pull/77), [#97](https://github.com/run-ai/karta/pull/97), [#91](https://github.com/run-ai/karta/pull/91)) |
+| 🌲 **WorkloadTree** | A `WorkloadTree` is the raw component hierarchy of a workload (its desired structure, scale, specs, and status) produced by the Karta library, giving clients a single shared tree to traverse and render. ([#87](https://github.com/run-ai/karta/pull/87))|
+| 🪶 **New pod-grouping API** | `gangScheduling.podGroup` adds subgroups and topology constraints for better schedulers integration; the old `gangScheduling.podGroups` is deprecated but still honored. ([#145](https://github.com/run-ai/karta/pull/145)) |
 
-- Go toolchain `1.25.9` to `1.26.3`; `k8s.io/api` `v0.35.1` to `v0.36.2` (#75, #93).
+---
 
-### Deprecated
+### 📦 Install
 
-- The previous `gangScheduling.podGroups` grouping format. Still honored; migrate to `gangScheduling.podGroup`:
+**Helm chart** ( from GHCR ) :
 
-  ```diff
-    optimizationInstructions:
-      gangScheduling:
-  -     podGroups:
-  -       - name: job
-  -         members:
-  -           - componentName: launcher
-  -             groupByKeyPaths:
-  -               - .metadata.labels["training.kubeflow.org/job-name"]
-  -           - componentName: worker
-  -             groupByKeyPaths:
-  -               - .metadata.labels["training.kubeflow.org/job-name"]
-  +     podGroup:
-  +       name: job
-  +       subGroups:
-  +         - componentName: launcher
-  +         - componentName: worker
-  ```
+```bash
+helm install karta oci://ghcr.io/run-ai/karta/karta --version 0.2.0
+```
 
-### Fixed
+**Go consumers** :
 
-- Native resource discovery (#132).
-- Append aliasing of caller-owned component slices (#129).
-- RayJob worker `instanceIdPath` nesting in the sample (#133).
-- Dependabot missing code generation failing CI (#150).
+```bash
+go get github.com/run-ai/karta@v0.2.0
+```
 
-[Full changelog](https://github.com/run-ai/karta/compare/v0.1.0...v0.2.0)
+```go
+import karta "github.com/run-ai/karta/pkg/api/runai/v1alpha1"
+```
 
+---
+
+### 📚 Compatibility
+
+| | |
+|---|---|
+| **Kubernetes** | tested against v1.31 – v1.35 ( `k8s.io/api v0.36.2` ) |
+| **Go** | 1.26.3 or later |
+| **Helm** | 3.14 or later |
+
+---
+
+### ⚠️ Deprecations
+
+#### `gangScheduling.podGroups` → `gangScheduling.podGroup`
+
+The alpha grouping format `podGroups` (a list) is deprecated in favor of the new `podGroup` mapping, which adds subgroups and topology constraints. Existing Kartas using `podGroups` continue to validate and run; migrate when convenient.
+
+```diff
+  optimizationInstructions:
+    gangScheduling:
+-     podGroups:
+-       - name: job
+-         members:
+-           - componentName: launcher
+-             groupByKeyPaths:
+-               - .metadata.labels["training.kubeflow.org/job-name"]
+-           - componentName: worker
+-             groupByKeyPaths:
+-               - .metadata.labels["training.kubeflow.org/job-name"]
++     podGroup:
++       name: job
++       subGroups:
++         - componentName: launcher
++         - componentName: worker
+```
+
+---
+
+### ✨ New features
+
+- **Controller reconcile core** — the operator's central reconcile logic. ([#77](https://github.com/run-ai/karta/pull/77) by @shaked-bouktus)
+- **`WorkloadTree` data model and builder** — a typed tree that assembles a workload's root and child components. ([#87](https://github.com/run-ai/karta/pull/87) by @rogirun)
+- **Operator Helm chart** — deploy the karta operator via Helm. ([#97](https://github.com/run-ai/karta/pull/97) by @shaked-bouktus)
+- **Operator container images** — Dockerfiles for the karta operator. ([#91](https://github.com/run-ai/karta/pull/91) by @shaked-bouktus)
+- **Operator Makefile** — build / run targets for the operator. ([#96](https://github.com/run-ai/karta/pull/96) by @shaked-bouktus)
+- **`karta` CLI** — CLI entrypoint and Cobra root command. ([#127](https://github.com/run-ai/karta/pull/127) by @rogirun)
+- **New pod-grouping API** — `gangScheduling.podGroup` with subgroups and topology. ([#145](https://github.com/run-ai/karta/pull/145) by @davidLif)
+- **Kind-based e2e provisioner** — `hack/e2e` spins up a kind cluster for end-to-end tests. ([#144](https://github.com/run-ai/karta/pull/144) by @AviadHayumi)
+- **Expanded workload sample catalog** — many additional built-in Karta samples across core, batch, training, serving, and Ray workloads. ([#155](https://github.com/run-ai/karta/pull/155) by @AviadHayumi)
+- **Grove `PodCliqueSet` sample** — `grove.io/v1alpha1` Karta example. ([#66](https://github.com/run-ai/karta/pull/66) by @shmuel-runai)
+- **Milvus sample** — `milvus.io/v1beta1` Karta example. ([#103](https://github.com/run-ai/karta/pull/103) by @ronlv10)
+- **Controller example with LWS** — a worked controller example over LeaderWorkerSet. ([#92](https://github.com/run-ai/karta/pull/92) by @yuval-gr)
+- **Quickstart controller example** — minimal controller to get started. ([#84](https://github.com/run-ai/karta/pull/84) by @yuval-gr)
+
+### 🐛 Bug fixes
+
+- Fix native resource discovery. ([#132](https://github.com/run-ai/karta/pull/132) by @shaked-bouktus)
+- Avoid append aliasing of caller-owned component slices. ([#129](https://github.com/run-ai/karta/pull/129) by @ronlv10)
+- Fix rayjob worker `instanceIdPath` nesting in the sample. ([#133](https://github.com/run-ai/karta/pull/133) by @lavianalon)
+- Fix dependabot missing code generation failing CI. ([#150](https://github.com/run-ai/karta/pull/150) by @Isan-Rivkin)
+
+### 🧹 Maintenance
+
+- Bump Go to 1.26.3 and update dependencies. ([#75](https://github.com/run-ai/karta/pull/75) by @yuval-gr)
+- Update `golang.org/x` dependencies to latest. ([#93](https://github.com/run-ai/karta/pull/93) by @yuval-gr)
+- Bump the go-minor-patch dependency group. ([#136](https://github.com/run-ai/karta/pull/136), [#147](https://github.com/run-ai/karta/pull/147) by @dependabot)
+- Add `dependabot.yml` for version updates. ([#120](https://github.com/run-ai/karta/pull/120) by @yuval-gr)
+- Create verified dependabot codegen commits via the GitHub API. ([#153](https://github.com/run-ai/karta/pull/153) by @Isan-Rivkin)
+- CI action bumps: checkout 4→7 ([#123](https://github.com/run-ai/karta/pull/123)), cache 4→6 ([#122](https://github.com/run-ai/karta/pull/122)), setup-go 5→6 ([#121](https://github.com/run-ai/karta/pull/121)), setup-buildx 3→4 ([#146](https://github.com/run-ai/karta/pull/146)). (by @dependabot)
+
+### 📖 Documentation
+
+- Add an authoring tutorial and troubleshooting guide. ([#130](https://github.com/run-ai/karta/pull/130) by @lavianalon)
+- Add ROADMAP and GOVERNANCE. ([#89](https://github.com/run-ai/karta/pull/89) by @lavianalon)
+- Add a maintainer ladder / emeritus policy and RELEASE.md. ([#128](https://github.com/run-ai/karta/pull/128) by @lavianalon)
+- Harden OSS health docs (security policy, code of conduct, contributing). ([#111](https://github.com/run-ai/karta/pull/111) by @lavianalon)
+- Add README badges, community section, and CoC link. ([#125](https://github.com/run-ai/karta/pull/125) by @lavianalon)
+- Add AGENTS.md guide for AI coding agents. ([#73](https://github.com/run-ai/karta/pull/73) by @lavianalon)
+- Add a CLI high-level design document. ([#31](https://github.com/run-ai/karta/pull/31) by @ronlv10)
+- Add KAI Scheduler to the "who uses Karta" section. ([#156](https://github.com/run-ai/karta/pull/156) by @lavianalon)
+- Drop the API group rename from the roadmap and governance. ([#119](https://github.com/run-ai/karta/pull/119) by @lavianalon)
+
+---
+
+### 📊 Dependencies
+
+#### Changed
+
+- Go `1.25.9` → **`1.26.3`**
+- `k8s.io/api` `v0.35.1` → **`v0.36.2`**
+
+---
+
+### 🤝 Contributors
+
+thanks to everyone who shipped this release :
+
+[@AviadHayumi](https://github.com/AviadHayumi) , [@Isan-Rivkin](https://github.com/Isan-Rivkin) , [@davidLif](https://github.com/davidLif) , [@lavianalon](https://github.com/lavianalon) , [@rogirun](https://github.com/rogirun) , [@ronlv10](https://github.com/ronlv10) , [@shaked-bouktus](https://github.com/shaked-bouktus) , [@shmuel-runai](https://github.com/shmuel-runai) , [@yuval-gr](https://github.com/yuval-gr)
+
+plus automated dependency updates from [@dependabot](https://github.com/dependabot).
+
+---
+
+**Full changelog** : https://github.com/run-ai/karta/compare/v0.1.0...v0.2.0
+**Helm chart** : `oci://ghcr.io/run-ai/karta:0.2.0`
+**Container images** : see [packages page](https://github.com/run-ai/karta/pkgs/container/karta)
 ## v0.1.0 - 2026-05-12
 
-### Changed
+This release completes the project rename from `ri` / `krt` to **karta** , decouples the library from `sigs.k8s.io/controller-runtime` , and introduces native suspend / resume support on the CRD. See [Breaking changes](#%EF%B8%8F-breaking-changes) for migration steps.
 
-- Breaking: project renamed from `ri`/`krt` to karta. API group is `run.ai/v1alpha1`, the CRD kind is `Karta`, and the Helm chart is named `karta` (#42, #50).
-- The library no longer imports `sigs.k8s.io/controller-runtime`. Consumers that only need the CRD types or resource helpers no longer inherit it transitively (#62).
+---
 
-### Added
+### 🌟 Highlights
 
-- Suspend/resume support: new `SuspendDefinition` field on the CRD and new resource statuses `Suspended`, `Suspending`, `Resuming` (#56).
+| | |
+|---|---|
+| 🆕 **Project rename to `karta`** | API group is now `run.ai/v1alpha1` , the CRD `Kind` is `Karta` , and the Helm chart is named `karta`. ([#42](https://github.com/run-ai/karta/pull/42) , [#50](https://github.com/run-ai/karta/pull/50)) |
+| 🪶 **Zero controller-runtime dependency** | karta no longer imports `sigs.k8s.io/controller-runtime`. Consumers that only need the CRD types or the resource helpers no longer inherit it transitively. ([#62](https://github.com/run-ai/karta/pull/62)) |
+| ⏸️ **Suspend / Resume support** | New `SuspendDefinition` field on the CRD , and new resource statuses `Suspended` , `Suspending` , `Resuming`. ([#56](https://github.com/run-ai/karta/pull/56)) |
 
-[Full changelog](https://github.com/run-ai/karta/compare/v0.0.12...v0.1.0)
+---
 
+### 📦 Install
+
+**Helm chart** ( from GHCR ) :
+
+```bash
+helm install karta oci://ghcr.io/run-ai/karta/karta --version 0.1.0
+```
+
+**Go consumers** :
+
+```bash
+go get github.com/run-ai/karta@v0.1.0
+```
+
+```go
+import karta "github.com/run-ai/karta/pkg/api/runai/v1alpha1"
+```
+
+---
+
+### 📚 Compatibility
+
+| | |
+|---|---|
+| **Kubernetes** | tested against v1.30 – v1.34 ( `k8s.io/api v0.35.1` ) |
+| **Go** | 1.25.9 or later |
+| **Helm** | 3.14 or later |
+
+---
+
+### ⚠️ Breaking changes
+
+#### 1. Project rename : `ri` / `krt` → `karta`
+
+| was | now |
+|---|---|
+| CRD `Kind` `ResourceInterface` | `Karta` |
+| API group `optimization.nvidia.com/v1alpha1` | `run.ai/v1alpha1` |
+| Go package `github.com/run-ai/karta/pkg/api/optimization/v1alpha1` | `github.com/run-ai/karta/pkg/api/runai/v1alpha1` |
+| Field on `ComponentFactory` : `ri *ResourceInterface` | `karta *Karta` |
+| Helm chart `krt` | `karta` |
+
+**Cluster migration** — existing CRDs need to be re-applied under the new GVK :
+
+```bash
+kubectl get resourceinterfaces.optimization.nvidia.com -o yaml | \
+    sed 's|optimization.nvidia.com/v1alpha1|run.ai/v1alpha1|; s|kind: ResourceInterface|kind: Karta|' | \
+    kubectl apply -f -
+
+kubectl delete crd resourceinterfaces.optimization.nvidia.com
+```
+
+**Go consumer migration** :
+
+```diff
+- import ri "github.com/run-ai/karta/pkg/api/optimization/v1alpha1"
++ import karta "github.com/run-ai/karta/pkg/api/runai/v1alpha1"
+
+- var obj ri.ResourceInterface
++ var obj karta.Karta
+
+- factory := resource.NewComponentFactoryFromObject(myRi, kubeObj)
++ factory := resource.NewComponentFactoryFromObject(myKarta, kubeObj)
+```
+
+#### 2. `sigs.k8s.io/controller-runtime` no longer a karta dependency
+
+karta now uses `k8s.io/apimachinery` directly for the two things it previously needed from controller-runtime :
+
+| was | now |
+|---|---|
+| `&scheme.Builder{GroupVersion: ...}` from `controller-runtime/pkg/scheme` | `runtime.NewSchemeBuilder(addKnownTypes)` from `k8s.io/apimachinery/pkg/runtime` |
+| `client.Object` from `controller-runtime/pkg/client` ( in `NewComponentFactoryFromObject` and `GetResource` ) | local `KubernetesObject` interface ( `metav1.Object` + `runtime.Object` ) |
+
+**Consumer impact : no source code changes required.** Go matches interfaces structurally ( by method set ) , so :
+
+```go
+import "sigs.k8s.io/controller-runtime/pkg/client"
+
+var pod client.Object = &corev1.Pod{...}
+factory := resource.NewComponentFactoryFromObject(myKarta, pod)  // still compiles
+obj, _ := factory.GetResource()
+var asClientObject client.Object = obj                            // still compiles
+```
+
+**Cleanup opportunity** : consumers that only had `sigs.k8s.io/controller-runtime` in their `go.mod` because karta dragged it in can now drop it :
+
+```bash
+go get sigs.k8s.io/controller-runtime@none  # if you don't otherwise use it
+go mod tidy
+```
+
+This is the dominant pattern across major K8s OSS — see the same idiom in [kubevirt/api](https://github.com/kubevirt/api/blob/0a124c6271bf8ad3b2263b3b16b4544bae794ecd/core/v1/register.go#L85) , [prometheus-operator](https://github.com/prometheus-operator/prometheus-operator/blob/0bd09d4dae2c319b9b43eb1921afe869f123d3a8/pkg/apis/monitoring/v1/register.go#L35) , [tektoncd/pipeline](https://github.com/tektoncd/pipeline/blob/a3305b1d9b31f743fc625485e5c88837a731bbd3/pkg/apis/pipeline/v1/register.go#L40) , [cert-manager](https://github.com/cert-manager/cert-manager/blob/7c3e89bf397945fa0143e3836144fa150bcc55c7/pkg/apis/certmanager/v1/register.go#L36) , [cluster-api](https://github.com/kubernetes-sigs/cluster-api/blob/93bb18264d28410997c248052da4d7c4dbad7b91/api/core/v1beta2/groupversion_info.go#L30) , [knative/pkg `kmeta.Accessor`](https://github.com/knative/pkg/blob/df317a52d1121053934fddcfff0e1081cfae42c2/kmeta/accessor.go#L32) , and [crossplane-runtime `resource.Object`](https://github.com/crossplane/crossplane-runtime/blob/a596e1f7563505485b8ab0a06c1c3dc2d21ecf90/pkg/resource/interfaces.go#L193).
+
+---
+
+### ✨ New features
+
+- **Suspend / Resume definitions and statuses** — new `SuspendDefinition` on the CRD , plus new resource statuses `Suspended` , `Suspending` , `Resuming`. ([#56](https://github.com/run-ai/karta/pull/56) by @TomB30)
+- **`ValidateParsedJQ` is now exported** — external consumers that already hold a compiled `*gojq.Query` can run the read-only / safe-expression check without re-parsing. ([#53](https://github.com/run-ai/karta/pull/53) by @AviadHayumi)
+- **Helm chart published to GHCR on every release** — pull with `helm install karta oci://ghcr.io/run-ai/karta --version 0.1.0`. ([#27](https://github.com/run-ai/karta/pull/27) by @AviadHayumi)
+- **Chart version bump enforcement in CI** — `ct lint` blocks PRs that change the chart without bumping `Chart.yaml` version. Matches the prometheus-operator / argo enforcement model. ([#48](https://github.com/run-ai/karta/pull/48) by @AviadHayumi)
+- **`docs/examples/*.yaml` validated in CI** — example Kartas are exercised by CI so docs cant silently drift from the schema. ([#61](https://github.com/run-ai/karta/pull/61) by @Isan-Rivkin)
+- **Issue templates + code of conduct** — bug / feature templates plus a contributor CoC. ([#38](https://github.com/run-ai/karta/pull/38) by @yuval-gr)
+- **Helm chart annotated with OCI source** — `helm.sh/chart-source` annotation links chart back to the GHCR package page. ([#49](https://github.com/run-ai/karta/pull/49) by @AviadHayumi)
+
+### 🐛 Bug fixes
+
+- Repaired `docs/examples/mpijob.yaml` and simplified the pytorch running mapping. ([#58](https://github.com/run-ai/karta/pull/58) by @lavianalon)
+- Removed accidentally pushed `docs/ri-studio/` directory. ([#40](https://github.com/run-ai/karta/pull/40) by @ronlv10)
+- Fixed formatting and validation in issue templates. ([#41](https://github.com/run-ai/karta/pull/41) by @yuval-gr)
+
+### 🧹 Maintenance
+
+- Renamed `ri` → `krt` across the codebase ( first half of the rename to karta ). ([#42](https://github.com/run-ai/karta/pull/42) by @AviadHayumi)
+- Renamed Helm chart `krt` → `karta` ( finishing the rename ). ([#50](https://github.com/run-ai/karta/pull/50) by @AviadHayumi)
+- Bumped `golang.org/x/net` to v0.51.0 ( security ). ([#45](https://github.com/run-ai/karta/pull/45) by @yuval-gr)
+- Updated Go toolchain to 1.25.9. ([#30](https://github.com/run-ai/karta/pull/30) by @yuval-gr)
+
+---
+
+### 📊 Dependencies
+
+#### Added
+
+_nothing_
+
+#### Changed
+
+- `golang.org/x/net` v0.39.0 → **v0.51.0**
+- Go toolchain 1.25.7 → **1.25.9**
+- `k8s.io/api` v0.34.x → **v0.35.1**
+- `k8s.io/apimachinery` v0.34.x → **v0.35.1**
+
+#### Removed
+
+- `sigs.k8s.io/controller-runtime` ( previously v0.23.1 ) — **dropped entirely**
+- `sigs.k8s.io/controller-runtime/pkg/client` ( transitive ) — no longer pulled in
+- `sigs.k8s.io/controller-runtime/pkg/scheme` ( transitive ) — no longer pulled in
+
+---
+
+### 🤝 Contributors
+
+thanks to everyone who shipped this release :
+
+[@AviadHayumi](https://github.com/AviadHayumi) , [@Isan-Rivkin](https://github.com/Isan-Rivkin) , [@TomB30](https://github.com/TomB30) , [@lavianalon](https://github.com/lavianalon) , [@ronlv10](https://github.com/ronlv10) , [@yuval-gr](https://github.com/yuval-gr)
+
+---
+
+**Full changelog** : https://github.com/run-ai/karta/compare/v0.0.12...v0.1.0
+**Helm chart** : `oci://ghcr.io/run-ai/karta:0.1.0`
 ## v0.0.1 through v0.0.12 - 2025-09-03 to 2026-04-14
 
 Pre-rename development releases under the earlier project name. See the [release list](https://github.com/run-ai/karta/releases) for individual notes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,9 @@
 
 # Changelog
 
-Notable changes per release. This file is the in-repo source of record: a release's entry is added here before the tag is pushed (see [RELEASE.md](RELEASE.md)), and the [GitHub Release](https://github.com/run-ai/karta/releases) body is the same text, so tagged source archives carry their own entry.
+Notable changes per release. This file is the in-repo source of record: a release's entry is added here before the tag is pushed (see [RELEASE.md](RELEASE.md)), and the [GitHub Release](https://github.com/run-ai/karta/releases) body carries the same content, normalized to the repository Markdown rules in [AGENTS.md](AGENTS.md).
 
 Scope: this file covers minor and major releases, which are tagged from `main`. Patch releases are tagged from their release branch (`v0.1`, `v0.2`) and their entries live in that branch's changelog.
-
-Entries here were backfilled from the published GitHub release notes when this file was introduced.
-
 
 ## v0.2.0 - 2026-07-15
 
@@ -16,25 +13,25 @@ This release extends Karta from a CRD and Go library into an optional runnable s
 
 ---
 
-### 🌟 Highlights
+### Highlights
 
 | | |
 |---|---|
-| 🚀 **Controller / operator** | The reconcile core, an operator Helm chart, and container images all land, so Karta can now run as a controller rather than only being a CRD plus library. ([#77](https://github.com/run-ai/karta/pull/77), [#97](https://github.com/run-ai/karta/pull/97), [#91](https://github.com/run-ai/karta/pull/91)) |
-| 🌲 **WorkloadTree** | A `WorkloadTree` is the raw component hierarchy of a workload (its desired structure, scale, specs, and status) produced by the Karta library, giving clients a single shared tree to traverse and render. ([#87](https://github.com/run-ai/karta/pull/87))|
-| 🪶 **New pod-grouping API** | `gangScheduling.podGroup` adds subgroups and topology constraints for better schedulers integration; the old `gangScheduling.podGroups` is deprecated but still honored. ([#145](https://github.com/run-ai/karta/pull/145)) |
+| Controller / operator | The reconcile core, an operator Helm chart, and container images all land, so Karta can now run as a controller rather than only being a CRD plus library. ([#77](https://github.com/run-ai/karta/pull/77), [#97](https://github.com/run-ai/karta/pull/97), [#91](https://github.com/run-ai/karta/pull/91)) |
+| WorkloadTree | A `WorkloadTree` is the raw component hierarchy of a workload (its desired structure, scale, specs, and status) produced by the Karta library, giving clients a single shared tree to traverse and render. ([#87](https://github.com/run-ai/karta/pull/87))|
+| New pod-grouping API | `gangScheduling.podGroup` adds subgroups and topology constraints for better schedulers integration; the old `gangScheduling.podGroups` is deprecated but still honored. ([#145](https://github.com/run-ai/karta/pull/145)) |
 
 ---
 
-### 📦 Install
+### Install
 
-**Helm chart** ( from GHCR ) :
+Helm chart (from GHCR):
 
 ```bash
 helm install karta oci://ghcr.io/run-ai/karta/karta --version 0.2.0
 ```
 
-**Go consumers** :
+Go consumers:
 
 ```bash
 go get github.com/run-ai/karta@v0.2.0
@@ -46,21 +43,29 @@ import karta "github.com/run-ai/karta/pkg/api/runai/v1alpha1"
 
 ---
 
-### 📚 Compatibility
+### Compatibility
 
 | | |
 |---|---|
-| **Kubernetes** | tested against v1.31 – v1.35 ( `k8s.io/api v0.36.2` ) |
-| **Go** | 1.26.3 or later |
-| **Helm** | 3.14 or later |
+| Kubernetes | tested against v1.31 - v1.35 (`k8s.io/api v0.36.2`) |
+| Go | 1.26.3 or later |
+| Helm | 3.14 or later |
 
 ---
 
-### ⚠️ Deprecations
+### Deprecations
 
-#### `gangScheduling.podGroups` → `gangScheduling.podGroup`
+#### `gangScheduling.podGroups` -> `gangScheduling.podGroup`
 
-The alpha grouping format `podGroups` (a list) is deprecated in favor of the new `podGroup` mapping, which adds subgroups and topology constraints. Existing Kartas using `podGroups` continue to validate and run; migrate when convenient.
+The alpha grouping format `podGroups` (a list) is deprecated in favor of the new `podGroup` mapping, which adds subgroups and topology constraints. Existing Kartas using `podGroups` continue to validate and run.
+
+Correction added after release: this is not a drop-in migration at v0.2.0, and the original release notes did not say so.
+
+- Karta's own instruction helpers read only `podGroups`. `pkg/instructions/summary.go` builds gang-scheduling candidates from `GangScheduling.PodGroups` and never reads `GangScheduling.PodGroup`. That is true at v0.2.0 and still true today. A consumer that relies on those helpers for grouping loses its grouping if it switches formats.
+- `podGroup` is honored by the scheduler integration instead. The KAI Karta podgrouper plugin prefers `podGroup` and falls back to `podGroups`. It shipped in KAI v0.17.0 on 2026-08-03, after this release, so at v0.2.0 nothing consumed the new field yet.
+- The two formats are not equivalent. A `podGroups` member carries `groupByKeyPaths`; a `subGroups` entry carries only `componentName` and `topology`, so per-component grouping keys have no direct counterpart.
+
+Target shape of the new format:
 
 ```diff
   optimizationInstructions:
@@ -83,39 +88,39 @@ The alpha grouping format `podGroups` (a list) is deprecated in favor of the new
 
 ---
 
-### ✨ New features
+### New features
 
-- **Controller reconcile core** — the operator's central reconcile logic. ([#77](https://github.com/run-ai/karta/pull/77) by @shaked-bouktus)
-- **`WorkloadTree` data model and builder** — a typed tree that assembles a workload's root and child components. ([#87](https://github.com/run-ai/karta/pull/87) by @rogirun)
-- **Operator Helm chart** — deploy the karta operator via Helm. ([#97](https://github.com/run-ai/karta/pull/97) by @shaked-bouktus)
-- **Operator container images** — Dockerfiles for the karta operator. ([#91](https://github.com/run-ai/karta/pull/91) by @shaked-bouktus)
-- **Operator Makefile** — build / run targets for the operator. ([#96](https://github.com/run-ai/karta/pull/96) by @shaked-bouktus)
-- **`karta` CLI** — CLI entrypoint and Cobra root command. ([#127](https://github.com/run-ai/karta/pull/127) by @rogirun)
-- **New pod-grouping API** — `gangScheduling.podGroup` with subgroups and topology. ([#145](https://github.com/run-ai/karta/pull/145) by @davidLif)
-- **Kind-based e2e provisioner** — `hack/e2e` spins up a kind cluster for end-to-end tests. ([#144](https://github.com/run-ai/karta/pull/144) by @AviadHayumi)
-- **Expanded workload sample catalog** — many additional built-in Karta samples across core, batch, training, serving, and Ray workloads. ([#155](https://github.com/run-ai/karta/pull/155) by @AviadHayumi)
-- **Grove `PodCliqueSet` sample** — `grove.io/v1alpha1` Karta example. ([#66](https://github.com/run-ai/karta/pull/66) by @shmuel-runai)
-- **Milvus sample** — `milvus.io/v1beta1` Karta example. ([#103](https://github.com/run-ai/karta/pull/103) by @ronlv10)
-- **Controller example with LWS** — a worked controller example over LeaderWorkerSet. ([#92](https://github.com/run-ai/karta/pull/92) by @yuval-gr)
-- **Quickstart controller example** — minimal controller to get started. ([#84](https://github.com/run-ai/karta/pull/84) by @yuval-gr)
+- Controller reconcile core - the operator's central reconcile logic. ([#77](https://github.com/run-ai/karta/pull/77) by @shaked-bouktus)
+- `WorkloadTree` data model and builder - a typed tree that assembles a workload's root and child components. ([#87](https://github.com/run-ai/karta/pull/87) by @rogirun)
+- Operator Helm chart - deploy the karta operator via Helm. ([#97](https://github.com/run-ai/karta/pull/97) by @shaked-bouktus)
+- Operator container images - Dockerfiles for the karta operator. ([#91](https://github.com/run-ai/karta/pull/91) by @shaked-bouktus)
+- Operator Makefile - build / run targets for the operator. ([#96](https://github.com/run-ai/karta/pull/96) by @shaked-bouktus)
+- `karta` CLI - CLI entrypoint and Cobra root command. ([#127](https://github.com/run-ai/karta/pull/127) by @rogirun)
+- New pod-grouping API - `gangScheduling.podGroup` with subgroups and topology. ([#145](https://github.com/run-ai/karta/pull/145) by @davidLif)
+- Kind-based e2e provisioner - `hack/e2e` spins up a kind cluster for end-to-end tests. ([#144](https://github.com/run-ai/karta/pull/144) by @AviadHayumi)
+- Expanded workload sample catalog - many additional built-in Karta samples across core, batch, training, serving, and Ray workloads. ([#155](https://github.com/run-ai/karta/pull/155) by @AviadHayumi)
+- Grove `PodCliqueSet` sample - `grove.io/v1alpha1` Karta example. ([#66](https://github.com/run-ai/karta/pull/66) by @shmuel-runai)
+- Milvus sample - `milvus.io/v1beta1` Karta example. ([#103](https://github.com/run-ai/karta/pull/103) by @ronlv10)
+- Controller example with LWS - a worked controller example over LeaderWorkerSet. ([#92](https://github.com/run-ai/karta/pull/92) by @yuval-gr)
+- Quickstart controller example - minimal controller to get started. ([#84](https://github.com/run-ai/karta/pull/84) by @yuval-gr)
 
-### 🐛 Bug fixes
+### Bug fixes
 
 - Fix native resource discovery. ([#132](https://github.com/run-ai/karta/pull/132) by @shaked-bouktus)
 - Avoid append aliasing of caller-owned component slices. ([#129](https://github.com/run-ai/karta/pull/129) by @ronlv10)
 - Fix rayjob worker `instanceIdPath` nesting in the sample. ([#133](https://github.com/run-ai/karta/pull/133) by @lavianalon)
 - Fix dependabot missing code generation failing CI. ([#150](https://github.com/run-ai/karta/pull/150) by @Isan-Rivkin)
 
-### 🧹 Maintenance
+### Maintenance
 
 - Bump Go to 1.26.3 and update dependencies. ([#75](https://github.com/run-ai/karta/pull/75) by @yuval-gr)
 - Update `golang.org/x` dependencies to latest. ([#93](https://github.com/run-ai/karta/pull/93) by @yuval-gr)
 - Bump the go-minor-patch dependency group. ([#136](https://github.com/run-ai/karta/pull/136), [#147](https://github.com/run-ai/karta/pull/147) by @dependabot)
 - Add `dependabot.yml` for version updates. ([#120](https://github.com/run-ai/karta/pull/120) by @yuval-gr)
 - Create verified dependabot codegen commits via the GitHub API. ([#153](https://github.com/run-ai/karta/pull/153) by @Isan-Rivkin)
-- CI action bumps: checkout 4→7 ([#123](https://github.com/run-ai/karta/pull/123)), cache 4→6 ([#122](https://github.com/run-ai/karta/pull/122)), setup-go 5→6 ([#121](https://github.com/run-ai/karta/pull/121)), setup-buildx 3→4 ([#146](https://github.com/run-ai/karta/pull/146)). (by @dependabot)
+- CI action bumps: checkout 4->7 ([#123](https://github.com/run-ai/karta/pull/123)), cache 4->6 ([#122](https://github.com/run-ai/karta/pull/122)), setup-go 5->6 ([#121](https://github.com/run-ai/karta/pull/121)), setup-buildx 3->4 ([#146](https://github.com/run-ai/karta/pull/146)). (by @dependabot)
 
-### 📖 Documentation
+### Documentation
 
 - Add an authoring tutorial and troubleshooting guide. ([#130](https://github.com/run-ai/karta/pull/130) by @lavianalon)
 - Add ROADMAP and GOVERNANCE. ([#89](https://github.com/run-ai/karta/pull/89) by @lavianalon)
@@ -129,54 +134,54 @@ The alpha grouping format `podGroups` (a list) is deprecated in favor of the new
 
 ---
 
-### 📊 Dependencies
+### Dependencies
 
 #### Changed
 
-- Go `1.25.9` → **`1.26.3`**
-- `k8s.io/api` `v0.35.1` → **`v0.36.2`**
+- Go `1.25.9` -> `1.26.3`
+- `k8s.io/api` `v0.35.1` -> `v0.36.2`
 
 ---
 
-### 🤝 Contributors
+### Contributors
 
-thanks to everyone who shipped this release :
+thanks to everyone who shipped this release:
 
-[@AviadHayumi](https://github.com/AviadHayumi) , [@Isan-Rivkin](https://github.com/Isan-Rivkin) , [@davidLif](https://github.com/davidLif) , [@lavianalon](https://github.com/lavianalon) , [@rogirun](https://github.com/rogirun) , [@ronlv10](https://github.com/ronlv10) , [@shaked-bouktus](https://github.com/shaked-bouktus) , [@shmuel-runai](https://github.com/shmuel-runai) , [@yuval-gr](https://github.com/yuval-gr)
+[@AviadHayumi](https://github.com/AviadHayumi), [@Isan-Rivkin](https://github.com/Isan-Rivkin), [@davidLif](https://github.com/davidLif), [@lavianalon](https://github.com/lavianalon), [@rogirun](https://github.com/rogirun), [@ronlv10](https://github.com/ronlv10), [@shaked-bouktus](https://github.com/shaked-bouktus), [@shmuel-runai](https://github.com/shmuel-runai), [@yuval-gr](https://github.com/yuval-gr)
 
 plus automated dependency updates from [@dependabot](https://github.com/dependabot).
 
 ---
 
-**Full changelog** : https://github.com/run-ai/karta/compare/v0.1.0...v0.2.0
-**Helm chart** : `oci://ghcr.io/run-ai/karta:0.2.0`
-**Container images** : see [packages page](https://github.com/run-ai/karta/pkgs/container/karta)
+Full changelog: https://github.com/run-ai/karta/compare/v0.1.0...v0.2.0
+Helm chart: `oci://ghcr.io/run-ai/karta:0.2.0`
+Container images: see [packages page](https://github.com/run-ai/karta/pkgs/container/karta)
 
 ## v0.1.0 - 2026-05-12
 
-This release completes the project rename from `ri` / `krt` to **karta** , decouples the library from `sigs.k8s.io/controller-runtime` , and introduces native suspend / resume support on the CRD. See [Breaking changes](#%EF%B8%8F-breaking-changes) for migration steps.
+This release completes the project rename from `ri` / `krt` to karta, decouples the library from `sigs.k8s.io/controller-runtime`, and introduces native suspend / resume support on the CRD. See [Breaking changes](#%EF%B8%8F-breaking-changes) for migration steps.
 
 ---
 
-### 🌟 Highlights
+### Highlights
 
 | | |
 |---|---|
-| 🆕 **Project rename to `karta`** | API group is now `run.ai/v1alpha1` , the CRD `Kind` is `Karta` , and the Helm chart is named `karta`. ([#42](https://github.com/run-ai/karta/pull/42) , [#50](https://github.com/run-ai/karta/pull/50)) |
-| 🪶 **Zero controller-runtime dependency** | karta no longer imports `sigs.k8s.io/controller-runtime`. Consumers that only need the CRD types or the resource helpers no longer inherit it transitively. ([#62](https://github.com/run-ai/karta/pull/62)) |
-| ⏸️ **Suspend / Resume support** | New `SuspendDefinition` field on the CRD , and new resource statuses `Suspended` , `Suspending` , `Resuming`. ([#56](https://github.com/run-ai/karta/pull/56)) |
+| Project rename to `karta` | API group is now `run.ai/v1alpha1`, the CRD `Kind` is `Karta`, and the Helm chart is named `karta`. ([#42](https://github.com/run-ai/karta/pull/42), [#50](https://github.com/run-ai/karta/pull/50)) |
+| Zero controller-runtime dependency | karta no longer imports `sigs.k8s.io/controller-runtime`. Consumers that only need the CRD types or the resource helpers no longer inherit it transitively. ([#62](https://github.com/run-ai/karta/pull/62)) |
+| Suspend / Resume support | New `SuspendDefinition` field on the CRD, and new resource statuses `Suspended`, `Suspending`, `Resuming`. ([#56](https://github.com/run-ai/karta/pull/56)) |
 
 ---
 
-### 📦 Install
+### Install
 
-**Helm chart** ( from GHCR ) :
+Helm chart (from GHCR):
 
 ```bash
 helm install karta oci://ghcr.io/run-ai/karta/karta --version 0.1.0
 ```
 
-**Go consumers** :
+Go consumers:
 
 ```bash
 go get github.com/run-ai/karta@v0.1.0
@@ -188,29 +193,29 @@ import karta "github.com/run-ai/karta/pkg/api/runai/v1alpha1"
 
 ---
 
-### 📚 Compatibility
+### Compatibility
 
 | | |
 |---|---|
-| **Kubernetes** | tested against v1.30 – v1.34 ( `k8s.io/api v0.35.1` ) |
-| **Go** | 1.25.9 or later |
-| **Helm** | 3.14 or later |
+| Kubernetes | tested against v1.30 - v1.34 (`k8s.io/api v0.35.1`) |
+| Go | 1.25.9 or later |
+| Helm | 3.14 or later |
 
 ---
 
-### ⚠️ Breaking changes
+### Breaking changes
 
-#### 1. Project rename : `ri` / `krt` → `karta`
+#### 1. Project rename: `ri` / `krt` -> `karta`
 
 | was | now |
 |---|---|
 | CRD `Kind` `ResourceInterface` | `Karta` |
 | API group `optimization.nvidia.com/v1alpha1` | `run.ai/v1alpha1` |
 | Go package `github.com/run-ai/karta/pkg/api/optimization/v1alpha1` | `github.com/run-ai/karta/pkg/api/runai/v1alpha1` |
-| Field on `ComponentFactory` : `ri *ResourceInterface` | `karta *Karta` |
+| Field on `ComponentFactory`: `ri *ResourceInterface` | `karta *Karta` |
 | Helm chart `krt` | `karta` |
 
-**Cluster migration** — existing CRDs need to be re-applied under the new GVK :
+Cluster migration - existing CRDs need to be re-applied under the new GVK:
 
 ```bash
 kubectl get resourceinterfaces.optimization.nvidia.com -o yaml | \
@@ -220,7 +225,7 @@ kubectl get resourceinterfaces.optimization.nvidia.com -o yaml | \
 kubectl delete crd resourceinterfaces.optimization.nvidia.com
 ```
 
-**Go consumer migration** :
+Go consumer migration:
 
 ```diff
 - import ri "github.com/run-ai/karta/pkg/api/optimization/v1alpha1"
@@ -235,14 +240,14 @@ kubectl delete crd resourceinterfaces.optimization.nvidia.com
 
 #### 2. `sigs.k8s.io/controller-runtime` no longer a karta dependency
 
-karta now uses `k8s.io/apimachinery` directly for the two things it previously needed from controller-runtime :
+karta now uses `k8s.io/apimachinery` directly for the two things it previously needed from controller-runtime:
 
 | was | now |
 |---|---|
-| `&scheme.Builder{GroupVersion: ...}` from `controller-runtime/pkg/scheme` | `runtime.NewSchemeBuilder(addKnownTypes)` from `k8s.io/apimachinery/pkg/runtime` |
-| `client.Object` from `controller-runtime/pkg/client` ( in `NewComponentFactoryFromObject` and `GetResource` ) | local `KubernetesObject` interface ( `metav1.Object` + `runtime.Object` ) |
+| `&scheme.Builder{GroupVersion:...}` from `controller-runtime/pkg/scheme` | `runtime.NewSchemeBuilder(addKnownTypes)` from `k8s.io/apimachinery/pkg/runtime` |
+| `client.Object` from `controller-runtime/pkg/client` (in `NewComponentFactoryFromObject` and `GetResource`) | local `KubernetesObject` interface (`metav1.Object` + `runtime.Object`) |
 
-**Consumer impact : no source code changes required.** Go matches interfaces structurally ( by method set ) , so :
+Consumer impact: no source code changes required. Go matches interfaces structurally (by method set), so:
 
 ```go
 import "sigs.k8s.io/controller-runtime/pkg/client"
@@ -253,43 +258,43 @@ obj, _ := factory.GetResource()
 var asClientObject client.Object = obj                            // still compiles
 ```
 
-**Cleanup opportunity** : consumers that only had `sigs.k8s.io/controller-runtime` in their `go.mod` because karta dragged it in can now drop it :
+Cleanup opportunity: consumers that only had `sigs.k8s.io/controller-runtime` in their `go.mod` because karta dragged it in can now drop it:
 
 ```bash
 go get sigs.k8s.io/controller-runtime@none  # if you don't otherwise use it
 go mod tidy
 ```
 
-This is the dominant pattern across major K8s OSS — see the same idiom in [kubevirt/api](https://github.com/kubevirt/api/blob/0a124c6271bf8ad3b2263b3b16b4544bae794ecd/core/v1/register.go#L85) , [prometheus-operator](https://github.com/prometheus-operator/prometheus-operator/blob/0bd09d4dae2c319b9b43eb1921afe869f123d3a8/pkg/apis/monitoring/v1/register.go#L35) , [tektoncd/pipeline](https://github.com/tektoncd/pipeline/blob/a3305b1d9b31f743fc625485e5c88837a731bbd3/pkg/apis/pipeline/v1/register.go#L40) , [cert-manager](https://github.com/cert-manager/cert-manager/blob/7c3e89bf397945fa0143e3836144fa150bcc55c7/pkg/apis/certmanager/v1/register.go#L36) , [cluster-api](https://github.com/kubernetes-sigs/cluster-api/blob/93bb18264d28410997c248052da4d7c4dbad7b91/api/core/v1beta2/groupversion_info.go#L30) , [knative/pkg `kmeta.Accessor`](https://github.com/knative/pkg/blob/df317a52d1121053934fddcfff0e1081cfae42c2/kmeta/accessor.go#L32) , and [crossplane-runtime `resource.Object`](https://github.com/crossplane/crossplane-runtime/blob/a596e1f7563505485b8ab0a06c1c3dc2d21ecf90/pkg/resource/interfaces.go#L193).
+This is the dominant pattern across major K8s OSS - see the same idiom in [kubevirt/api](https://github.com/kubevirt/api/blob/0a124c6271bf8ad3b2263b3b16b4544bae794ecd/core/v1/register.go#L85), [prometheus-operator](https://github.com/prometheus-operator/prometheus-operator/blob/0bd09d4dae2c319b9b43eb1921afe869f123d3a8/pkg/apis/monitoring/v1/register.go#L35), [tektoncd/pipeline](https://github.com/tektoncd/pipeline/blob/a3305b1d9b31f743fc625485e5c88837a731bbd3/pkg/apis/pipeline/v1/register.go#L40), [cert-manager](https://github.com/cert-manager/cert-manager/blob/7c3e89bf397945fa0143e3836144fa150bcc55c7/pkg/apis/certmanager/v1/register.go#L36), [cluster-api](https://github.com/kubernetes-sigs/cluster-api/blob/93bb18264d28410997c248052da4d7c4dbad7b91/api/core/v1beta2/groupversion_info.go#L30), [knative/pkg `kmeta.Accessor`](https://github.com/knative/pkg/blob/df317a52d1121053934fddcfff0e1081cfae42c2/kmeta/accessor.go#L32), and [crossplane-runtime `resource.Object`](https://github.com/crossplane/crossplane-runtime/blob/a596e1f7563505485b8ab0a06c1c3dc2d21ecf90/pkg/resource/interfaces.go#L193).
 
 ---
 
-### ✨ New features
+### New features
 
-- **Suspend / Resume definitions and statuses** — new `SuspendDefinition` on the CRD , plus new resource statuses `Suspended` , `Suspending` , `Resuming`. ([#56](https://github.com/run-ai/karta/pull/56) by @TomB30)
-- **`ValidateParsedJQ` is now exported** — external consumers that already hold a compiled `*gojq.Query` can run the read-only / safe-expression check without re-parsing. ([#53](https://github.com/run-ai/karta/pull/53) by @AviadHayumi)
-- **Helm chart published to GHCR on every release** — pull with `helm install karta oci://ghcr.io/run-ai/karta --version 0.1.0`. ([#27](https://github.com/run-ai/karta/pull/27) by @AviadHayumi)
-- **Chart version bump enforcement in CI** — `ct lint` blocks PRs that change the chart without bumping `Chart.yaml` version. Matches the prometheus-operator / argo enforcement model. ([#48](https://github.com/run-ai/karta/pull/48) by @AviadHayumi)
-- **`docs/examples/*.yaml` validated in CI** — example Kartas are exercised by CI so docs cant silently drift from the schema. ([#61](https://github.com/run-ai/karta/pull/61) by @Isan-Rivkin)
-- **Issue templates + code of conduct** — bug / feature templates plus a contributor CoC. ([#38](https://github.com/run-ai/karta/pull/38) by @yuval-gr)
-- **Helm chart annotated with OCI source** — `helm.sh/chart-source` annotation links chart back to the GHCR package page. ([#49](https://github.com/run-ai/karta/pull/49) by @AviadHayumi)
+- Suspend / Resume definitions and statuses - new `SuspendDefinition` on the CRD, plus new resource statuses `Suspended`, `Suspending`, `Resuming`. ([#56](https://github.com/run-ai/karta/pull/56) by @TomB30)
+- `ValidateParsedJQ` is now exported - external consumers that already hold a compiled `*gojq.Query` can run the read-only / safe-expression check without re-parsing. ([#53](https://github.com/run-ai/karta/pull/53) by @AviadHayumi)
+- Helm chart published to GHCR on every release - pull with `helm install karta oci://ghcr.io/run-ai/karta --version 0.1.0`. ([#27](https://github.com/run-ai/karta/pull/27) by @AviadHayumi)
+- Chart version bump enforcement in CI - `ct lint` blocks PRs that change the chart without bumping `Chart.yaml` version. Matches the prometheus-operator / argo enforcement model. ([#48](https://github.com/run-ai/karta/pull/48) by @AviadHayumi)
+- **`docs/examples/*.yaml` validated in CI** - example Kartas are exercised by CI so docs cant silently drift from the schema. ([#61](https://github.com/run-ai/karta/pull/61) by @Isan-Rivkin)
+- Issue templates + code of conduct - bug / feature templates plus a contributor CoC. ([#38](https://github.com/run-ai/karta/pull/38) by @yuval-gr)
+- Helm chart annotated with OCI source - `helm.sh/chart-source` annotation links chart back to the GHCR package page. ([#49](https://github.com/run-ai/karta/pull/49) by @AviadHayumi)
 
-### 🐛 Bug fixes
+### Bug fixes
 
 - Repaired `docs/examples/mpijob.yaml` and simplified the pytorch running mapping. ([#58](https://github.com/run-ai/karta/pull/58) by @lavianalon)
 - Removed accidentally pushed `docs/ri-studio/` directory. ([#40](https://github.com/run-ai/karta/pull/40) by @ronlv10)
 - Fixed formatting and validation in issue templates. ([#41](https://github.com/run-ai/karta/pull/41) by @yuval-gr)
 
-### 🧹 Maintenance
+### Maintenance
 
-- Renamed `ri` → `krt` across the codebase ( first half of the rename to karta ). ([#42](https://github.com/run-ai/karta/pull/42) by @AviadHayumi)
-- Renamed Helm chart `krt` → `karta` ( finishing the rename ). ([#50](https://github.com/run-ai/karta/pull/50) by @AviadHayumi)
-- Bumped `golang.org/x/net` to v0.51.0 ( security ). ([#45](https://github.com/run-ai/karta/pull/45) by @yuval-gr)
+- Renamed `ri` -> `krt` across the codebase (first half of the rename to karta). ([#42](https://github.com/run-ai/karta/pull/42) by @AviadHayumi)
+- Renamed Helm chart `krt` -> `karta` (finishing the rename). ([#50](https://github.com/run-ai/karta/pull/50) by @AviadHayumi)
+- Bumped `golang.org/x/net` to v0.51.0 (security). ([#45](https://github.com/run-ai/karta/pull/45) by @yuval-gr)
 - Updated Go toolchain to 1.25.9. ([#30](https://github.com/run-ai/karta/pull/30) by @yuval-gr)
 
 ---
 
-### 📊 Dependencies
+### Dependencies
 
 #### Added
 
@@ -297,29 +302,29 @@ _nothing_
 
 #### Changed
 
-- `golang.org/x/net` v0.39.0 → **v0.51.0**
-- Go toolchain 1.25.7 → **1.25.9**
-- `k8s.io/api` v0.34.x → **v0.35.1**
-- `k8s.io/apimachinery` v0.34.x → **v0.35.1**
+- `golang.org/x/net` v0.39.0 -> v0.51.0
+- Go toolchain 1.25.7 -> 1.25.9
+- `k8s.io/api` v0.34.x -> v0.35.1
+- `k8s.io/apimachinery` v0.34.x -> v0.35.1
 
 #### Removed
 
-- `sigs.k8s.io/controller-runtime` ( previously v0.23.1 ) — **dropped entirely**
-- `sigs.k8s.io/controller-runtime/pkg/client` ( transitive ) — no longer pulled in
-- `sigs.k8s.io/controller-runtime/pkg/scheme` ( transitive ) — no longer pulled in
+- `sigs.k8s.io/controller-runtime` (previously v0.23.1) - dropped entirely
+- `sigs.k8s.io/controller-runtime/pkg/client` (transitive) - no longer pulled in
+- `sigs.k8s.io/controller-runtime/pkg/scheme` (transitive) - no longer pulled in
 
 ---
 
-### 🤝 Contributors
+### Contributors
 
-thanks to everyone who shipped this release :
+thanks to everyone who shipped this release:
 
-[@AviadHayumi](https://github.com/AviadHayumi) , [@Isan-Rivkin](https://github.com/Isan-Rivkin) , [@TomB30](https://github.com/TomB30) , [@lavianalon](https://github.com/lavianalon) , [@ronlv10](https://github.com/ronlv10) , [@yuval-gr](https://github.com/yuval-gr)
+[@AviadHayumi](https://github.com/AviadHayumi), [@Isan-Rivkin](https://github.com/Isan-Rivkin), [@TomB30](https://github.com/TomB30), [@lavianalon](https://github.com/lavianalon), [@ronlv10](https://github.com/ronlv10), [@yuval-gr](https://github.com/yuval-gr)
 
 ---
 
-**Full changelog** : https://github.com/run-ai/karta/compare/v0.0.12...v0.1.0
-**Helm chart** : `oci://ghcr.io/run-ai/karta:0.1.0`
+Full changelog: https://github.com/run-ai/karta/compare/v0.0.12...v0.1.0
+Helm chart: `oci://ghcr.io/run-ai/karta:0.1.0`
 
 ## v0.0.1 through v0.0.12 - 2025-09-03 to 2026-04-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@
 
 Notable changes per release. This file is the in-repo source of record: a release's entry is added here before the tag is pushed (see [RELEASE.md](RELEASE.md)), and the [GitHub Release](https://github.com/run-ai/karta/releases) body carries the same content, normalized to the repository Markdown rules in [AGENTS.md](AGENTS.md).
 
-Scope: this file covers minor and major releases, which are tagged from `main`. Patch releases are tagged from their release branch (`v0.1`, `v0.2`) and their entries live in that branch's changelog.
+Scope: this file covers releases tagged from `main`. Patch releases on a minor line are tagged from that line's release branch (`v0.1`, `v0.2`) and are documented in the changelog there. The v0.0.x releases predate that scheme and are summarized at the end.
 
 ## v0.2.0 - 2026-07-15
 
-This release extends Karta from a CRD and Go library into an optional runnable system. It lands the controller / operator (reconcile core, workload-tree model, Helm chart, container images), and a new pod-grouping API for better schedulers integration, alongside a much larger catalog of built-in workload samples. There are no breaking API changes; the previous grouping format is deprecated but still works. See [Deprecations](#%EF%B8%8F-deprecations) for the recommended migration.
+This release extends Karta from a CRD and Go library into an optional runnable system. It lands the controller / operator (reconcile core, workload-tree model, Helm chart, container images), and a new pod-grouping API for better schedulers integration, alongside a much larger catalog of built-in workload samples. There are no breaking API changes; the previous grouping format is deprecated but still works. See [Deprecations](#deprecations) for the recommended migration.
 
 ---
 
@@ -63,7 +63,7 @@ Correction added after release: this is not a drop-in migration at v0.2.0, and t
 
 - Karta's own instruction helpers read only `podGroups`. `pkg/instructions/summary.go` builds gang-scheduling candidates from `GangScheduling.PodGroups` and never reads `GangScheduling.PodGroup`. That is true at v0.2.0 and still true today. A consumer that relies on those helpers for grouping loses its grouping if it switches formats.
 - `podGroup` is honored by the scheduler integration instead. The KAI Karta podgrouper plugin prefers `podGroup` and falls back to `podGroups`. It shipped in KAI v0.17.0 on 2026-08-03, after this release, so at v0.2.0 nothing consumed the new field yet.
-- The two formats are not equivalent. A `podGroups` member carries `groupByKeyPaths`; a `subGroups` entry carries only `componentName` and `topology`, so per-component grouping keys have no direct counterpart.
+- The two formats are not equivalent. A `podGroups` member carries `groupByKeyPaths` and `filters`; a `subGroups` entry carries only `componentName` and `topology`, so per-component grouping keys and filters have no direct counterpart.
 
 Target shape of the new format:
 
@@ -159,7 +159,7 @@ Container images: see [packages page](https://github.com/run-ai/karta/pkgs/conta
 
 ## v0.1.0 - 2026-05-12
 
-This release completes the project rename from `ri` / `krt` to karta, decouples the library from `sigs.k8s.io/controller-runtime`, and introduces native suspend / resume support on the CRD. See [Breaking changes](#%EF%B8%8F-breaking-changes) for migration steps.
+This release completes the project rename from `ri` / `krt` to karta, decouples the library from `sigs.k8s.io/controller-runtime`, and introduces native suspend / resume support on the CRD. See [Breaking changes](#breaking-changes) for migration steps.
 
 ---
 
@@ -275,7 +275,7 @@ This is the dominant pattern across major K8s OSS - see the same idiom in [kubev
 - `ValidateParsedJQ` is now exported - external consumers that already hold a compiled `*gojq.Query` can run the read-only / safe-expression check without re-parsing. ([#53](https://github.com/run-ai/karta/pull/53) by @AviadHayumi)
 - Helm chart published to GHCR on every release - pull with `helm install karta oci://ghcr.io/run-ai/karta --version 0.1.0`. ([#27](https://github.com/run-ai/karta/pull/27) by @AviadHayumi)
 - Chart version bump enforcement in CI - `ct lint` blocks PRs that change the chart without bumping `Chart.yaml` version. Matches the prometheus-operator / argo enforcement model. ([#48](https://github.com/run-ai/karta/pull/48) by @AviadHayumi)
-- **`docs/examples/*.yaml` validated in CI** - example Kartas are exercised by CI so docs cant silently drift from the schema. ([#61](https://github.com/run-ai/karta/pull/61) by @Isan-Rivkin)
+- `docs/examples/*.yaml` validated in CI - example Kartas are exercised by CI so docs cannot silently drift from the schema. ([#61](https://github.com/run-ai/karta/pull/61) by @Isan-Rivkin)
 - Issue templates + code of conduct - bug / feature templates plus a contributor CoC. ([#38](https://github.com/run-ai/karta/pull/38) by @yuval-gr)
 - Helm chart annotated with OCI source - `helm.sh/chart-source` annotation links chart back to the GHCR package page. ([#49](https://github.com/run-ai/karta/pull/49) by @AviadHayumi)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Scope: this file covers minor and major releases, which are tagged from `main`. 
 
 Entries here were backfilled from the published GitHub release notes when this file was introduced.
 
+
 ## v0.2.0 - 2026-07-15
 
 This release extends Karta from a CRD and Go library into an optional runnable system. It lands the controller / operator (reconcile core, workload-tree model, Helm chart, container images), and a new pod-grouping API for better schedulers integration, alongside a much larger catalog of built-in workload samples. There are no breaking API changes; the previous grouping format is deprecated but still works. See [Deprecations](#%EF%B8%8F-deprecations) for the recommended migration.
@@ -150,6 +151,7 @@ plus automated dependency updates from [@dependabot](https://github.com/dependab
 **Full changelog** : https://github.com/run-ai/karta/compare/v0.1.0...v0.2.0
 **Helm chart** : `oci://ghcr.io/run-ai/karta:0.2.0`
 **Container images** : see [packages page](https://github.com/run-ai/karta/pkgs/container/karta)
+
 ## v0.1.0 - 2026-05-12
 
 This release completes the project rename from `ri` / `krt` to **karta** , decouples the library from `sigs.k8s.io/controller-runtime` , and introduces native suspend / resume support on the CRD. See [Breaking changes](#%EF%B8%8F-breaking-changes) for migration steps.
@@ -318,6 +320,7 @@ thanks to everyone who shipped this release :
 
 **Full changelog** : https://github.com/run-ai/karta/compare/v0.0.12...v0.1.0
 **Helm chart** : `oci://ghcr.io/run-ai/karta:0.1.0`
+
 ## v0.0.1 through v0.0.12 - 2025-09-03 to 2026-04-14
 
 Pre-rename development releases under the earlier project name. See the [release list](https://github.com/run-ai/karta/releases) for individual notes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,7 +160,7 @@ git push origin v1.2.3
 
 Pushing the tag triggers `push-artifacts.yaml`, which publishes `oci://ghcr.io/run-ai/karta/karta:1.2.3` with both `version` and `appVersion` set to `1.2.3`, and creates a corresponding GitHub release.
 
-No release-prep PR or `Chart.yaml` bump is needed - the tag is the source of truth.
+No `Chart.yaml` bump is needed - the tag is the source of truth for versions. The one pre-tag step is adding the version's entry to [CHANGELOG.md](CHANGELOG.md); see [RELEASE.md](RELEASE.md) for the policy.
 
 ## Code of Conduct
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,8 +20,9 @@ release notes. Consumers should pin to a specific released version.
 
 Karta releases on an as-needed basis rather than a fixed calendar. A release is
 cut when a meaningful set of changes has accumulated on `main`, or when a fix needs
-to ship. There is no separate release branch while the project is pre-1.0; releases
-are tagged from `main`.
+to ship. Minor releases are tagged from `main`. Each minor line then gets a release
+branch (`v0.1`, `v0.2`), and patch releases are tagged from that branch, so patch
+fixes ship without waiting on `main`.
 
 ## Who can cut a release
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -33,12 +33,17 @@ built by CI from the pushed tag, never from a local machine.
 The full steps live in [CONTRIBUTING.md](CONTRIBUTING.md#versioning). In short, a
 maintainer pushes a `vX.Y.Z` tag, which triggers the `push-artifacts` workflow to
 publish the Helm chart to GHCR and create the corresponding GitHub Release. No
-release-prep pull request or `Chart.yaml` bump is required; the tag is the source
-of truth.
+`Chart.yaml` bump is required; the tag is the source of truth for versions.
+
+The one pre-tag step is the changelog: before pushing the tag, add the version's
+entry to [CHANGELOG.md](CHANGELOG.md) so the tagged source archive carries its own
+entry. Conventional Commits make this mechanical (a `git log` pass over the range
+since the previous tag); a generator script is tracked as a follow-up.
 
 ## Release notes and breaking changes
 
-Each GitHub Release includes notes describing what changed. Every breaking change
+The GitHub Release body is written from the version's CHANGELOG.md entry; the
+changelog is the source, the release body is the copy. Every breaking change
 (API field changes, removed or renamed library surface, behavioral changes that
 require consumer action) must be documented in the release notes with migration
 guidance so that downstream consumers can upgrade predictably.


### PR DESCRIPTION
## What does this PR do?

Adds an in-repo CHANGELOG.md summarizing notable changes per release, with GitHub Releases noted as the canonical record. Covers v0.1.0 through v0.2.3 individually (content sourced from the published release notes) and collapses the pre-rename v0.0.x line into one entry. Gives offline consumers and vendored copies a scannable history without leaving the repo.

Docs-only change; no code affected.

## Related issue(s)

Fixes #241 (item 2)

## Checklist

- [x] All commits are signed off with DCO (`git commit -s`)
- [x] New/modified files have SPDX license and copyright headers
- [x] Documentation updated (if applicable)
- [x] Tests pass (`make check`)
- [x] No proprietary or internal information included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded changelog entries for v0.1.0 and v0.2.0, including installation, compatibility, features, fixes, maintenance, dependencies, contributors, and release artifacts.
  * Documented pod-grouping deprecation and migration guidance, along with rename and controller-runtime migration steps.
  * Clarified release preparation, including chart version updates, changelog entries, tagging rules, release branches, and GitHub Release content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->