### PR TITLE
fix(catalog): close workload state gaps found by e2e recording

### DIFF
--- a/docs/catalog/apps-deployment-v1.yaml
+++ b/docs/catalog/apps-deployment-v1.yaml
@@ -25,11 +25,9 @@ spec:
           reasonFieldName: reason
         statusMappings:
           initializing:
-            - byConditions:
-                - type: Progressing
-                  status: "True"
-                - type: Available
-                  status: "False"
+            - byExpression:
+                expression: (([.status.conditions[]? | select(.type == "Progressing" and .status == "True")] | length) > 0) and (([.status.conditions[]? | select(.type == "Available" and .status == "True")] | length) == 0)
+                expectedResult: "true"
           running:
             - byConditions:
                 - type: Progressing

--- a/docs/catalog/apps-nvidia-com-nimservice-v1alpha1.yaml
+++ b/docs/catalog/apps-nvidia-com-nimservice-v1alpha1.yaml
@@ -32,8 +32,9 @@ spec:
           messageFieldName: message
         statusMappings:
           initializing:
-            - byPhase: NotReady
-            - byPhase: Pending
+            - byExpression:
+                expression: (.status.state // "") != "Ready" and (.status.state // "") != "Failed"
+                expectedResult: "true"
           running:
             - byPhase: Ready
           failed:

--- a/docs/catalog/apps-statefulset-v1.yaml
+++ b/docs/catalog/apps-statefulset-v1.yaml
@@ -20,7 +20,7 @@ spec:
         statusMappings:
           initializing:
             - byExpression:
-                expression: (.spec.replicas // 1) > 0 and ((.status.observedGeneration // 0) != (.metadata.generation // 0) or (.status.readyReplicas // 0) == 0 or (.status.updatedReplicas // 0) != (.spec.replicas // 1) or (.status.currentRevision != .status.updateRevision))
+                expression: (.spec.replicas // 1) > 0 and ((.status.observedGeneration // 0) != (.metadata.generation // 0) or (.status.readyReplicas // 0) == 0 or (.status.readyReplicas // 0) > (.spec.replicas // 1) or (.status.updatedReplicas // 0) != (.spec.replicas // 1) or (.status.currentRevision != .status.updateRevision))
                 expectedResult: "true"
           running:
             - byExpression:

--- a/docs/catalog/batch-job-v1.yaml
+++ b/docs/catalog/batch-job-v1.yaml
@@ -36,9 +36,15 @@ spec:
             - byConditions:
                 - type: Complete
                   status: "True"
+            - byConditions:
+                - type: SuccessCriteriaMet
+                  status: "True"
           failed:
             - byConditions:
                 - type: Failed
+                  status: "True"
+            - byConditions:
+                - type: FailureTarget
                   status: "True"
           degraded:
             - byExpression:

--- a/docs/catalog/jobset-x-k8s-io-jobset-v1alpha2.yaml
+++ b/docs/catalog/jobset-x-k8s-io-jobset-v1alpha2.yaml
@@ -22,11 +22,11 @@ spec:
         statusMappings:
           initializing:
             - byExpression:
-                expression: (.status.replicatedJobsStatus // []) | any(.active > 0 and (.ready // 0) == 0) and all(.failed == 0)
+                expression: ((.status.replicatedJobsStatus // []) | length) > 0 and ((.status.replicatedJobsStatus // []) | all((.active // 0) == 0 and (.ready // 0) == 0)) and (([.status.conditions[]? | select((.type == "Completed" or .type == "Failed" or .type == "Suspended") and .status == "True")] | length) == 0)
                 expectedResult: "true"
           running:
             - byExpression:
-                expression: (.status.replicatedJobsStatus // []) | any(.ready > 0 and .active > 0) and all(.failed == 0)
+                expression: (.status.replicatedJobsStatus // []) | any((.active // 0) > 0 or (.ready // 0) > 0) and all((.failed // 0) == 0)
                 expectedResult: "true"
           completed:
             - byConditions:

--- a/docs/catalog/leaderworkerset-x-k8s-io-leaderworkerset-v1.yaml
+++ b/docs/catalog/leaderworkerset-x-k8s-io-leaderworkerset-v1.yaml
@@ -20,20 +20,13 @@ spec:
           messageFieldName: message
         statusMappings:
           initializing:
-            - byConditions:
-                - type: Progressing
-                  status: "True"
-                - type: Available
-                  status: "False"
+            - byExpression:
+                expression: (([.status.conditions[]? | select(.type == "Progressing" and .status == "True")] | length) > 0) and (([.status.conditions[]? | select(.type == "Available" and .status == "True")] | length) == 0)
+                expectedResult: "true"
           running:
             - byConditions:
                 - type: Available
                   status: "True"
-                  reason: AllGroupsReady
-                - type: Progressing
-                  status: "False"
-                - type: UpdateInProgress
-                  status: "False"
             - byExpression:
                 expression: (.status.replicas // 0) > 0 and .status.readyReplicas == .status.replicas and .status.updatedReplicas == .status.replicas
                 expectedResult: "true"

--- a/docs/catalog/milvus-io-milvus-v1beta1.yaml
+++ b/docs/catalog/milvus-io-milvus-v1beta1.yaml
@@ -22,6 +22,9 @@ spec:
         statusMappings:
           initializing:
             - byPhase: Pending
+            - byExpression:
+                expression: (.status.status // "") == ""
+                expectedResult: "true"
           running:
             - byPhase: Healthy
           degraded:

--- a/docs/catalog/nvidia-com-dynamographdeployment-v1alpha1.yaml
+++ b/docs/catalog/nvidia-com-dynamographdeployment-v1alpha1.yaml
@@ -19,6 +19,9 @@ spec:
           initializing:
             - byPhase: initializing
             - byPhase: pending
+            - byExpression:
+                expression: (.status.state // "") == ""
+                expectedResult: "true"
           running:
             - byPhase: successful
           failed:

--- a/docs/catalog/ray-io-raycluster-v1.yaml
+++ b/docs/catalog/ray-io-raycluster-v1.yaml
@@ -16,6 +16,10 @@ spec:
         phaseDefinition:
           path: .status.state
         statusMappings:
+          initializing:
+            - byExpression:
+                expression: (.spec.suspend != true) and (.status.state != "ready") and (.status.state != "failed")
+                expectedResult: "true"
           running:
             - byPhase: ready
           failed:

--- a/docs/catalog/ray-io-rayjob-v1.yaml
+++ b/docs/catalog/ray-io-rayjob-v1.yaml
@@ -23,6 +23,9 @@ spec:
         statusMappings:
           initializing:
             - byPhase: PENDING
+            - byExpression:
+                expression: (.status.jobStatus // "") == "" and (.status.jobDeploymentStatus // "") != "Suspended" and (.status.jobDeploymentStatus // "") != "Suspending"
+                expectedResult: "true"
           running:
             - byPhase: RUNNING
           completed:
@@ -31,7 +34,7 @@ spec:
             - byPhase: FAILED
           suspended:
             - byExpression:
-                expression: .status.jobDeploymentStatus == "Suspended"
+                expression: .status.jobDeploymentStatus == "Suspended" or .status.jobDeploymentStatus == "Suspending"
                 expectedResult: "true"
       suspendDefinition:
         suspendActions:

--- a/docs/catalog/serving-knative-dev-service-v1.yaml
+++ b/docs/catalog/serving-knative-dev-service-v1.yaml
@@ -19,10 +19,18 @@ spec:
           statusFieldName: status
           messageFieldName: message
         statusMappings:
+          initializing:
+            - byConditions:
+                - type: Ready
+                  status: Unknown
           running:
             - byConditions:
                 - type: Ready
                   status: "True"
+          failed:
+            - byConditions:
+                - type: Ready
+                  status: "False"
     childComponents:
       - name: revision
         kind:

--- a/docs/catalog/serving-kserve-io-inferenceservice-v1beta1.yaml
+++ b/docs/catalog/serving-kserve-io-inferenceservice-v1beta1.yaml
@@ -19,6 +19,10 @@ spec:
           statusFieldName: status
           messageFieldName: message
         statusMappings:
+          initializing:
+            - byExpression:
+                expression: (([.status.conditions[]? | select(.type == "Ready" and .status == "True")] | length) == 0) and (([.status.conditions[]? | select(.type == "Ready" and .status == "False")] | length) == 0)
+                expectedResult: "true"
           running:
             - byConditions:
                 - type: PredictorReady

--- a/pkg/catalog/kartas/batch_job.go
+++ b/pkg/catalog/kartas/batch_job.go
@@ -43,8 +43,14 @@ func BatchJob() *v1alpha1.Karta {
 								Expression:     "(.status.active // 0) > 0 and (.status.ready // 0) > 0",
 								ExpectedResult: "true",
 							}}},
-							Completed: []v1alpha1.StatusMatcher{{ByConditions: []v1alpha1.ExpectedCondition{{Type: "Complete", Status: ptr.To("True")}}}},
-							Failed:    []v1alpha1.StatusMatcher{{ByConditions: []v1alpha1.ExpectedCondition{{Type: "Failed", Status: ptr.To("True")}}}},
+							Completed: []v1alpha1.StatusMatcher{
+								{ByConditions: []v1alpha1.ExpectedCondition{{Type: "Complete", Status: ptr.To("True")}}},
+								{ByConditions: []v1alpha1.ExpectedCondition{{Type: "SuccessCriteriaMet", Status: ptr.To("True")}}},
+							},
+							Failed: []v1alpha1.StatusMatcher{
+								{ByConditions: []v1alpha1.ExpectedCondition{{Type: "Failed", Status: ptr.To("True")}}},
+								{ByConditions: []v1alpha1.ExpectedCondition{{Type: "FailureTarget", Status: ptr.To("True")}}},
+							},
 							Degraded: []v1alpha1.StatusMatcher{{ByExpression: &v1alpha1.ExpressionMatcher{
 								Expression:     ".spec.parallelism > 1 and (.status.ready // 0) < .spec.parallelism and ((.status.succeeded // 0) > 0 or (.status.failed // 0) > 0)",
 								ExpectedResult: "true",

--- a/pkg/catalog/kartas/deployment.go
+++ b/pkg/catalog/kartas/deployment.go
@@ -35,9 +35,11 @@ func Deployment() *v1alpha1.Karta {
 							ReasonFieldName:  ptr.To("reason"),
 						},
 						StatusMappings: v1alpha1.StatusMappings{
-							Initializing: []v1alpha1.StatusMatcher{{ByConditions: []v1alpha1.ExpectedCondition{
-								{Type: "Progressing", Status: ptr.To("True")},
-								{Type: "Available", Status: ptr.To("False")},
+							// Progressing while not yet Available: Available False, or absent (a just-created
+							// Deployment is Progressing/NewReplicaSetCreated before Available is written).
+							Initializing: []v1alpha1.StatusMatcher{{ByExpression: &v1alpha1.ExpressionMatcher{
+								Expression:     `(([.status.conditions[]? | select(.type == "Progressing" and .status == "True")] | length) > 0) and (([.status.conditions[]? | select(.type == "Available" and .status == "True")] | length) == 0)`,
+								ExpectedResult: "true",
 							}}},
 							Running: []v1alpha1.StatusMatcher{{ByConditions: []v1alpha1.ExpectedCondition{
 								{Type: "Progressing", Status: ptr.To("True"), Reason: ptr.To("NewReplicaSetAvailable")},

--- a/pkg/catalog/kartas/dynamo.go
+++ b/pkg/catalog/kartas/dynamo.go
@@ -27,6 +27,11 @@ func Dynamo() *v1alpha1.Karta {
 							Initializing: []v1alpha1.StatusMatcher{
 								{ByPhase: "initializing"},
 								{ByPhase: "pending"},
+								// Just created: the operator has not written status.state yet.
+								{ByExpression: &v1alpha1.ExpressionMatcher{
+									Expression:     `(.status.state // "") == ""`,
+									ExpectedResult: "true",
+								}},
 							},
 							Running: []v1alpha1.StatusMatcher{{ByPhase: "successful"}},
 							Failed:  []v1alpha1.StatusMatcher{{ByPhase: "failed"}},

--- a/pkg/catalog/kartas/jobset.go
+++ b/pkg/catalog/kartas/jobset.go
@@ -35,15 +35,18 @@ func Jobset() *v1alpha1.Karta {
 						},
 						StatusMappings: v1alpha1.StatusMappings{
 							Initializing: []v1alpha1.StatusMatcher{{ByExpression: &v1alpha1.ExpressionMatcher{
-								// Some replicatedJobs are active but none are ready yet.
-								// Guard against a null replicatedJobsStatus before the JobSet
-								// controller initializes status.
-								Expression:     "(.status.replicatedJobsStatus // []) | any(.active > 0 and (.ready // 0) == 0) and all(.failed == 0)",
+								// In progress with no working pods: status exists, no replicatedJob has
+								// active or ready pods, and no terminal or suspended condition is set.
+								// Covers a just-created JobSet (all counts zero) and the window after a
+								// job succeeds but before the JobSet-level Completed condition is set.
+								Expression:     "((.status.replicatedJobsStatus // []) | length) > 0 and ((.status.replicatedJobsStatus // []) | all((.active // 0) == 0 and (.ready // 0) == 0)) and (([.status.conditions[]? | select((.type == \"Completed\" or .type == \"Failed\" or .type == \"Suspended\") and .status == \"True\")] | length) == 0)",
 								ExpectedResult: "true",
 							}}},
 							Running: []v1alpha1.StatusMatcher{{ByExpression: &v1alpha1.ExpressionMatcher{
-								// Total ready across all replicatedJobs equals total expected replicas.
-								Expression:     "(.status.replicatedJobsStatus // []) | any(.ready > 0 and .active > 0) and all(.failed == 0)",
+								// Working: at least one replicatedJob has active or ready pods and none
+								// have failed. Reading either count (not both) keeps the state stable
+								// while the controller briefly flaps ready to 0 mid-run.
+								Expression:     "(.status.replicatedJobsStatus // []) | any((.active // 0) > 0 or (.ready // 0) > 0) and all((.failed // 0) == 0)",
 								ExpectedResult: "true",
 							}}},
 							Completed: []v1alpha1.StatusMatcher{{ByConditions: []v1alpha1.ExpectedCondition{{Type: "Completed", Status: ptr.To("True")}}}},

--- a/pkg/catalog/kartas/knative_serving.go
+++ b/pkg/catalog/kartas/knative_serving.go
@@ -30,6 +30,11 @@ func KnativeServing() *v1alpha1.Karta {
 						},
 						StatusMappings: v1alpha1.StatusMappings{
 							Running: []v1alpha1.StatusMatcher{{ByConditions: []v1alpha1.ExpectedCondition{{Type: "Ready", Status: ptr.To("True")}}}},
+							// Deploying: Ready is Unknown while the revision, route, and ingress
+							// come up (reasons OutOfDate, RevisionMissing, IngressNotConfigured,
+							// Uninitialized). Failed once Ready settles False.
+							Initializing: []v1alpha1.StatusMatcher{{ByConditions: []v1alpha1.ExpectedCondition{{Type: "Ready", Status: ptr.To("Unknown")}}}},
+							Failed:       []v1alpha1.StatusMatcher{{ByConditions: []v1alpha1.ExpectedCondition{{Type: "Ready", Status: ptr.To("False")}}}},
 						},
 					},
 				},

--- a/pkg/catalog/kartas/kserve.go
+++ b/pkg/catalog/kartas/kserve.go
@@ -34,6 +34,13 @@ func KServe() *v1alpha1.Karta {
 								{Type: "RoutesReady", Status: ptr.To("True")},
 								{Type: "LatestDeploymentReady", Status: ptr.To("True")},
 							}}},
+							// Deploying: Ready is not yet decided (absent early, then Unknown while
+							// the predictor, routes, and ingress come up). Failed is the specific
+							// all-False pattern below, where Ready is False, so this stays disjoint.
+							Initializing: []v1alpha1.StatusMatcher{{ByExpression: &v1alpha1.ExpressionMatcher{
+								Expression:     `(([.status.conditions[]? | select(.type == "Ready" and .status == "True")] | length) == 0) and (([.status.conditions[]? | select(.type == "Ready" and .status == "False")] | length) == 0)`,
+								ExpectedResult: "true",
+							}}},
 							Failed: []v1alpha1.StatusMatcher{{ByConditions: []v1alpha1.ExpectedCondition{
 								{Type: "PredictorReady", Status: ptr.To("False")},
 								{Type: "PredictorConfigurationReady", Status: ptr.To("False")},

--- a/pkg/catalog/kartas/lws.go
+++ b/pkg/catalog/kartas/lws.go
@@ -29,15 +29,21 @@ func LWS() *v1alpha1.Karta {
 							MessageFieldName: ptr.To("message"),
 						},
 						StatusMappings: v1alpha1.StatusMappings{
-							Initializing: []v1alpha1.StatusMatcher{{ByConditions: []v1alpha1.ExpectedCondition{
-								{Type: "Progressing", Status: ptr.To("True")},
-								{Type: "Available", Status: ptr.To("False")},
+							// Progressing while not yet available: Available False, or absent (a
+							// starting LeaderWorkerSet is Progressing before it writes Available).
+							Initializing: []v1alpha1.StatusMatcher{{ByExpression: &v1alpha1.ExpressionMatcher{
+								Expression:     `(([.status.conditions[]? | select(.type == "Progressing" and .status == "True")] | length) > 0) and (([.status.conditions[]? | select(.type == "Available" and .status == "True")] | length) == 0)`,
+								ExpectedResult: "true",
 							}}},
+							// Available is the authoritative "all groups ready" signal and stays
+							// True while scaling down sheds an extra pod, so key on it alone rather
+							// than on the replica counts (which lag) or UpdateInProgress (which is
+							// absent mid-scale). This ConditionsDefinition does not extract reason,
+							// so match on status only. The replica-settled expression is a fallback
+							// for when the condition is not populated.
 							Running: []v1alpha1.StatusMatcher{
 								{ByConditions: []v1alpha1.ExpectedCondition{
-									{Type: "Available", Status: ptr.To("True"), Reason: ptr.To("AllGroupsReady")},
-									{Type: "Progressing", Status: ptr.To("False")},
-									{Type: "UpdateInProgress", Status: ptr.To("False")},
+									{Type: "Available", Status: ptr.To("True")},
 								}},
 								{ByExpression: &v1alpha1.ExpressionMatcher{
 									Expression:     "(.status.replicas // 0) > 0 and .status.readyReplicas == .status.replicas and .status.updatedReplicas == .status.replicas",

--- a/pkg/catalog/kartas/milvus.go
+++ b/pkg/catalog/kartas/milvus.go
@@ -37,6 +37,11 @@ func Milvus() *v1alpha1.Karta {
 							},
 							Initializing: []v1alpha1.StatusMatcher{
 								{ByPhase: "Pending"},
+								// Just created: the operator has not written status.status yet.
+								{ByExpression: &v1alpha1.ExpressionMatcher{
+									Expression:     `(.status.status // "") == ""`,
+									ExpectedResult: "true",
+								}},
 							},
 							Degraded: []v1alpha1.StatusMatcher{
 								{ByPhase: "Unhealthy"},

--- a/pkg/catalog/kartas/nimservice.go
+++ b/pkg/catalog/kartas/nimservice.go
@@ -45,10 +45,13 @@ func NIMService() *v1alpha1.Karta {
 							MessageFieldName: ptr.To("message"),
 						},
 						StatusMappings: v1alpha1.StatusMappings{
-							Initializing: []v1alpha1.StatusMatcher{
-								{ByPhase: "NotReady"},
-								{ByPhase: "Pending"},
-							},
+							// In progress: any state that is not the terminal Ready or Failed. Covers
+							// the empty just-created state and every intermediate the operator writes
+							// (PVC-Created, NotReady, Pending, ...).
+							Initializing: []v1alpha1.StatusMatcher{{ByExpression: &v1alpha1.ExpressionMatcher{
+								Expression:     `(.status.state // "") != "Ready" and (.status.state // "") != "Failed"`,
+								ExpectedResult: "true",
+							}}},
 							Running: []v1alpha1.StatusMatcher{
 								{ByPhase: "Ready"},
 							},

--- a/pkg/catalog/kartas/raycluster.go
+++ b/pkg/catalog/kartas/raycluster.go
@@ -32,6 +32,13 @@ func Raycluster() *v1alpha1.Karta {
 						StatusMappings: v1alpha1.StatusMappings{
 							Running: []v1alpha1.StatusMatcher{{ByPhase: "ready"}},
 							Failed:  []v1alpha1.StatusMatcher{{ByPhase: "failed"}},
+							// Converging toward ready: not suspended and state not yet "ready" or
+							// "failed". Covers a fresh provision (state empty) and the resume window
+							// where suspend is already false but state still lags at "suspended".
+							Initializing: []v1alpha1.StatusMatcher{{ByExpression: &v1alpha1.ExpressionMatcher{
+								Expression:     `(.spec.suspend != true) and (.status.state != "ready") and (.status.state != "failed")`,
+								ExpectedResult: "true",
+							}}},
 							Suspended: []v1alpha1.StatusMatcher{{ByExpression: &v1alpha1.ExpressionMatcher{
 								Expression:     `.spec.suspend == true and (.status.state == "suspended" or (.status.state | not))`,
 								ExpectedResult: "true",

--- a/pkg/catalog/kartas/rayjob.go
+++ b/pkg/catalog/kartas/rayjob.go
@@ -36,12 +36,23 @@ func Rayjob() *v1alpha1.Karta {
 							MessageFieldName: ptr.To("message"),
 						},
 						StatusMappings: v1alpha1.StatusMappings{
-							Initializing: []v1alpha1.StatusMatcher{{ByPhase: "PENDING"}},
-							Running:      []v1alpha1.StatusMatcher{{ByPhase: "RUNNING"}},
-							Completed:    []v1alpha1.StatusMatcher{{ByPhase: "SUCCEEDED"}},
-							Failed:       []v1alpha1.StatusMatcher{{ByPhase: "FAILED"}},
+							// PENDING once the job is queued, plus the provisioning window before
+							// that: jobStatus empty while the RayJob brings up its cluster and it is
+							// not suspended (jobDeploymentStatus Initializing/Running, or empty).
+							Initializing: []v1alpha1.StatusMatcher{
+								{ByPhase: "PENDING"},
+								{ByExpression: &v1alpha1.ExpressionMatcher{
+									Expression:     `(.status.jobStatus // "") == "" and (.status.jobDeploymentStatus // "") != "Suspended" and (.status.jobDeploymentStatus // "") != "Suspending"`,
+									ExpectedResult: "true",
+								}},
+							},
+							Running:   []v1alpha1.StatusMatcher{{ByPhase: "RUNNING"}},
+							Completed: []v1alpha1.StatusMatcher{{ByPhase: "SUCCEEDED"}},
+							Failed:    []v1alpha1.StatusMatcher{{ByPhase: "FAILED"}},
+							// Suspended or on the way there: the operator reports Suspending while it
+							// tears the cluster down before settling on Suspended.
 							Suspended: []v1alpha1.StatusMatcher{{ByExpression: &v1alpha1.ExpressionMatcher{
-								Expression:     `.status.jobDeploymentStatus == "Suspended"`,
+								Expression:     `.status.jobDeploymentStatus == "Suspended" or .status.jobDeploymentStatus == "Suspending"`,
 								ExpectedResult: "true",
 							}}},
 						},

--- a/pkg/catalog/kartas/statefulset.go
+++ b/pkg/catalog/kartas/statefulset.go
@@ -37,7 +37,7 @@ func StatefulSet() *v1alpha1.Karta {
 								ExpectedResult: "true",
 							}}},
 							Initializing: []v1alpha1.StatusMatcher{{ByExpression: &v1alpha1.ExpressionMatcher{
-								Expression:     "(.spec.replicas // 1) > 0 and ((.status.observedGeneration // 0) != (.metadata.generation // 0) or (.status.readyReplicas // 0) == 0 or (.status.updatedReplicas // 0) != (.spec.replicas // 1) or (.status.currentRevision != .status.updateRevision))",
+								Expression:     "(.spec.replicas // 1) > 0 and ((.status.observedGeneration // 0) != (.metadata.generation // 0) or (.status.readyReplicas // 0) == 0 or (.status.readyReplicas // 0) > (.spec.replicas // 1) or (.status.updatedReplicas // 0) != (.spec.replicas // 1) or (.status.currentRevision != .status.updateRevision))",
 								ExpectedResult: "true",
 							}}},
 						},


### PR DESCRIPTION
Part of #137. Supersedes #252 (same content, cherry-picked into the stack): the catalog state gaps found by e2e recording, placed below the flow layers so their fixtures replay green. #252 can be closed.