### PR TITLE
docs: fix stale catalog links after samples rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ spec:
 
 The groups, roles, replica counts, GPU requests, and status conditions are all in there, but nested in fields that only LeaderWorkerSet-aware code knows how to find. RayCluster, JobSet, and every other workload type nests the same information differently.
 
-With the pre-built [LeaderWorkerSet Karta definition](docs/samples/lws.yaml), any tool can resolve that object and its live pods into a uniform structural view:
+With the pre-built [LeaderWorkerSet Karta definition](docs/catalog/leaderworkerset-x-k8s-io-leaderworkerset-v1.yaml), any tool can resolve that object and its live pods into a uniform structural view:
 
 ![Workload tree derived from the LeaderWorkerSet: demo (Running, 4 pods, 32 GPUs, gang scheduled per group) with two groups, each 2/2 ready with a leader pod and a worker pod at 8 GPUs each, resolved to their nodes](docs/assets/lws-workload-tree.svg)
 

--- a/docs/assets/lws-workload-tree.svg
+++ b/docs/assets/lws-workload-tree.svg
@@ -97,5 +97,5 @@
   </g>
 
   <!-- footer -->
-  <text x="24" y="446" font-size="11.5" fill="#8b949e">Derived from docs/samples/lws.yaml &#183; no LeaderWorkerSet-specific code</text>
+  <text x="24" y="446" font-size="11.5" fill="#8b949e">Derived from docs/catalog/leaderworkerset-x-k8s-io-leaderworkerset-v1.yaml &#183; no LeaderWorkerSet-specific code</text>
 </svg>

--- a/skills/add-workload-type/reference/sample-index.md
+++ b/skills/add-workload-type/reference/sample-index.md
@@ -44,13 +44,15 @@ multi-instance or nested pattern (for example Ray worker groups needing
 
 - Single full pod template: `podTemplateSpecPath`. See `batch-job-v1.yaml`.
 - Bare pod spec with separate metadata: `podSpecPath` plus `metadataPath`. See
-  the transformer child in `kserve.yaml`.
-- Scattered fields: `fragmentedPodSpecDefinition`. See `dynamo-v1beta1.yaml`.
+  the transformer child in `serving-kserve-io-inferenceservice-v1beta1.yaml`.
+- Scattered fields: `fragmentedPodSpecDefinition`. See
+  `nvidia-com-dynamographdeployment-v1beta1.yaml`.
 - Conditions status: `conditionsDefinition` plus `byConditions`. See
-  `rayservice.yaml`, which also uses `reason` to separate degraded from failed.
-- Phase status: `phaseDefinition` plus `byPhase`. See `raycluster.yaml`.
+  `ray-io-rayservice-v1.yaml`, which also uses `reason` to separate degraded from
+  failed.
+- Phase status: `phaseDefinition` plus `byPhase`. See `ray-io-raycluster-v1.yaml`.
 - Expression status: `byExpression`. See `batch-job-v1.yaml`.
 - Per-instance identity: `instanceIdPath` plus `componentInstanceSelector`. See
-  `raycluster.yaml`.
+  `ray-io-raycluster-v1.yaml`.
 - Replica identity within identical sub-structures: `replicaSelector`. See
-  `lws.yaml`.
+  `leaderworkerset-x-k8s-io-leaderworkerset-v1.yaml`.


### PR DESCRIPTION
## What does this PR do?

fix stale catalog links after samples rename

## Checklist

- [x] All commits are signed off with DCO (`git commit -s`)
- [x] New/modified files have SPDX license and copyright headers
- [x] Documentation updated (if applicable)
- [x] Tests pass (`make check`)
- [x] No proprietary or internal information included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the LeaderWorkerSet example link to the current catalog location.
  * Refreshed pattern quick-reference links for transformer, pod specification, conditions, phase, per-instance, and replica identity examples.
  * Added Roadmap and Changelog links to the Documentation section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->