### PR TITLE
docs(skills): add add-workload-type benchmark and sharpen eval assertions

### DIFF
--- a/skills/add-workload-type/BENCHMARK.md
+++ b/skills/add-workload-type/BENCHMARK.md
@@ -1,0 +1,147 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright (c) 2026 NVIDIA Corporation -->
+
+# Skill Benchmark: add-workload-type
+
+Model: claude-opus-5
+Date: 2026-08-18
+Evals: 1, 2, 3 from `evals/evals.json` (3 runs each per configuration, 18 runs total)
+
+Each eval prompt was run by an agent with the skill available and by a baseline
+agent without it. Both configurations had full repository access. Every produced
+definition was checked with `hack/karta-verify` and a jq audit script rather than
+by inspection.
+
+## Summary
+
+| Metric | With Skill | Without Skill | Delta |
+|--------|------------|---------------|-------|
+| Pass Rate | 97% +/- 8% | 97% +/- 8% | +0.00 |
+| Time | 284.8s +/- 258.7s | 428.4s +/- 468.4s | -143.6s |
+| Tokens | 56410 +/- 19981 | 81135 +/- 49419 | -24724 |
+
+## Revised assertions
+
+The expectations in `evals/evals.json` were rewritten after this run, because the
+original set could not tell the two configurations apart. The same 18 run
+artifacts were then graded again against the revised set. No agent was re-run, so
+the time and token figures above are unchanged and only the pass rates move.
+
+| Assertion set | With Skill | Without Skill | Delta |
+|---------------|------------|---------------|-------|
+| Original | 97% | 97% | +0.00 |
+| Revised, evals 1-3 | 96% | 51% | +0.44 |
+| Revised, discriminating only, eval 1 | 93% | 7% | +0.87 |
+| Revised, discriminating only, eval 2 | 100% | 22% | +0.78 |
+
+What separates the configurations, measured as with_skill/without_skill over 3
+runs each:
+
+| Behaviour | Eval 1 | Eval 2 |
+|-----------|--------|--------|
+| Deliverable is a definition only, no Go source or e2e module | 3/3 vs 0/3 | n/a |
+| Predictions written before the run, exercised with `--strict` | 3/3 vs 0/3 | 3/3 vs 0/3 |
+| Validated with `hack/karta-verify` rather than a bespoke harness | 3/3 vs 1/3 | 3/3 vs 0/3 |
+| Suspended Workflow resolves Suspended, not Running | 2/3 vs 0/3 | n/a |
+| States which parts remain unproven | n/a | 3/3 vs 0/3 |
+
+The suspend guard is the one pure correctness discriminator. All three baseline
+runs mapped `running` to a bare `byPhase: Running`, which misreports a suspended
+workflow, because Argo leaves `.status.phase` at Running while `.spec.suspend` is
+true. Two of the three skill-guided runs guarded the rule against `.spec.suspend`.
+
+The rest are verification discipline rather than output quality, and that
+distinction is worth keeping in view: they measure whether the run followed the
+skill's steps 6 and 7. They are not circular, because following those steps
+changed outcomes. Both skill-guided eval 1 runs discovered through the
+predict-then-run step that an Argo Workflow needs a multi-instance component,
+after a single-instance draft failed with `instance ids count (1) does not match
+results count (2)`. Neither reasoned it out in advance.
+
+Eval 4 was added to `evals.json` for Volcano Job, which is absent from
+`docs/catalog/`, to replace the content-discrimination role eval 2 can no longer
+serve. It has not been run, and its expectations carry no measured counts.
+
+## Per-eval breakdown
+
+| Eval | Config | Pass rate | Tokens | Time |
+|------|--------|-----------|--------|------|
+| 1 Argo Workflow, authored from scratch | with skill | 0.92 | 80847 | 617s |
+| 1 Argo Workflow, authored from scratch | baseline | 0.92 | 147265 | 1006s |
+| 2 batch/v1 CronJob | with skill | 1.00 | 54791 | 176s |
+| 2 batch/v1 CronJob | baseline | 1.00 | 62038 | 218s |
+| 3 Quickstart question, boundary case | with skill | 1.00 | 33594 | 61s |
+| 3 Quickstart question, boundary case | baseline | 1.00 | 34101 | 61s |
+
+## Notes
+
+The pass-rate delta was zero under the assertions in force when this run
+executed. Those assertions were rewritten afterwards, and the revised set scores
+the same artifacts at +0.44. See the revised assertions section above. The
+summary table reports the original grading, so it understates the difference.
+
+Why the original assertions failed to discriminate. The validator passed on all
+13 definitions produced across both configurations, so "passes the KartaValidator"
+cannot separate them. The same holds for full GVK, presence of a root
+statusDefinition, one spec pattern per component, and the nested
+`.spec.jobTemplate.spec.template` path. Baselines got all of these right unaided.
+These are correctness minimums, and they are retained in `evals.json` marked as
+floor expectations so a regression still fails, but they carry no signal about
+the skill.
+
+Cost runs the other way from the usual expectation. The skill made the work
+cheaper, not more expensive. On eval 1 the baseline used 82 percent more tokens
+and 63 percent more wall-clock. The cause is scope: both baseline runs that
+finished eval 1 expanded the task into a typed Go catalog constructor under
+`pkg/catalog/kartas/`, an `hack/e2e` operator module, and a landing checklist,
+none of which the prompt asked for. The skill-guided runs produced a definition
+and stopped. Bounding scope is the clearest measured effect in this run.
+
+Eval 2 is contaminated. The repository already ships
+`docs/catalog/batch-cronjob-v1.yaml`. Both configurations found it, so eval 2
+tests whether an agent can locate an existing catalog entry, not whether it can
+author a definition. Both scored 1.00. Replace it with a workload absent from
+`docs/catalog/` before treating its result as meaningful.
+
+Eval 3 shows no over-triggering. All 3 skill-available runs declined to use the
+skill, recorded `SKILL_USED: no`, answered the question, and authored no
+definition. Triggering was correct in both directions across the set: the skill
+fired on evals 1 and 2 without being named, and stayed out of eval 3.
+
+Variance is high and the run count is low. Three runs per configuration with a
+population stddev near 468s on baseline time is not enough to call the time and
+token deltas precisely. The direction is consistent across every eval; the
+magnitude is not settled.
+
+The one quality difference the assertions missed. Both skill-guided eval 1 runs
+discovered through step 7 that an Argo Workflow needs a multi-instance component,
+after a single-instance draft failed with `instance ids count (1) does not match
+results count (2)`. Neither reasoned this out in advance. That is the predict-then-run
+step doing real work, and no current assertion credits it.
+
+## Environment note
+
+Every skill-guided run that reached validation reported that the step 6 command
+failed and worked around it with `-mod=readonly`:
+
+```
+go: inconsistent vendoring in <repo>:
+	github.com/onsi/ginkgo/v2@v2.32.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
+```
+
+This was a stale local `vendor/` directory on the machine that ran the benchmark,
+not a defect in the skill or the repository. `vendor/` is gitignored and is not
+referenced by the Makefile or CI, so a dependency bump in go.mod left it behind
+and Go's automatic vendor mode then failed every command. Removing the directory
+resolved it. The step 6 command in `SKILL.md` is correct as written.
+
+The measured effect is still worth noting: an unrelated broken toolchain cost
+each run several tool calls to diagnose, which inflates the token and time
+figures above for both configurations.
+
+## Reproducing
+
+1. Run each prompt in `evals/evals.json` with and without the skill available.
+2. Grade each run against its `expectations` list.
+3. Validate every produced definition: `go run ./hack/karta-verify --karta <file>`.
+4. Aggregate the per-run results into this summary.

--- a/skills/add-workload-type/BENCHMARK.md
+++ b/skills/add-workload-type/BENCHMARK.md
@@ -9,8 +9,8 @@ Evals: 1, 2, 3 from `evals/evals.json` (3 runs each per configuration, 18 runs t
 
 Each eval prompt was run by an agent with the skill available and by a baseline
 agent without it. Both configurations had full repository access. Every produced
-definition was checked with `hack/karta-verify` and a jq audit script rather than
-by inspection.
+definition was checked with `hack/karta-verify` and by querying the produced YAML
+for the asserted paths, rather than by inspection.
 
 ## Summary
 
@@ -76,7 +76,7 @@ serve. It has not been run, and its expectations carry no measured counts.
 ## Notes
 
 The pass-rate delta was zero under the assertions in force when this run
-executed. Those assertions were rewritten afterwards, and the revised set scores
+executed. Those assertions were rewritten afterward, and the revised set scores
 the same artifacts at +0.44. See the revised assertions section above. The
 summary table reports the original grading, so it understates the difference.
 
@@ -124,7 +124,7 @@ step doing real work, and no current assertion credits it.
 Every skill-guided run that reached validation reported that the step 6 command
 failed and worked around it with `-mod=readonly`:
 
-```
+```text
 go: inconsistent vendoring in <repo>:
 	github.com/onsi/ginkgo/v2@v2.32.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
 ```
@@ -141,7 +141,21 @@ figures above for both configurations.
 
 ## Reproducing
 
-1. Run each prompt in `evals/evals.json` with and without the skill available.
+1. Run the eval 1, 2 and 3 prompts from `evals/evals.json` with and without the
+   skill available, 3 runs each. Eval 4 is documented but was not run and is not
+   part of these figures.
 2. Grade each run against its `expectations` list.
-3. Validate every produced definition: `go run ./hack/karta-verify --karta <file>`.
-4. Aggregate the per-run results into this summary.
+3. Validate every produced definition, and exercise it against a real CR with
+   predictions written before the run:
+
+   ```sh
+   go run ./hack/karta-verify --karta <definition> \
+     --workload <cr> --predict <predictions> --strict
+   ```
+
+   `--karta` alone only validates the definition. `--workload`, `--predict` and
+   `--strict` are what make the predict-then-run discriminators observable;
+   without them a run cannot fail the way the benchmark records.
+4. Confirm each asserted path resolves in the produced YAML, rather than reading
+   it by eye.
+5. Aggregate the per-run results into this summary.

--- a/skills/add-workload-type/evals/evals.json
+++ b/skills/add-workload-type/evals/evals.json
@@ -1,39 +1,142 @@
 {
   "skill_name": "add-workload-type",
+  "notes": "Expectations are chosen to separate a skill-guided run from an unaided one. Each expectation records the pass counts measured over 3 runs per configuration in the 2026-08-18 benchmark, as with_skill/without_skill. Expectations marked floor are correctness minimums that both configurations already satisfy; they are kept to catch regressions, not to show a delta.",
   "evals": [
     {
       "id": 1,
+      "purpose": "Primary discriminator. Argo Workflow is absent from docs/catalog/, so the definition must be authored from scratch.",
       "prompt": "We run Argo Workflows on our cluster and want Karta to understand them. Add support for the Argo Workflow type.",
-      "expected_output": "The agent selects the add-workload-type skill from intent, gathers the Argo facts, and produces a valid Karta definition for argoproj.io/v1alpha1 Workflow with a phase-based status mapping and null-safe jq paths.",
+      "expected_output": "A single Karta definition for argoproj.io/v1alpha1 Workflow, validated with the repository harness and exercised against a CR with predictions written first, with a phase-based status mapping that does not misreport a suspended workflow as Running.",
       "expectations": [
-        "The add-workload-type skill is selected without the user naming it",
-        "The root component declares the full GVK: group argoproj.io, version v1alpha1, kind Workflow",
-        "The root component has a statusDefinition",
-        "Status is mapped from the real .status.phase values (for example Pending, Running, Succeeded, Failed, Error) rather than invented condition types",
-        "Every jq path is absolute and null-safe",
-        "The definition satisfies the skill's validation checklist"
+        {
+          "text": "The add-workload-type skill is selected without the user naming it",
+          "measured": "3/3 vs n/a",
+          "kind": "triggering"
+        },
+        {
+          "text": "The deliverable is a Karta YAML definition only. No Go source file under pkg/catalog/kartas/, no catalog registration, and no hack/e2e module are produced",
+          "measured": "3/3 vs 0/3",
+          "kind": "discriminating"
+        },
+        {
+          "text": "Expected status, replica counts and container names are written to a predictions file before the definition is run, and the run uses --strict",
+          "measured": "3/3 vs 0/3",
+          "kind": "discriminating"
+        },
+        {
+          "text": "The definition is validated with the repository harness, go run ./hack/karta-verify --karta <file>, rather than a purpose-built Go program that calls the library directly",
+          "measured": "3/3 vs 1/3",
+          "kind": "discriminating"
+        },
+        {
+          "text": "A suspended Workflow resolves to Suspended and not Running. Argo leaves .status.phase at Running while .spec.suspend is true, so the running rule must be guarded against .spec.suspend rather than matching byPhase Running alone",
+          "measured": "2/3 vs 0/3",
+          "kind": "discriminating"
+        },
+        {
+          "text": "The root component declares the full GVK group argoproj.io, version v1alpha1, kind Workflow, and has a statusDefinition",
+          "measured": "3/3 vs 3/3",
+          "kind": "floor"
+        },
+        {
+          "text": "Status is mapped from the real .status.phase values (Pending, Running, Succeeded, Failed, Error) rather than invented condition types, and every jq path is absolute and null-safe",
+          "measured": "2/3 vs 2/3",
+          "kind": "floor"
+        }
       ]
     },
     {
       "id": 2,
+      "purpose": "Process regression only. docs/catalog/batch-cronjob-v1.yaml already ships in this repository, so both configurations can find the answer and no content expectation here can discriminate. Retained for the verification-discipline expectations, which do separate.",
       "prompt": "Write a Karta definition for a batch/v1 CronJob. It should report status and expose the pod template.",
-      "expected_output": "A valid Karta definition for batch/v1 CronJob that uses the nested jobTemplate pod-template path, sets exactly one spec pattern per component, and maps status from real fields with null-safe expressions.",
+      "expected_output": "A valid Karta definition for batch/v1 CronJob, verified with the repository harness against sample CRs with predictions written first.",
       "expectations": [
-        "Exactly one specDefinition pattern is set on each component",
-        "The pod template path is .spec.jobTemplate.spec.template, not .spec.template",
-        "Every jq path is null-safe and evaluated against the workload object, not a pod",
-        "Status mapping references real fields such as .spec.suspend or .status via byExpression",
-        "The definition passes the KartaValidator and the skill's validation checklist"
+        {
+          "text": "The definition is validated with go run ./hack/karta-verify --karta <file> and exercised against sample CronJobs with --strict, with predictions written before the run",
+          "measured": "3/3 vs 0/3",
+          "kind": "discriminating"
+        },
+        {
+          "text": "podTemplateSpecPath is declared on the root cronjob component, matching the convention in docs/catalog/batch-cronjob-v1.yaml",
+          "measured": "3/3 vs 2/3",
+          "kind": "discriminating"
+        },
+        {
+          "text": "The answer states which parts remain unproven, for example that the sample CRs are synthetic or that suspend writes were not exercised",
+          "measured": "3/3 vs 0/3",
+          "kind": "discriminating"
+        },
+        {
+          "text": "The pod template path is .spec.jobTemplate.spec.template, not .spec.template, and exactly one specDefinition pattern is set on each component",
+          "measured": "3/3 vs 3/3",
+          "kind": "floor"
+        },
+        {
+          "text": "Status is mapped with byExpression over real fields such as .spec.suspend and .status.active, and every jq path is null-safe and evaluated against the workload object",
+          "measured": "3/3 vs 3/3",
+          "kind": "floor"
+        }
       ]
     },
     {
       "id": 3,
+      "purpose": "Over-triggering guard. Both configurations answer this correctly by construction, so it cannot show a delta. It fails loudly if the skill starts driving non-authoring requests.",
       "prompt": "What does the Karta offline quickstart print when I run it, and where is its source?",
-      "expected_output": "A direct answer that describes the quickstart output and points at docs/examples/quickstart/, without authoring a new Karta definition. This is a non-authoring, boundary case: the skill should not drive the response.",
+      "expected_output": "A direct answer describing the quickstart output and pointing at docs/examples/quickstart/, with no Karta definition authored.",
       "expectations": [
-        "The response does not author or scaffold a Karta definition",
-        "The answer points at docs/examples/quickstart/ and describes its output",
-        "The add-workload-type skill does not drive the response"
+        {
+          "text": "The response does not author or scaffold a Karta definition",
+          "measured": "3/3 vs 3/3",
+          "kind": "guard"
+        },
+        {
+          "text": "The answer points at docs/examples/quickstart/ and describes its output",
+          "measured": "3/3 vs 3/3",
+          "kind": "guard"
+        },
+        {
+          "text": "The add-workload-type skill does not drive the response",
+          "measured": "3/3 vs n/a",
+          "kind": "guard"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "purpose": "Uncontaminated content discriminator, added to replace the role eval 2 can no longer serve. Volcano Job is absent from docs/catalog/ and has multiple task roles plus gang scheduling, which exercises multi-instance components. Not yet run: expectations are derived from eval 1's measured discriminators and carry no measured counts.",
+      "prompt": "We schedule Volcano jobs on this cluster. Add support for batch.volcano.sh/v1alpha1 Job to Karta.",
+      "expected_output": "A Karta definition for batch.volcano.sh/v1alpha1 Job with one component instance per entry in .spec.tasks[], replicas read per task, and a status mapping built from the real .status.state.phase values.",
+      "expectations": [
+        {
+          "text": "The deliverable is a Karta YAML definition only, with no Go source and no catalog registration",
+          "measured": null,
+          "kind": "discriminating"
+        },
+        {
+          "text": "Expected values are written to a predictions file before the run, and the definition is exercised with go run ./hack/karta-verify --karta <file> --workload <cr> --predict <file> --strict",
+          "measured": null,
+          "kind": "discriminating"
+        },
+        {
+          "text": "The task roles are modelled as a multi-instance component keyed on .spec.tasks[].name, with instanceIdPath and componentInstanceSelector both present",
+          "measured": null,
+          "kind": "discriminating"
+        },
+        {
+          "text": "Gang scheduling is either modelled from .spec.minAvailable or explicitly declined with a stated reason, rather than silently omitted",
+          "measured": null,
+          "kind": "discriminating"
+        },
+        {
+          "text": "The root component declares the full GVK group batch.volcano.sh, version v1alpha1, kind Job, and status is mapped from the real .status.state.phase values rather than invented condition types",
+          "measured": null,
+          "kind": "floor"
+        },
+        {
+          "text": "Replicas are read per task from .spec.tasks[].replicas with a null-safe default, and every jq path is absolute",
+          "measured": null,
+          "kind": "floor"
+        }
       ]
     }
   ]

--- a/skills/add-workload-type/evals/evals.json
+++ b/skills/add-workload-type/evals/evals.json
@@ -1,6 +1,6 @@
 {
   "skill_name": "add-workload-type",
-  "notes": "Expectations are chosen to separate a skill-guided run from an unaided one. Each expectation records the pass counts measured over 3 runs per configuration in the 2026-08-18 benchmark, as with_skill/without_skill. Expectations marked floor are correctness minimums that both configurations already satisfy; they are kept to catch regressions, not to show a delta.",
+  "notes": "Expectations are chosen to separate a skill-guided run from an unaided one. Each expectation records the pass counts measured over 3 runs per configuration in the 2026-08-18 benchmark, as with_skill/without_skill. Expectations marked floor are correctness minimums that both configurations already satisfy where measured; they are kept to catch regressions, not to show a delta. Expectations with a null measured value come from evals that have not been run, so neither their floor nor their discriminating status is established.",
   "evals": [
     {
       "id": 1,


### PR DESCRIPTION
## What does this PR do?

Benchmarks the `add-workload-type` skill and rewrites its eval assertions so they
measure the skill rather than the model.

The benchmark ran 3 evals in two configurations, with the skill available and
without it, 3 runs each, 18 runs total. Result recorded in
`skills/add-workload-type/BENCHMARK.md`.

The headline finding is that the original assertions did not discriminate: both
configurations scored 97 percent. The validator passed on all 13 definitions
produced, and baselines got full GVK, root `statusDefinition`, one spec pattern
per component, and the nested `.spec.jobTemplate.spec.template` path right
unaided. Those assertions were measuring the model.

The expectations were rewritten around behaviours the run data showed to
separate, and the same 18 artifacts were graded again. No agent was re-run:

| Assertion set | With skill | Baseline | Delta |
|---|---|---|---|
| Original | 97% | 97% | +0.00 |
| Revised, evals 1-3 | 96% | 51% | +0.44 |
| Revised, discriminating only, eval 1 | 93% | 7% | +0.87 |

What separates the configurations, as with_skill/without_skill over 3 runs each:

| Behaviour | Eval 1 | Eval 2 |
|---|---|---|
| Deliverable is a definition only, no Go source or e2e module | 3/3 vs 0/3 | n/a |
| Predictions written before the run, exercised with `--strict` | 3/3 vs 0/3 | 3/3 vs 0/3 |
| Validated with `hack/karta-verify` rather than a bespoke harness | 3/3 vs 1/3 | 3/3 vs 0/3 |
| Suspended Workflow resolves Suspended, not Running | 2/3 vs 0/3 | n/a |
| States which parts remain unproven | n/a | 3/3 vs 0/3 |

The skill also made the task cheaper, not more expensive: 56k tokens against 81k,
and 285s against 428s. On eval 1 the baseline runs expanded the task into a Go
catalog constructor, an e2e module and a landing checklist that the prompt never
asked for. The skill-guided runs produced a definition and stopped.

## Points for review

- Most discriminators are verification discipline rather than output quality.
  They measure whether a run followed steps 6 and 7. They are not circular,
  because following those steps changed outcomes: both skill-guided eval 1 runs
  found the multi-instance requirement only after a single-instance draft failed
  `--strict`. But the suspend guard is currently the only pure correctness
  signal, which is thin.
- Expectations changed shape, from plain strings to objects with `text`,
  `measured` and `kind`. This embeds benchmark counts in the eval definition,
  which couples two things that were separate and will go stale as the skill
  changes. Happy to revert to the string form and keep only the new text.
- Eval 2 keeps its prompt, but `docs/catalog/batch-cronjob-v1.yaml` already
  ships, so both configurations can find the answer and no content expectation
  there can discriminate. It is retained for the verification expectations and
  documented as such.
- Eval 4 for Volcano Job is new and has not been run. Its expectations carry no
  measured counts and are derived from eval 1's patterns.

## Related issue(s)

Relates to #194. That issue asks for scale-semantics guidance in the skill and a
value-level eval that makes valid-but-wrong scale bugs catchable. This PR
addresses the general form of the second point, making the evals catch real
errors instead of passing trivially, but does not add the scale-specific
assertions or the guidance, so it does not close the issue.

## Checklist

- [x] All commits are signed off with DCO (`git commit -s`)
- [x] New/modified files have SPDX license and copyright headers
- [x] Documentation updated (if applicable)
- [x] Tests pass (`make check`)
- [x] No proprietary or internal information included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a benchmark report covering 18 runs across three evaluations, including assertion results, behavioral comparisons, verification findings, triggering, variance, environment considerations, and reproduction steps.
  * Expanded evaluation documentation with structured purposes, expectations, measured results, and expectation types.
  * Clarified that benchmark-floor claims apply only to measured expectations and that unmeasured evaluation results remain unestablished.
  * Documented unmeasured Volcano Job requirements, including multi-instance components, gang scheduling, status mapping, and replica handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->