### PR TITLE
test(e2e): add the offline replay suite for the recorded fixtures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,11 @@ test: generate-mocks ## Run tests with mock generation
 	go test ./...
 	go -C test/e2e test ./recorder/...
 
+.PHONY: test-replay
+test-replay: ## Replay the recorded fixtures through Karta offline (no cluster)
+	go -C test/e2e build ./...
+	go -C test/e2e test ./replay_tests/...
+
 lint-go: golangci-lint
 	echo "Running golangci linter"
 	$(GOLANGCI_LINT) run -v -c .golangci.yml
@@ -158,7 +163,7 @@ cli-lint: golangci-lint ## Lint the CLI module.
 	cd cli && $(GOLANGCI_LINT) run -c $(PROJECT_DIR)/.golangci.yml
 
 .PHONY: check
-check: download-dependencies validate verify-recordings test cli-test cli-lint cli-verify-version
+check: download-dependencies validate verify-recordings test test-replay cli-test cli-lint cli-verify-version
 
 ##@ Helm
 

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -45,8 +45,10 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
+	github.com/samber/lo v1.53.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	go.uber.org/mock v0.6.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/mod v0.36.0 // indirect

--- a/test/e2e/go.sum
+++ b/test/e2e/go.sum
@@ -106,6 +106,8 @@ github.com/prometheus/procfs v0.19.2 h1:zUMhqEW66Ex7OXIiDkll3tl9a1ZdilUOd/F6ZXw4
 github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05ZpYlu+b4J7mw=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/samber/lo v1.53.0 h1:t975lj2py4kJPQ6haz1QMgtId2gtmfktACxIXArw3HM=
+github.com/samber/lo v1.53.0/go.mod h1:4+MXEGsJzbKGaUEQFKBq2xtfuznW9oz/WrgyzMzRoM0=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -131,6 +133,8 @@ github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+go.uber.org/mock v0.6.0 h1:hyF9dfmbgIX5EfOdasqLsWD6xqpNZlXblLB/Dbnwv3Y=
+go.uber.org/mock v0.6.0/go.mod h1:KiVJ4BqZJaMj4svdfmHM0AUx4NJYO8ZNpPnZn1Z+BBU=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.27.1 h1:08RqriUEv8+ArZRYSTXy1LeBScaMpVSTBhCeaZYfMYc=

--- a/test/e2e/replay_tests/status_test.go
+++ b/test/e2e/replay_tests/status_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package replay
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/yaml"
+
+	kartav1alpha1 "github.com/run-ai/karta/pkg/api/runai/v1alpha1"
+	"github.com/run-ai/karta/pkg/resource"
+	"github.com/run-ai/karta/test/e2e/recorder"
+)
+
+const (
+	repoRoot     = "../../.."
+	recordedGlob = "../recorded_data/*/*/*/*.yaml"
+)
+
+// Each recording is a real flow the recorder captured. Walk it step by step through the recording reader:
+// Karta must parse every CR, and the statuses it reads must include the state the recorder observed from
+// the CR's own fields.
+var _ = Describe("Karta reads the recorded state", func() {
+	recordings, _ := filepath.Glob(recordedGlob)
+	if len(recordings) == 0 {
+		It("has recordings to replay", func() {
+			Skip("no recordings under test/e2e/recorded_data; run make record-e2e")
+		})
+		return
+	}
+
+	for _, path := range recordings {
+		path := path
+		It(strings.TrimPrefix(path, "../recorded_data/"), func(ctx SpecContext) {
+			r, err := recorder.OpenRecording(path)
+			Expect(err).NotTo(HaveOccurred())
+
+			kartaYAML, err := os.ReadFile(filepath.Join(repoRoot, r.Recording().KartaFile))
+			Expect(err).NotTo(HaveOccurred())
+			karta := &kartav1alpha1.Karta{}
+			Expect(yaml.Unmarshal(kartaYAML, karta)).To(Succeed())
+
+			for r.Next() {
+				state, cr := r.State(), r.Object()
+				root, err := resource.NewComponentFactoryFromObject(karta, cr).GetRootComponent()
+				Expect(err).NotTo(HaveOccurred(), "Karta could not parse the %q CR", state)
+				status, err := root.GetStatus(ctx)
+				Expect(err).NotTo(HaveOccurred(), "Karta could not read the %q CR", state)
+				Expect(status).NotTo(BeNil(), "Karta read no status from the %q CR", state)
+				Expect(status.MatchedStatuses).To(ContainElement(kartav1alpha1.ResourceStatus(state)),
+					"Karta read %v, recorded state was %q", status.MatchedStatuses, state)
+			}
+		})
+	}
+})

--- a/test/e2e/replay_tests/status_test.go
+++ b/test/e2e/replay_tests/status_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Karta reads the recorded state", func() {
 	recordings, _ := filepath.Glob(recordedGlob)
 	if len(recordings) == 0 {
 		It("has recordings to replay", func() {
-			Skip("no recordings under test/e2e/recorded_data; run make record-e2e")
+			Fail("no recordings under test/e2e/recorded_data; run make record-e2e")
 		})
 		return
 	}
@@ -40,7 +40,10 @@ var _ = Describe("Karta reads the recorded state", func() {
 			r, err := recorder.OpenRecording(path)
 			Expect(err).NotTo(HaveOccurred())
 
-			kartaYAML, err := os.ReadFile(filepath.Join(repoRoot, r.Recording().KartaFile))
+			name := filepath.Base(r.Recording().KartaFile)
+			Expect(name).To(MatchRegexp(`^[a-zA-Z0-9._-]+\.yaml$`),
+				"recording %q names a suspicious KartaFile %q", path, r.Recording().KartaFile)
+			kartaYAML, err := os.ReadFile(filepath.Join(repoRoot, "docs", "catalog", name))
 			Expect(err).NotTo(HaveOccurred())
 			karta := &kartav1alpha1.Karta{}
 			Expect(yaml.Unmarshal(kartaYAML, karta)).To(Succeed())

--- a/test/e2e/replay_tests/suite_test.go
+++ b/test/e2e/replay_tests/suite_test.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package replay
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestReplay(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Karta Replay Suite")
+}


### PR DESCRIPTION
Closes #141.

Stacked on #256 (the pod flow and its fixtures) - part of the recorded-fixtures epic #137.

Walk every recording under `test/e2e/recorded_data` back through Karta: parse each captured CR and assert the statuses Karta reads include the state the recorder observed from the CR's own fields. Runs offline in under a second - no cluster, no operators.

- `make test-replay` runs it; `make check` now includes it
- `go mod tidy` adds the go.sum entries the library import pulls in

`make check` green locally (validate, lint, unit, replay, cli).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added offline end-to-end replay tests using recorded fixtures.
  * Replay tests validate that recorded resource states are parsed correctly and returned in status results.
  * Added replay testing to the standard project check workflow.
  * Tests verify fixture availability and validate each recording’s configuration and referenced files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->