### PR TITLE
test(e2e): add the jobset flow and its recorded fixtures

### DIFF
--- a/test/e2e/flows/actions.go
+++ b/test/e2e/flows/actions.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package flows
+
+import (
+	"fmt"
+
+	"github.com/run-ai/karta/test/e2e/recorder"
+)
+
+// Flow actions: each builds a recorder.Action, the merge-patch a flow fires to drive a transition the
+// operator will not make itself.
+
+// Resume clears spec.suspend so a suspended workload resumes.
+func Resume() *recorder.Action {
+	return &recorder.Action{Type: recorder.ActionResume, Patch: []byte(`{"spec":{"suspend":false}}`)}
+}
+
+// ScaleParallelism sets a batch Job's spec.parallelism.
+func ScaleParallelism(n int) *recorder.Action {
+	return &recorder.Action{Type: recorder.ActionScale, Patch: []byte(fmt.Sprintf(`{"spec":{"parallelism":%d}}`, n))}
+}
+
+// ScaleReplicas sets spec.replicas, for any workload with a scalar replica count (Deployment,
+// StatefulSet, LeaderWorkerSet, Grove, ...).
+func ScaleReplicas(n int) *recorder.Action {
+	return &recorder.Action{Type: recorder.ActionScale, Patch: []byte(fmt.Sprintf(`{"spec":{"replicas":%d}}`, n))}
+}
+
+// ResumeRunPolicy clears spec.runPolicy.suspend, where Kubeflow jobs (PyTorchJob, MPIJob) keep the suspend
+// flag, unlike the top-level spec.suspend that Resume patches.
+func ResumeRunPolicy() *recorder.Action {
+	return &recorder.Action{Type: recorder.ActionResume, Patch: []byte(`{"spec":{"runPolicy":{"suspend":false}}}`)}
+}

--- a/test/e2e/flows/jobset_test.go
+++ b/test/e2e/flows/jobset_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package flows
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kartav1alpha1 "github.com/run-ai/karta/pkg/api/runai/v1alpha1"
+	"github.com/run-ai/karta/test/e2e/recorder"
+)
+
+var _ = Describe("JobSet", Ordered, Label("jobset"), func() {
+	var rec *recorder.Recorder
+	var fx recorder.Fixture
+
+	BeforeAll(func(ctx SpecContext) {
+		installKarta(ctx, "../../docs/catalog/jobset-x-k8s-io-jobset-v1alpha2.yaml", "jobset-x-k8s-io-jobset-v1alpha2")
+		// Suspended first so a lingering Suspended condition never masks real progress after a resume.
+		fx = recorder.Fixture{Operator: "jobset", Version: operatorVersion("jobset"), KartaName: "jobset-x-k8s-io-jobset-v1alpha2", KartaFile: "docs/catalog/jobset-x-k8s-io-jobset-v1alpha2.yaml"}
+		rec = recorder.New(cfg).
+			AddState(kartav1alpha1.SuspendedStatus, CondTrue("Suspended")).
+			AddState(kartav1alpha1.InitializingStatus, JobsetInitializing()).
+			AddState(kartav1alpha1.RunningStatus, JobsetRunning()).
+			AddState(kartav1alpha1.CompletedStatus, CondTrue("Completed")).
+			AddState(kartav1alpha1.FailedStatus, CondTrue("Failed"))
+	})
+
+	It("running", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "running", "testdata/jobset/running.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("completed", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "completed", "testdata/jobset/completed.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus),
+			recorder.Reaches(kartav1alpha1.InitializingStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.CompletedStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("failed", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "failed", "testdata/jobset/failed.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.InitializingStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.FailedStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("resumed", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "resumed", "testdata/jobset/resumed.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.SuspendedStatus).Do(Resume()),
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus),
+			recorder.Reaches(kartav1alpha1.InitializingStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.CompletedStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("suspended", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "suspended", "testdata/jobset/suspended.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.SuspendedStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+})

--- a/test/e2e/flows/predicates.go
+++ b/test/e2e/flows/predicates.go
@@ -9,12 +9,81 @@ import (
 	"github.com/run-ai/karta/test/e2e/recorder"
 )
 
-// State predicates: each reads a workload's own fields to recognise one state, never Karta.
+// CondTrue matches when any of the given condition types is present with status True.
+func CondTrue(condTypes ...string) recorder.StateCheck {
+	return func(u *unstructured.Unstructured) bool {
+		conds, _, _ := unstructured.NestedSlice(u.Object, "status", "conditions")
+		for _, c := range conds {
+			m, ok := c.(map[string]any)
+			if !ok || m["status"] != "True" {
+				continue
+			}
+			for _, t := range condTypes {
+				if m["type"] == t {
+					return true
+				}
+			}
+		}
+		return false
+	}
+}
 
-// PhaseEq matches when the string at the path equals want (a Pod is Running while status.phase is "Running").
 func PhaseEq(want string, path ...string) recorder.StateCheck {
 	return func(u *unstructured.Unstructured) bool {
 		got, _, _ := unstructured.NestedString(u.Object, path...)
 		return got == want
+	}
+}
+
+// JobsetRunning matches a JobSet with working pods: at least one replicatedJob has active or ready pods and
+// none have failed. Reading either count (not both) keeps the state stable while the controller briefly
+// flaps ready to 0 mid-run.
+func JobsetRunning() recorder.StateCheck {
+	return func(u *unstructured.Unstructured) bool {
+		rjs, _, _ := unstructured.NestedSlice(u.Object, "status", "replicatedJobsStatus")
+		anyWorking := false
+		for _, r := range rjs {
+			m, ok := r.(map[string]any)
+			if !ok {
+				continue
+			}
+			if failed, _, _ := unstructured.NestedInt64(m, "failed"); failed > 0 {
+				return false
+			}
+			ready, _, _ := unstructured.NestedInt64(m, "ready")
+			active, _, _ := unstructured.NestedInt64(m, "active")
+			if ready > 0 || active > 0 {
+				anyWorking = true
+			}
+		}
+		return anyWorking
+	}
+}
+
+// JobsetInitializing matches a JobSet in progress with no working pods: status exists, no replicatedJob
+// has active or ready pods, and no terminal or suspended condition is set. Covers a just-created JobSet
+// (all counts zero) and the window after a job succeeds but before the JobSet-level Completed condition is
+// set.
+func JobsetInitializing() recorder.StateCheck {
+	return func(u *unstructured.Unstructured) bool {
+		rjs, _, _ := unstructured.NestedSlice(u.Object, "status", "replicatedJobsStatus")
+		if len(rjs) == 0 {
+			return false
+		}
+		if CondTrue("Completed", "Failed", "Suspended")(u) {
+			return false
+		}
+		for _, r := range rjs {
+			m, ok := r.(map[string]any)
+			if !ok {
+				continue
+			}
+			ready, _, _ := unstructured.NestedInt64(m, "ready")
+			active, _, _ := unstructured.NestedInt64(m, "active")
+			if ready > 0 || active > 0 {
+				return false
+			}
+		}
+		return true
 	}
 }

--- a/test/e2e/flows/testdata/jobset/completed.yaml
+++ b/test/e2e/flows/testdata/jobset/completed.yaml
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A JobSet whose single replicated Job runs briefly and succeeds. The completed flow observes it
+# move Initializing -> Running -> Completed. sleep 20 with a readiness probe gives a stable
+# Initializing then Running window before the JobSet reports Completed.
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  name: karta-e2e-jobset-completed
+  namespace: default
+spec:
+  replicatedJobs:
+    - name: workers
+      replicas: 1
+      template:
+        spec:
+          parallelism: 1
+          completions: 1
+          backoffLimit: 0
+          template:
+            spec:
+              restartPolicy: Never
+              containers:
+                - name: worker
+                  image: busybox:1.36
+                  command: ["sh", "-c", "sleep 20"]
+                  readinessProbe:
+                    exec:
+                      command: ["true"]
+                    initialDelaySeconds: 6
+                    periodSeconds: 2
+                  resources:
+                    requests: {cpu: 50m, memory: 32Mi}

--- a/test/e2e/flows/testdata/jobset/failed.yaml
+++ b/test/e2e/flows/testdata/jobset/failed.yaml
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A JobSet whose replicated Job fails: the pod runs briefly then exits non-zero with no retries
+# (backoffLimit 0 and the default failure policy), so the Job fails and the JobSet reports Failed.
+# A readiness probe that never passes keeps the pod NotReady while it runs, so the JobSet fails
+# straight from Initializing and Karta never sees it Running.
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  name: karta-e2e-jobset-failed
+  namespace: default
+spec:
+  replicatedJobs:
+    - name: workers
+      replicas: 1
+      template:
+        spec:
+          parallelism: 1
+          completions: 1
+          backoffLimit: 0
+          template:
+            spec:
+              restartPolicy: Never
+              containers:
+                - name: worker
+                  image: busybox:1.36
+                  command: ["sh", "-c", "sleep 5; exit 1"]
+                  readinessProbe:
+                    exec:
+                      command: ["false"]
+                    initialDelaySeconds: 1
+                    periodSeconds: 2
+                  resources:
+                    requests: {cpu: 50m, memory: 32Mi}

--- a/test/e2e/flows/testdata/jobset/resumed.yaml
+++ b/test/e2e/flows/testdata/jobset/resumed.yaml
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A JobSet created already suspended. The resumed flow observes it Suspended, clears spec.suspend,
+# and the JobSet starts a replicated Job that runs to completion. sleep 20 with a readiness probe
+# gives a stable Running window before the JobSet reports Completed.
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  name: karta-e2e-jobset-resumed
+  namespace: default
+spec:
+  suspend: true
+  replicatedJobs:
+    - name: workers
+      replicas: 1
+      template:
+        spec:
+          parallelism: 1
+          completions: 1
+          backoffLimit: 0
+          template:
+            spec:
+              restartPolicy: Never
+              containers:
+                - name: worker
+                  image: busybox:1.36
+                  command: ["sh", "-c", "sleep 20"]
+                  readinessProbe:
+                    exec:
+                      command: ["true"]
+                    initialDelaySeconds: 6
+                    periodSeconds: 2
+                  resources:
+                    requests: {cpu: 50m, memory: 32Mi}

--- a/test/e2e/flows/testdata/jobset/running.yaml
+++ b/test/e2e/flows/testdata/jobset/running.yaml
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A JobSet with one long-running replicated Job. The running flow observes it initialize then
+# reach Running (a pod ready), and stops there; the pod sleeps well past the check so Running
+# is stable. A readiness probe gives a distinct Initializing then Running window.
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  name: karta-e2e-jobset-running
+  namespace: default
+spec:
+  replicatedJobs:
+    - name: workers
+      replicas: 1
+      template:
+        spec:
+          parallelism: 1
+          completions: 1
+          backoffLimit: 0
+          template:
+            spec:
+              restartPolicy: Never
+              containers:
+                - name: worker
+                  image: busybox:1.36
+                  command: ["sh", "-c", "sleep 300"]
+                  readinessProbe:
+                    exec:
+                      command: ["true"]
+                    initialDelaySeconds: 6
+                    periodSeconds: 2
+                  resources:
+                    requests: {cpu: 50m, memory: 32Mi}

--- a/test/e2e/flows/testdata/jobset/suspended.yaml
+++ b/test/e2e/flows/testdata/jobset/suspended.yaml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A JobSet created suspended (spec.suspend=true). The controller creates no child Jobs and sets the
+# Suspended condition, which the Karta library reads as Suspended.
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  name: karta-e2e-jobset-suspended
+  namespace: default
+spec:
+  suspend: true
+  replicatedJobs:
+    - name: workers
+      replicas: 1
+      template:
+        spec:
+          parallelism: 1
+          completions: 1
+          backoffLimit: 0
+          template:
+            spec:
+              restartPolicy: Never
+              containers:
+                - name: worker
+                  image: busybox:1.36
+                  command: ["true"]
+                  resources:
+                    requests: {cpu: 50m, memory: 32Mi}

--- a/test/e2e/recorded_data/jobset/v1.34.0/jobset-x-k8s-io-jobset-v1alpha2/completed.yaml
+++ b/test/e2e/recorded_data/jobset/v1.34.0/jobset-x-k8s-io-jobset-v1alpha2/completed.yaml
@@ -1,0 +1,383 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: jobset.x-k8s.io/v1alpha2
+    kind: JobSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:29:28Z"
+      generation: 1
+      name: karta-e2e-jobset-completed
+      namespace: test-8m4bc
+      uid: 026c7b4f-a72b-4366-ad39-5a7b650c9a61
+    spec:
+      network:
+        enableDNSHostnames: true
+        publishNotReadyAddresses: true
+      replicatedJobs:
+      - groupName: default
+        name: workers
+        replicas: 1
+        template:
+          metadata: {}
+          spec:
+            backoffLimit: 0
+            completionMode: Indexed
+            completions: 1
+            parallelism: 1
+            template:
+              metadata: {}
+              spec:
+                containers:
+                - command:
+                  - sh
+                  - -c
+                  - sleep 20
+                  image: busybox:1.36
+                  name: worker
+                  readinessProbe:
+                    exec:
+                      command:
+                      - "true"
+                    initialDelaySeconds: 6
+                    periodSeconds: 2
+                  resources:
+                    requests:
+                      cpu: 50m
+                      memory: 32Mi
+                restartPolicy: Never
+      startupPolicy:
+        startupPolicyOrder: AnyOrder
+      successPolicy:
+        operator: All
+    status:
+      replicatedJobsStatus:
+      - active: 0
+        failed: 0
+        name: workers
+        ready: 0
+        succeeded: 0
+        suspended: 0
+      restarts: 0
+  resourceVersion: "8733"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: jobset.x-k8s.io/v1alpha2
+    kind: JobSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:29:28Z"
+      generation: 1
+      name: karta-e2e-jobset-completed
+      namespace: test-8m4bc
+      uid: 026c7b4f-a72b-4366-ad39-5a7b650c9a61
+    spec:
+      network:
+        enableDNSHostnames: true
+        publishNotReadyAddresses: true
+      replicatedJobs:
+      - groupName: default
+        name: workers
+        replicas: 1
+        template:
+          metadata: {}
+          spec:
+            backoffLimit: 0
+            completionMode: Indexed
+            completions: 1
+            parallelism: 1
+            template:
+              metadata: {}
+              spec:
+                containers:
+                - command:
+                  - sh
+                  - -c
+                  - sleep 20
+                  image: busybox:1.36
+                  name: worker
+                  readinessProbe:
+                    exec:
+                      command:
+                      - "true"
+                    initialDelaySeconds: 6
+                    periodSeconds: 2
+                  resources:
+                    requests:
+                      cpu: 50m
+                      memory: 32Mi
+                restartPolicy: Never
+      startupPolicy:
+        startupPolicyOrder: AnyOrder
+      successPolicy:
+        operator: All
+    status:
+      replicatedJobsStatus:
+      - active: 1
+        failed: 0
+        name: workers
+        ready: 0
+        succeeded: 0
+        suspended: 0
+      restarts: 0
+  resourceVersion: "8740"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: jobset.x-k8s.io/v1alpha2
+    kind: JobSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:29:28Z"
+      generation: 1
+      name: karta-e2e-jobset-completed
+      namespace: test-8m4bc
+      uid: 026c7b4f-a72b-4366-ad39-5a7b650c9a61
+    spec:
+      network:
+        enableDNSHostnames: true
+        publishNotReadyAddresses: true
+      replicatedJobs:
+      - groupName: default
+        name: workers
+        replicas: 1
+        template:
+          metadata: {}
+          spec:
+            backoffLimit: 0
+            completionMode: Indexed
+            completions: 1
+            parallelism: 1
+            template:
+              metadata: {}
+              spec:
+                containers:
+                - command:
+                  - sh
+                  - -c
+                  - sleep 20
+                  image: busybox:1.36
+                  name: worker
+                  readinessProbe:
+                    exec:
+                      command:
+                      - "true"
+                    initialDelaySeconds: 6
+                    periodSeconds: 2
+                  resources:
+                    requests:
+                      cpu: 50m
+                      memory: 32Mi
+                restartPolicy: Never
+      startupPolicy:
+        startupPolicyOrder: AnyOrder
+      successPolicy:
+        operator: All
+    status:
+      replicatedJobsStatus:
+      - active: 1
+        failed: 0
+        name: workers
+        ready: 1
+        succeeded: 0
+        suspended: 0
+      restarts: 0
+  resourceVersion: "8823"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: jobset.x-k8s.io/v1alpha2
+    kind: JobSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:29:28Z"
+      generation: 1
+      name: karta-e2e-jobset-completed
+      namespace: test-8m4bc
+      uid: 026c7b4f-a72b-4366-ad39-5a7b650c9a61
+    spec:
+      network:
+        enableDNSHostnames: true
+        publishNotReadyAddresses: true
+      replicatedJobs:
+      - groupName: default
+        name: workers
+        replicas: 1
+        template:
+          metadata: {}
+          spec:
+            backoffLimit: 0
+            completionMode: Indexed
+            completions: 1
+            parallelism: 1
+            template:
+              metadata: {}
+              spec:
+                containers:
+                - command:
+                  - sh
+                  - -c
+                  - sleep 20
+                  image: busybox:1.36
+                  name: worker
+                  readinessProbe:
+                    exec:
+                      command:
+                      - "true"
+                    initialDelaySeconds: 6
+                    periodSeconds: 2
+                  resources:
+                    requests:
+                      cpu: 50m
+                      memory: 32Mi
+                restartPolicy: Never
+      startupPolicy:
+        startupPolicyOrder: AnyOrder
+      successPolicy:
+        operator: All
+    status:
+      replicatedJobsStatus:
+      - active: 1
+        failed: 0
+        name: workers
+        ready: 0
+        succeeded: 0
+        suspended: 0
+      restarts: 0
+  resourceVersion: "8933"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: jobset.x-k8s.io/v1alpha2
+    kind: JobSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:29:28Z"
+      generation: 1
+      name: karta-e2e-jobset-completed
+      namespace: test-8m4bc
+      uid: 026c7b4f-a72b-4366-ad39-5a7b650c9a61
+    spec:
+      network:
+        enableDNSHostnames: true
+        publishNotReadyAddresses: true
+      replicatedJobs:
+      - groupName: default
+        name: workers
+        replicas: 1
+        template:
+          metadata: {}
+          spec:
+            backoffLimit: 0
+            completionMode: Indexed
+            completions: 1
+            parallelism: 1
+            template:
+              metadata: {}
+              spec:
+                containers:
+                - command:
+                  - sh
+                  - -c
+                  - sleep 20
+                  image: busybox:1.36
+                  name: worker
+                  readinessProbe:
+                    exec:
+                      command:
+                      - "true"
+                    initialDelaySeconds: 6
+                    periodSeconds: 2
+                  resources:
+                    requests:
+                      cpu: 50m
+                      memory: 32Mi
+                restartPolicy: Never
+      startupPolicy:
+        startupPolicyOrder: AnyOrder
+      successPolicy:
+        operator: All
+    status:
+      replicatedJobsStatus:
+      - active: 0
+        failed: 0
+        name: workers
+        ready: 1
+        succeeded: 0
+        suspended: 0
+      restarts: 0
+  resourceVersion: "8943"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: jobset.x-k8s.io/v1alpha2
+    kind: JobSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:29:28Z"
+      generation: 1
+      name: karta-e2e-jobset-completed
+      namespace: test-8m4bc
+      uid: 026c7b4f-a72b-4366-ad39-5a7b650c9a61
+    spec:
+      network:
+        enableDNSHostnames: true
+        publishNotReadyAddresses: true
+      replicatedJobs:
+      - groupName: default
+        name: workers
+        replicas: 1
+        template:
+          metadata: {}
+          spec:
+            backoffLimit: 0
+            completionMode: Indexed
+            completions: 1
+            parallelism: 1
+            template:
+              metadata: {}
+              spec:
+                containers:
+                - command:
+                  - sh
+                  - -c
+                  - sleep 20
+                  image: busybox:1.36
+                  name: worker
+                  readinessProbe:
+                    exec:
+                      command:
+                      - "true"
+                    initialDelaySeconds: 6
+                    periodSeconds: 2
+                  resources:
+                    requests:
+                      cpu: 50m
+                      memory: 32Mi
+                restartPolicy: Never
+      startupPolicy:
+        startupPolicyOrder: AnyOrder
+      successPolicy:
+        operator: All
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:29:51Z"
+        message: jobset completed successfully
+        reason: AllJobsCompleted
+        status: "True"
+        type: Completed
+      replicatedJobsStatus:
+      - active: 0
+        failed: 0
+        name: workers
+        ready: 0
+        succeeded: 1
+        suspended: 0
+      restarts: 0
+      terminalState: Completed
+  resourceVersion: "8947"
+  state: Completed
+flow: completed
+kartaFile: docs/catalog/jobset-x-k8s-io-jobset-v1alpha2.yaml
+kartaName: jobset-x-k8s-io-jobset-v1alpha2
+operator: jobset
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Completed

--- a/test/e2e/recorded_data/jobset/v1.34.0/jobset-x-k8s-io-jobset-v1alpha2/failed.yaml
+++ b/test/e2e/recorded_data/jobset/v1.34.0/jobset-x-k8s-io-jobset-v1alpha2/failed.yaml
@@ -1,0 +1,262 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: jobset.x-k8s.io/v1alpha2
+    kind: JobSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:29:51Z"
+      generation: 1
+      name: karta-e2e-jobset-failed
+      namespace: test-8m4bc
+      uid: 0b88dc42-d339-4f98-a61d-def6b85e5f22
+    spec:
+      network:
+        enableDNSHostnames: true
+        publishNotReadyAddresses: true
+      replicatedJobs:
+      - groupName: default
+        name: workers
+        replicas: 1
+        template:
+          metadata: {}
+          spec:
+            backoffLimit: 0
+            completionMode: Indexed
+            completions: 1
+            parallelism: 1
+            template:
+              metadata: {}
+              spec:
+                containers:
+                - command:
+                  - sh
+                  - -c
+                  - sleep 5; exit 1
+                  image: busybox:1.36
+                  name: worker
+                  readinessProbe:
+                    exec:
+                      command:
+                      - "false"
+                    initialDelaySeconds: 1
+                    periodSeconds: 2
+                  resources:
+                    requests:
+                      cpu: 50m
+                      memory: 32Mi
+                restartPolicy: Never
+      startupPolicy:
+        startupPolicyOrder: AnyOrder
+      successPolicy:
+        operator: All
+    status:
+      replicatedJobsStatus:
+      - active: 0
+        failed: 0
+        name: workers
+        ready: 0
+        succeeded: 0
+        suspended: 0
+      restarts: 0
+  resourceVersion: "8961"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: jobset.x-k8s.io/v1alpha2
+    kind: JobSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:29:51Z"
+      generation: 1
+      name: karta-e2e-jobset-failed
+      namespace: test-8m4bc
+      uid: 0b88dc42-d339-4f98-a61d-def6b85e5f22
+    spec:
+      network:
+        enableDNSHostnames: true
+        publishNotReadyAddresses: true
+      replicatedJobs:
+      - groupName: default
+        name: workers
+        replicas: 1
+        template:
+          metadata: {}
+          spec:
+            backoffLimit: 0
+            completionMode: Indexed
+            completions: 1
+            parallelism: 1
+            template:
+              metadata: {}
+              spec:
+                containers:
+                - command:
+                  - sh
+                  - -c
+                  - sleep 5; exit 1
+                  image: busybox:1.36
+                  name: worker
+                  readinessProbe:
+                    exec:
+                      command:
+                      - "false"
+                    initialDelaySeconds: 1
+                    periodSeconds: 2
+                  resources:
+                    requests:
+                      cpu: 50m
+                      memory: 32Mi
+                restartPolicy: Never
+      startupPolicy:
+        startupPolicyOrder: AnyOrder
+      successPolicy:
+        operator: All
+    status:
+      replicatedJobsStatus:
+      - active: 1
+        failed: 0
+        name: workers
+        ready: 0
+        succeeded: 0
+        suspended: 0
+      restarts: 0
+  resourceVersion: "8967"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: jobset.x-k8s.io/v1alpha2
+    kind: JobSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:29:51Z"
+      generation: 1
+      name: karta-e2e-jobset-failed
+      namespace: test-8m4bc
+      uid: 0b88dc42-d339-4f98-a61d-def6b85e5f22
+    spec:
+      network:
+        enableDNSHostnames: true
+        publishNotReadyAddresses: true
+      replicatedJobs:
+      - groupName: default
+        name: workers
+        replicas: 1
+        template:
+          metadata: {}
+          spec:
+            backoffLimit: 0
+            completionMode: Indexed
+            completions: 1
+            parallelism: 1
+            template:
+              metadata: {}
+              spec:
+                containers:
+                - command:
+                  - sh
+                  - -c
+                  - sleep 5; exit 1
+                  image: busybox:1.36
+                  name: worker
+                  readinessProbe:
+                    exec:
+                      command:
+                      - "false"
+                    initialDelaySeconds: 1
+                    periodSeconds: 2
+                  resources:
+                    requests:
+                      cpu: 50m
+                      memory: 32Mi
+                restartPolicy: Never
+      startupPolicy:
+        startupPolicyOrder: AnyOrder
+      successPolicy:
+        operator: All
+    status:
+      replicatedJobsStatus:
+      - active: 0
+        failed: 0
+        name: workers
+        ready: 0
+        succeeded: 0
+        suspended: 0
+      restarts: 0
+  resourceVersion: "9047"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: jobset.x-k8s.io/v1alpha2
+    kind: JobSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:29:51Z"
+      generation: 1
+      name: karta-e2e-jobset-failed
+      namespace: test-8m4bc
+      uid: 0b88dc42-d339-4f98-a61d-def6b85e5f22
+    spec:
+      network:
+        enableDNSHostnames: true
+        publishNotReadyAddresses: true
+      replicatedJobs:
+      - groupName: default
+        name: workers
+        replicas: 1
+        template:
+          metadata: {}
+          spec:
+            backoffLimit: 0
+            completionMode: Indexed
+            completions: 1
+            parallelism: 1
+            template:
+              metadata: {}
+              spec:
+                containers:
+                - command:
+                  - sh
+                  - -c
+                  - sleep 5; exit 1
+                  image: busybox:1.36
+                  name: worker
+                  readinessProbe:
+                    exec:
+                      command:
+                      - "false"
+                    initialDelaySeconds: 1
+                    periodSeconds: 2
+                  resources:
+                    requests:
+                      cpu: 50m
+                      memory: 32Mi
+                restartPolicy: Never
+      startupPolicy:
+        startupPolicyOrder: AnyOrder
+      successPolicy:
+        operator: All
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:00Z"
+        message: 'jobset failed due to one or more job failures (first failed job:
+          karta-e2e-jobset-failed-workers-0)'
+        reason: FailedJobs
+        status: "True"
+        type: Failed
+      replicatedJobsStatus:
+      - active: 0
+        failed: 1
+        name: workers
+        ready: 0
+        succeeded: 0
+        suspended: 0
+      restarts: 0
+      terminalState: Failed
+  resourceVersion: "9051"
+  state: Failed
+flow: failed
+kartaFile: docs/catalog/jobset-x-k8s-io-jobset-v1alpha2.yaml
+kartaName: jobset-x-k8s-io-jobset-v1alpha2
+operator: jobset
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Failed

--- a/test/e2e/recorded_data/jobset/v1.34.0/jobset-x-k8s-io-jobset-v1alpha2/resumed.yaml
+++ b/test/e2e/recorded_data/jobset/v1.34.0/jobset-x-k8s-io-jobset-v1alpha2/resumed.yaml
@@ -1,0 +1,705 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: jobset.x-k8s.io/v1alpha2
+    kind: JobSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:00Z"
+      generation: 1
+      name: karta-e2e-jobset-resumed
+      namespace: test-8m4bc
+      uid: 86983e4e-83e7-4848-9f00-910898418dd4
+    spec:
+      network:
+        enableDNSHostnames: true
+        publishNotReadyAddresses: true
+      replicatedJobs:
+      - groupName: default
+        name: workers
+        replicas: 1
+        template:
+          metadata: {}
+          spec:
+            backoffLimit: 0
+            completionMode: Indexed
+            completions: 1
+            parallelism: 1
+            template:
+              metadata: {}
+              spec:
+                containers:
+                - command:
+                  - sh
+                  - -c
+                  - sleep 20
+                  image: busybox:1.36
+                  name: worker
+                  readinessProbe:
+                    exec:
+                      command:
+                      - "true"
+                    initialDelaySeconds: 6
+                    periodSeconds: 2
+                  resources:
+                    requests:
+                      cpu: 50m
+                      memory: 32Mi
+                restartPolicy: Never
+      startupPolicy:
+        startupPolicyOrder: AnyOrder
+      successPolicy:
+        operator: All
+      suspend: true
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:00Z"
+        message: jobset is suspended
+        reason: SuspendedJobs
+        status: "True"
+        type: Suspended
+      replicatedJobsStatus:
+      - active: 0
+        failed: 0
+        name: workers
+        ready: 0
+        succeeded: 0
+        suspended: 0
+      restarts: 0
+  resourceVersion: "9068"
+  state: Suspended
+- action:
+    name: Resume
+    operation:
+      patchType: application/merge-patch+json
+      payload:
+        spec:
+          suspend: false
+      verb: PATCH
+  kind: ACTION
+- kind: STATE
+  object:
+    apiVersion: jobset.x-k8s.io/v1alpha2
+    kind: JobSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:00Z"
+      generation: 1
+      name: karta-e2e-jobset-resumed
+      namespace: test-8m4bc
+      uid: 86983e4e-83e7-4848-9f00-910898418dd4
+    spec:
+      network:
+        enableDNSHostnames: true
+        publishNotReadyAddresses: true
+      replicatedJobs:
+      - groupName: default
+        name: workers
+        replicas: 1
+        template:
+          metadata: {}
+          spec:
+            backoffLimit: 0
+            completionMode: Indexed
+            completions: 1
+            parallelism: 1
+            template:
+              metadata: {}
+              spec:
+                containers:
+                - command:
+                  - sh
+                  - -c
+                  - sleep 20
+                  image: busybox:1.36
+                  name: worker
+                  readinessProbe:
+                    exec:
+                      command:
+                      - "true"
+                    initialDelaySeconds: 6
+                    periodSeconds: 2
+                  resources:
+                    requests:
+                      cpu: 50m
+                      memory: 32Mi
+                restartPolicy: Never
+      startupPolicy:
+        startupPolicyOrder: AnyOrder
+      successPolicy:
+        operator: All
+      suspend: true
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:00Z"
+        message: jobset is suspended
+        reason: SuspendedJobs
+        status: "True"
+        type: Suspended
+      replicatedJobsStatus:
+      - active: 0
+        failed: 0
+        name: workers
+        ready: 0
+        succeeded: 0
+        suspended: 1
+      restarts: 0
+  resourceVersion: "9070"
+  state: Suspended
+- kind: STATE
+  object:
+    apiVersion: jobset.x-k8s.io/v1alpha2
+    kind: JobSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:00Z"
+      generation: 2
+      name: karta-e2e-jobset-resumed
+      namespace: test-8m4bc
+      uid: 86983e4e-83e7-4848-9f00-910898418dd4
+    spec:
+      network:
+        enableDNSHostnames: true
+        publishNotReadyAddresses: true
+      replicatedJobs:
+      - groupName: default
+        name: workers
+        replicas: 1
+        template:
+          metadata: {}
+          spec:
+            backoffLimit: 0
+            completionMode: Indexed
+            completions: 1
+            parallelism: 1
+            template:
+              metadata: {}
+              spec:
+                containers:
+                - command:
+                  - sh
+                  - -c
+                  - sleep 20
+                  image: busybox:1.36
+                  name: worker
+                  readinessProbe:
+                    exec:
+                      command:
+                      - "true"
+                    initialDelaySeconds: 6
+                    periodSeconds: 2
+                  resources:
+                    requests:
+                      cpu: 50m
+                      memory: 32Mi
+                restartPolicy: Never
+      startupPolicy:
+        startupPolicyOrder: AnyOrder
+      successPolicy:
+        operator: All
+      suspend: false
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:00Z"
+        message: jobset is suspended
+        reason: SuspendedJobs
+        status: "True"
+        type: Suspended
+      replicatedJobsStatus:
+      - active: 0
+        failed: 0
+        name: workers
+        ready: 0
+        succeeded: 0
+        suspended: 1
+      restarts: 0
+  resourceVersion: "9071"
+  state: Suspended
+- kind: STATE
+  object:
+    apiVersion: jobset.x-k8s.io/v1alpha2
+    kind: JobSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:00Z"
+      generation: 2
+      name: karta-e2e-jobset-resumed
+      namespace: test-8m4bc
+      uid: 86983e4e-83e7-4848-9f00-910898418dd4
+    spec:
+      network:
+        enableDNSHostnames: true
+        publishNotReadyAddresses: true
+      replicatedJobs:
+      - groupName: default
+        name: workers
+        replicas: 1
+        template:
+          metadata: {}
+          spec:
+            backoffLimit: 0
+            completionMode: Indexed
+            completions: 1
+            parallelism: 1
+            template:
+              metadata: {}
+              spec:
+                containers:
+                - command:
+                  - sh
+                  - -c
+                  - sleep 20
+                  image: busybox:1.36
+                  name: worker
+                  readinessProbe:
+                    exec:
+                      command:
+                      - "true"
+                    initialDelaySeconds: 6
+                    periodSeconds: 2
+                  resources:
+                    requests:
+                      cpu: 50m
+                      memory: 32Mi
+                restartPolicy: Never
+      startupPolicy:
+        startupPolicyOrder: AnyOrder
+      successPolicy:
+        operator: All
+      suspend: false
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:00Z"
+        message: jobset is resumed
+        reason: ResumeJobs
+        status: "False"
+        type: Suspended
+      replicatedJobsStatus:
+      - active: 0
+        failed: 0
+        name: workers
+        ready: 0
+        succeeded: 0
+        suspended: 1
+      restarts: 0
+  resourceVersion: "9073"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: jobset.x-k8s.io/v1alpha2
+    kind: JobSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:00Z"
+      generation: 2
+      name: karta-e2e-jobset-resumed
+      namespace: test-8m4bc
+      uid: 86983e4e-83e7-4848-9f00-910898418dd4
+    spec:
+      network:
+        enableDNSHostnames: true
+        publishNotReadyAddresses: true
+      replicatedJobs:
+      - groupName: default
+        name: workers
+        replicas: 1
+        template:
+          metadata: {}
+          spec:
+            backoffLimit: 0
+            completionMode: Indexed
+            completions: 1
+            parallelism: 1
+            template:
+              metadata: {}
+              spec:
+                containers:
+                - command:
+                  - sh
+                  - -c
+                  - sleep 20
+                  image: busybox:1.36
+                  name: worker
+                  readinessProbe:
+                    exec:
+                      command:
+                      - "true"
+                    initialDelaySeconds: 6
+                    periodSeconds: 2
+                  resources:
+                    requests:
+                      cpu: 50m
+                      memory: 32Mi
+                restartPolicy: Never
+      startupPolicy:
+        startupPolicyOrder: AnyOrder
+      successPolicy:
+        operator: All
+      suspend: false
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:00Z"
+        message: jobset is resumed
+        reason: ResumeJobs
+        status: "False"
+        type: Suspended
+      replicatedJobsStatus:
+      - active: 0
+        failed: 0
+        name: workers
+        ready: 0
+        succeeded: 0
+        suspended: 0
+      restarts: 0
+  resourceVersion: "9076"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: jobset.x-k8s.io/v1alpha2
+    kind: JobSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:00Z"
+      generation: 2
+      name: karta-e2e-jobset-resumed
+      namespace: test-8m4bc
+      uid: 86983e4e-83e7-4848-9f00-910898418dd4
+    spec:
+      network:
+        enableDNSHostnames: true
+        publishNotReadyAddresses: true
+      replicatedJobs:
+      - groupName: default
+        name: workers
+        replicas: 1
+        template:
+          metadata: {}
+          spec:
+            backoffLimit: 0
+            completionMode: Indexed
+            completions: 1
+            parallelism: 1
+            template:
+              metadata: {}
+              spec:
+                containers:
+                - command:
+                  - sh
+                  - -c
+                  - sleep 20
+                  image: busybox:1.36
+                  name: worker
+                  readinessProbe:
+                    exec:
+                      command:
+                      - "true"
+                    initialDelaySeconds: 6
+                    periodSeconds: 2
+                  resources:
+                    requests:
+                      cpu: 50m
+                      memory: 32Mi
+                restartPolicy: Never
+      startupPolicy:
+        startupPolicyOrder: AnyOrder
+      successPolicy:
+        operator: All
+      suspend: false
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:00Z"
+        message: jobset is resumed
+        reason: ResumeJobs
+        status: "False"
+        type: Suspended
+      replicatedJobsStatus:
+      - active: 1
+        failed: 0
+        name: workers
+        ready: 0
+        succeeded: 0
+        suspended: 0
+      restarts: 0
+  resourceVersion: "9082"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: jobset.x-k8s.io/v1alpha2
+    kind: JobSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:00Z"
+      generation: 2
+      name: karta-e2e-jobset-resumed
+      namespace: test-8m4bc
+      uid: 86983e4e-83e7-4848-9f00-910898418dd4
+    spec:
+      network:
+        enableDNSHostnames: true
+        publishNotReadyAddresses: true
+      replicatedJobs:
+      - groupName: default
+        name: workers
+        replicas: 1
+        template:
+          metadata: {}
+          spec:
+            backoffLimit: 0
+            completionMode: Indexed
+            completions: 1
+            parallelism: 1
+            template:
+              metadata: {}
+              spec:
+                containers:
+                - command:
+                  - sh
+                  - -c
+                  - sleep 20
+                  image: busybox:1.36
+                  name: worker
+                  readinessProbe:
+                    exec:
+                      command:
+                      - "true"
+                    initialDelaySeconds: 6
+                    periodSeconds: 2
+                  resources:
+                    requests:
+                      cpu: 50m
+                      memory: 32Mi
+                restartPolicy: Never
+      startupPolicy:
+        startupPolicyOrder: AnyOrder
+      successPolicy:
+        operator: All
+      suspend: false
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:00Z"
+        message: jobset is resumed
+        reason: ResumeJobs
+        status: "False"
+        type: Suspended
+      replicatedJobsStatus:
+      - active: 1
+        failed: 0
+        name: workers
+        ready: 1
+        succeeded: 0
+        suspended: 0
+      restarts: 0
+  resourceVersion: "9164"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: jobset.x-k8s.io/v1alpha2
+    kind: JobSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:00Z"
+      generation: 2
+      name: karta-e2e-jobset-resumed
+      namespace: test-8m4bc
+      uid: 86983e4e-83e7-4848-9f00-910898418dd4
+    spec:
+      network:
+        enableDNSHostnames: true
+        publishNotReadyAddresses: true
+      replicatedJobs:
+      - groupName: default
+        name: workers
+        replicas: 1
+        template:
+          metadata: {}
+          spec:
+            backoffLimit: 0
+            completionMode: Indexed
+            completions: 1
+            parallelism: 1
+            template:
+              metadata: {}
+              spec:
+                containers:
+                - command:
+                  - sh
+                  - -c
+                  - sleep 20
+                  image: busybox:1.36
+                  name: worker
+                  readinessProbe:
+                    exec:
+                      command:
+                      - "true"
+                    initialDelaySeconds: 6
+                    periodSeconds: 2
+                  resources:
+                    requests:
+                      cpu: 50m
+                      memory: 32Mi
+                restartPolicy: Never
+      startupPolicy:
+        startupPolicyOrder: AnyOrder
+      successPolicy:
+        operator: All
+      suspend: false
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:00Z"
+        message: jobset is resumed
+        reason: ResumeJobs
+        status: "False"
+        type: Suspended
+      replicatedJobsStatus:
+      - active: 1
+        failed: 0
+        name: workers
+        ready: 0
+        succeeded: 0
+        suspended: 0
+      restarts: 0
+  resourceVersion: "9266"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: jobset.x-k8s.io/v1alpha2
+    kind: JobSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:00Z"
+      generation: 2
+      name: karta-e2e-jobset-resumed
+      namespace: test-8m4bc
+      uid: 86983e4e-83e7-4848-9f00-910898418dd4
+    spec:
+      network:
+        enableDNSHostnames: true
+        publishNotReadyAddresses: true
+      replicatedJobs:
+      - groupName: default
+        name: workers
+        replicas: 1
+        template:
+          metadata: {}
+          spec:
+            backoffLimit: 0
+            completionMode: Indexed
+            completions: 1
+            parallelism: 1
+            template:
+              metadata: {}
+              spec:
+                containers:
+                - command:
+                  - sh
+                  - -c
+                  - sleep 20
+                  image: busybox:1.36
+                  name: worker
+                  readinessProbe:
+                    exec:
+                      command:
+                      - "true"
+                    initialDelaySeconds: 6
+                    periodSeconds: 2
+                  resources:
+                    requests:
+                      cpu: 50m
+                      memory: 32Mi
+                restartPolicy: Never
+      startupPolicy:
+        startupPolicyOrder: AnyOrder
+      successPolicy:
+        operator: All
+      suspend: false
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:00Z"
+        message: jobset is resumed
+        reason: ResumeJobs
+        status: "False"
+        type: Suspended
+      replicatedJobsStatus:
+      - active: 0
+        failed: 0
+        name: workers
+        ready: 1
+        succeeded: 0
+        suspended: 0
+      restarts: 0
+  resourceVersion: "9276"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: jobset.x-k8s.io/v1alpha2
+    kind: JobSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:00Z"
+      generation: 2
+      name: karta-e2e-jobset-resumed
+      namespace: test-8m4bc
+      uid: 86983e4e-83e7-4848-9f00-910898418dd4
+    spec:
+      network:
+        enableDNSHostnames: true
+        publishNotReadyAddresses: true
+      replicatedJobs:
+      - groupName: default
+        name: workers
+        replicas: 1
+        template:
+          metadata: {}
+          spec:
+            backoffLimit: 0
+            completionMode: Indexed
+            completions: 1
+            parallelism: 1
+            template:
+              metadata: {}
+              spec:
+                containers:
+                - command:
+                  - sh
+                  - -c
+                  - sleep 20
+                  image: busybox:1.36
+                  name: worker
+                  readinessProbe:
+                    exec:
+                      command:
+                      - "true"
+                    initialDelaySeconds: 6
+                    periodSeconds: 2
+                  resources:
+                    requests:
+                      cpu: 50m
+                      memory: 32Mi
+                restartPolicy: Never
+      startupPolicy:
+        startupPolicyOrder: AnyOrder
+      successPolicy:
+        operator: All
+      suspend: false
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:00Z"
+        message: jobset is resumed
+        reason: ResumeJobs
+        status: "False"
+        type: Suspended
+      - lastTransitionTime: "2026-08-18T12:30:23Z"
+        message: jobset completed successfully
+        reason: AllJobsCompleted
+        status: "True"
+        type: Completed
+      replicatedJobsStatus:
+      - active: 0
+        failed: 0
+        name: workers
+        ready: 0
+        succeeded: 1
+        suspended: 0
+      restarts: 0
+      terminalState: Completed
+  resourceVersion: "9280"
+  state: Completed
+flow: resumed
+kartaFile: docs/catalog/jobset-x-k8s-io-jobset-v1alpha2.yaml
+kartaName: jobset-x-k8s-io-jobset-v1alpha2
+operator: jobset
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Completed

--- a/test/e2e/recorded_data/jobset/v1.34.0/jobset-x-k8s-io-jobset-v1alpha2/running.yaml
+++ b/test/e2e/recorded_data/jobset/v1.34.0/jobset-x-k8s-io-jobset-v1alpha2/running.yaml
@@ -1,0 +1,132 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: jobset.x-k8s.io/v1alpha2
+    kind: JobSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:29:28Z"
+      generation: 1
+      name: karta-e2e-jobset-running
+      namespace: test-8m4bc
+      uid: 28b754ca-4367-40ee-8e0c-f696fa5f64dd
+    spec:
+      network:
+        enableDNSHostnames: true
+        publishNotReadyAddresses: true
+      replicatedJobs:
+      - groupName: default
+        name: workers
+        replicas: 1
+        template:
+          metadata: {}
+          spec:
+            backoffLimit: 0
+            completionMode: Indexed
+            completions: 1
+            parallelism: 1
+            template:
+              metadata: {}
+              spec:
+                containers:
+                - command:
+                  - sh
+                  - -c
+                  - sleep 300
+                  image: busybox:1.36
+                  name: worker
+                  readinessProbe:
+                    exec:
+                      command:
+                      - "true"
+                    initialDelaySeconds: 6
+                    periodSeconds: 2
+                  resources:
+                    requests:
+                      cpu: 50m
+                      memory: 32Mi
+                restartPolicy: Never
+      startupPolicy:
+        startupPolicyOrder: AnyOrder
+      successPolicy:
+        operator: All
+    status:
+      replicatedJobsStatus:
+      - active: 0
+        failed: 0
+        name: workers
+        ready: 0
+        succeeded: 0
+        suspended: 0
+      restarts: 0
+  resourceVersion: "8714"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: jobset.x-k8s.io/v1alpha2
+    kind: JobSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:29:28Z"
+      generation: 1
+      name: karta-e2e-jobset-running
+      namespace: test-8m4bc
+      uid: 28b754ca-4367-40ee-8e0c-f696fa5f64dd
+    spec:
+      network:
+        enableDNSHostnames: true
+        publishNotReadyAddresses: true
+      replicatedJobs:
+      - groupName: default
+        name: workers
+        replicas: 1
+        template:
+          metadata: {}
+          spec:
+            backoffLimit: 0
+            completionMode: Indexed
+            completions: 1
+            parallelism: 1
+            template:
+              metadata: {}
+              spec:
+                containers:
+                - command:
+                  - sh
+                  - -c
+                  - sleep 300
+                  image: busybox:1.36
+                  name: worker
+                  readinessProbe:
+                    exec:
+                      command:
+                      - "true"
+                    initialDelaySeconds: 6
+                    periodSeconds: 2
+                  resources:
+                    requests:
+                      cpu: 50m
+                      memory: 32Mi
+                restartPolicy: Never
+      startupPolicy:
+        startupPolicyOrder: AnyOrder
+      successPolicy:
+        operator: All
+    status:
+      replicatedJobsStatus:
+      - active: 1
+        failed: 0
+        name: workers
+        ready: 0
+        succeeded: 0
+        suspended: 0
+      restarts: 0
+  resourceVersion: "8720"
+  state: Running
+flow: running
+kartaFile: docs/catalog/jobset-x-k8s-io-jobset-v1alpha2.yaml
+kartaName: jobset-x-k8s-io-jobset-v1alpha2
+operator: jobset
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Running

--- a/test/e2e/recorded_data/jobset/v1.34.0/jobset-x-k8s-io-jobset-v1alpha2/suspended.yaml
+++ b/test/e2e/recorded_data/jobset/v1.34.0/jobset-x-k8s-io-jobset-v1alpha2/suspended.yaml
@@ -1,0 +1,70 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: jobset.x-k8s.io/v1alpha2
+    kind: JobSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:23Z"
+      generation: 1
+      name: karta-e2e-jobset-suspended
+      namespace: test-8m4bc
+      uid: 58eebbcc-6f7a-4eb2-b6f7-7aa10cf5da63
+    spec:
+      network:
+        enableDNSHostnames: true
+        publishNotReadyAddresses: true
+      replicatedJobs:
+      - groupName: default
+        name: workers
+        replicas: 1
+        template:
+          metadata: {}
+          spec:
+            backoffLimit: 0
+            completionMode: Indexed
+            completions: 1
+            parallelism: 1
+            template:
+              metadata: {}
+              spec:
+                containers:
+                - command:
+                  - "true"
+                  image: busybox:1.36
+                  name: worker
+                  resources:
+                    requests:
+                      cpu: 50m
+                      memory: 32Mi
+                restartPolicy: Never
+      startupPolicy:
+        startupPolicyOrder: AnyOrder
+      successPolicy:
+        operator: All
+      suspend: true
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:23Z"
+        message: jobset is suspended
+        reason: SuspendedJobs
+        status: "True"
+        type: Suspended
+      replicatedJobsStatus:
+      - active: 0
+        failed: 0
+        name: workers
+        ready: 0
+        succeeded: 0
+        suspended: 0
+      restarts: 0
+  resourceVersion: "9297"
+  state: Suspended
+flow: suspended
+kartaFile: docs/catalog/jobset-x-k8s-io-jobset-v1alpha2.yaml
+kartaName: jobset-x-k8s-io-jobset-v1alpha2
+operator: jobset
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Suspended


### PR DESCRIPTION
Part of #139 - one workload type per PR, stacked. Adds the jobset flow: its spec steps, the predicates it judges stable states with (from the workload's own fields), and its recorded fixtures. Replayed offline by the suite in #260; `make check` green at every layer.