### PR TITLE
docs: link roadmap and changelog from README, document commit format in CONTRIBUTING

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,21 +89,7 @@ Use `Makefile` to build, test, lint, and generate code (e.g. `make test`, `make 
 
 ## Commits and Pull Requests
 
-Conventional Commits v1.0.0:
-
-```text
-<type>(<scope>): <short description>
-
-[optional body]
-```
-
-Types: `feat`, `fix`, `refactor`, `docs`, `test`, `build`, `ci`, `chore`.
-
-Sign off every commit with `-s` (DCO v1.1, real name required):
-
-```bash
-git commit -s -m "feat(cli): add tree alignment"
-```
+Commit messages follow Conventional Commits v1.0.0 with a DCO sign-off (`git commit -s`, real name required). The format, allowed types, and scope conventions are documented in `CONTRIBUTING.md` under Commit Messages; that section is the single source of truth. Do not restate the format here.
 
 Use the PR template at `.github/PULL_REQUEST_TEMPLATE.md`. Required: link to an open issue, run `make check`, add or update tests (or explain why none).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,22 @@ steps on every pull request. Running `make check` and `make lint` locally first
 is the fastest way to catch issues before pushing. If you only need a quick test
 pass, `make test` runs the tests and mock generation on their own.
 
+### Commit Messages
+
+Commit messages follow [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/):
+
+```text
+<type>(<scope>): <short description>
+
+[optional body]
+```
+
+Types: `feat`, `fix`, `refactor`, `docs`, `test`, `build`, `ci`, `chore`. When picking a scope, match an existing one from `git log`. Combine the format with the DCO sign-off described above:
+
+```bash
+git commit -s -m "fix(jq): reject expressions that exceed the evaluation depth limit"
+```
+
 ### Making Changes
 
 1. Fork the repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ Commit messages follow [Conventional Commits v1.0.0](https://www.conventionalcom
 Types: `feat`, `fix`, `refactor`, `docs`, `test`, `build`, `ci`, `chore`. When picking a scope, match an existing one from `git log`. Combine the format with the DCO sign-off described above:
 
 ```bash
-git commit -s -m "fix(jq): reject expressions that exceed the evaluation depth limit"
+git commit -s -m "fix(api): validate status mapping expressions before applying them"
 ```
 
 ### Making Changes

--- a/README.md
+++ b/README.md
@@ -242,6 +242,8 @@ See [ADOPTERS.md](ADOPTERS.md) for the full list of adopters. If you use Karta, 
 
 ## Documentation
 
+- [Roadmap](ROADMAP.md) - Where Karta is headed, in Now / Next / Later horizons
+- [Changelog](CHANGELOG.md) - Notable changes per release
 - [Technical Guide](docs/Technical%20Guide.md) - Full Karta spec, path syntax (jq), validation rules
 - [Webhook Certificates](docs/Webhook%20Certificates.md) - Webhook cert modes (auto self-signed or manual) and how to wire cert-manager
 - [Karta definitions](docs/catalog/) - Real-world Karta definitions for common workload types


### PR DESCRIPTION
## What does this PR do?

Two discoverability fixes:

- README: ROADMAP.md exists at the repo root but nothing linked to it. The Documentation section now lists the roadmap and the changelog. The changelog link becomes valid when the sibling changelog PR merges; merge that one first.
- CONTRIBUTING.md: the Conventional Commits format was documented only in AGENTS.md, which human contributors are not expected to read. A Commit Messages section now documents the format, types, scope convention, and a combined sign-off example in the contribution flow itself.

Docs-only change; no code affected.

## Related issue(s)

Fixes #241 (items 3 and 4)

## Checklist

- [x] All commits are signed off with DCO (`git commit -s`)
- [x] New/modified files have SPDX license and copyright headers
- [x] Documentation updated (if applicable)
- [x] Tests pass (`make check`)
- [x] No proprietary or internal information included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidance for Conventional Commits, including formatting, accepted types, scopes, and DCO signing examples.
  * Added roadmap and changelog links to the README documentation section.
  * Consolidated commit-message guidance under a single contributor documentation source, reducing duplication and clarifying where to find the latest conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->