### PR TITLE
test(e2e): add the batch-job flow and its recorded fixtures

### DIFF
--- a/test/e2e/flows/batch_job_test.go
+++ b/test/e2e/flows/batch_job_test.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package flows
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kartav1alpha1 "github.com/run-ai/karta/pkg/api/runai/v1alpha1"
+	"github.com/run-ai/karta/test/e2e/recorder"
+)
+
+var _ = Describe("BatchJob (built-in)", Ordered, Label("batch-job", "builtin"), func() {
+	var rec *recorder.Recorder
+	var fx recorder.Fixture
+
+	BeforeAll(func(ctx SpecContext) {
+		installKarta(ctx, "../../docs/catalog/batch-job-v1.yaml", "batch-job-v1")
+		fx = recorder.Fixture{Operator: "batch-job", Version: operatorVersion("batch-job"), KartaName: "batch-job-v1", KartaFile: "docs/catalog/batch-job-v1.yaml"}
+		rec = recorder.New(cfg).
+			AddState(kartav1alpha1.SuspendedStatus, CondTrue("Suspended")).
+			AddState(kartav1alpha1.InitializingStatus, IntAtLeast(1, "status", "active")).
+			AddState(kartav1alpha1.RunningStatus, IntAtLeast(1, "status", "ready")).
+			AddState(kartav1alpha1.CompletedStatus, CondTrue("Complete", "SuccessCriteriaMet")).
+			AddState(kartav1alpha1.FailedStatus, CondTrue("Failed", "FailureTarget")).
+			AddState(kartav1alpha1.DegradedStatus, JobDegraded())
+	})
+
+	It("running", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "running", "testdata/batch-job/running.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("completed", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "completed", "testdata/batch-job/completed.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus),
+			recorder.Reaches(kartav1alpha1.InitializingStatus), // active-not-ready dip as the pod terminates
+			recorder.Reaches(kartav1alpha1.CompletedStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("failed", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "failed", "testdata/batch-job/failed.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.FailedStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("resumed", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "resumed", "testdata/batch-job/resumed.yaml").Through(
+			recorder.Reaches(kartav1alpha1.SuspendedStatus).Do(Resume()),
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus),
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.CompletedStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("degraded", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "degraded", "testdata/batch-job/degraded.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus),
+			recorder.Reaches(kartav1alpha1.DegradedStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("suspended", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "suspended", "testdata/batch-job/suspended.yaml").
+			Through(recorder.Reaches(kartav1alpha1.SuspendedStatus)).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("scaled", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "scaled", "testdata/batch-job/scaled.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.RunningStatus).With(IntEq(1, "status", "ready")).Do(ScaleParallelism(3)),
+			recorder.Reaches(kartav1alpha1.RunningStatus).With(IntEq(3, "status", "ready")).Do(ScaleParallelism(1)),
+			recorder.Reaches(kartav1alpha1.RunningStatus).With(IntEq(1, "status", "ready")),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+})

--- a/test/e2e/flows/predicates.go
+++ b/test/e2e/flows/predicates.go
@@ -35,6 +35,48 @@ func PhaseEq(want string, path ...string) recorder.StateCheck {
 	}
 }
 
+func IntAtLeast(n int64, path ...string) recorder.StateCheck {
+	return func(u *unstructured.Unstructured) bool {
+		got, found, err := unstructured.NestedInt64(u.Object, path...)
+		return err == nil && found && got >= n
+	}
+}
+
+// IntEq matches when the integer field at the given path is present and exactly n. It gates a scale flow's
+// step for a workload whose readiness count is a single field (Grove reports status.availableReplicas).
+func IntEq(n int64, path ...string) recorder.StateCheck {
+	return func(u *unstructured.Unstructured) bool {
+		got, found, err := unstructured.NestedInt64(u.Object, path...)
+		return err == nil && found && got == n
+	}
+}
+
+// ReplicasDegraded matches a settled-degraded workload: every desired replica created (updatedReplicas ==
+// spec.replicas) but some not ready (0 < readyReplicas < spec.replicas).
+func ReplicasDegraded() recorder.StateCheck {
+	return func(u *unstructured.Unstructured) bool {
+		desired, ok, _ := unstructured.NestedInt64(u.Object, "spec", "replicas")
+		if !ok {
+			desired = 1
+		}
+		ready, _, _ := unstructured.NestedInt64(u.Object, "status", "readyReplicas")
+		updated, _, _ := unstructured.NestedInt64(u.Object, "status", "updatedReplicas")
+		return desired > 0 && updated == desired && ready > 0 && ready < desired
+	}
+}
+
+// JobDegraded matches a parallel Job settled degraded: parallelism > 1, some but not all pods ready, and
+// at least one pod already succeeded or failed - the Job analog of ReplicasDegraded.
+func JobDegraded() recorder.StateCheck {
+	return func(u *unstructured.Unstructured) bool {
+		par, ok, _ := unstructured.NestedInt64(u.Object, "spec", "parallelism")
+		ready, _, _ := unstructured.NestedInt64(u.Object, "status", "ready")
+		succeeded, _, _ := unstructured.NestedInt64(u.Object, "status", "succeeded")
+		failedN, _, _ := unstructured.NestedInt64(u.Object, "status", "failed")
+		return ok && par > 1 && ready > 0 && ready < par && (succeeded > 0 || failedN > 0)
+	}
+}
+
 // JobsetRunning matches a JobSet with working pods: at least one replicatedJob has active or ready pods and
 // none have failed. Reading either count (not both) keeps the state stable while the controller briefly
 // flaps ready to 0 mid-run.

--- a/test/e2e/flows/testdata/batch-job/completed.yaml
+++ b/test/e2e/flows/testdata/batch-job/completed.yaml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A batch/v1 Job that runs briefly and succeeds. The completed flow observes it move Initializing ->
+# Running -> Completed. sleep 20 with a readiness probe gives a stable Initializing then Running
+# window before the Job reports Complete.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: karta-e2e-job-completed
+  namespace: default
+spec:
+  parallelism: 1
+  completions: 1
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: worker
+          image: busybox:1.36
+          command: ["sh", "-c", "sleep 20"]
+          readinessProbe:
+            exec:
+              command: ["true"]
+            initialDelaySeconds: 6
+            periodSeconds: 2
+          resources:
+            requests: {cpu: 50m, memory: 32Mi}

--- a/test/e2e/flows/testdata/batch-job/degraded.yaml
+++ b/test/e2e/flows/testdata/batch-job/degraded.yaml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# An Indexed Job (parallelism 2, completions 2): index 0 runs `true` and succeeds, index 1 sleeps
+# forever. So one pod succeeded while one stays ready-but-not-done - a settled partial that the Karta
+# library reads as Degraded (parallelism > 1, 0 < ready < parallelism, at least one succeeded).
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: karta-e2e-job-degraded
+  namespace: default
+spec:
+  completionMode: Indexed
+  completions: 2
+  parallelism: 2
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: worker
+          image: busybox:1.36
+          command: ["sh", "-c", "if [ \"$JOB_COMPLETION_INDEX\" = \"0\" ]; then true; else sleep infinity; fi"]
+          resources:
+            requests: {cpu: 50m, memory: 32Mi}

--- a/test/e2e/flows/testdata/batch-job/failed.yaml
+++ b/test/e2e/flows/testdata/batch-job/failed.yaml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A batch/v1 Job that fails: the pod runs briefly then exits non-zero with no retries (backoffLimit
+# 0), so the Job reports Failed. A readiness probe that never passes keeps the pod NotReady while it
+# runs, so the Job fails straight from Initializing and Karta never sees it Running.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: karta-e2e-job-failed
+  namespace: default
+spec:
+  parallelism: 1
+  completions: 1
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: worker
+          image: busybox:1.36
+          command: ["sh", "-c", "sleep 5; exit 1"]
+          readinessProbe:
+            exec:
+              command: ["false"]
+            initialDelaySeconds: 1
+            periodSeconds: 2
+          resources:
+            requests: {cpu: 50m, memory: 32Mi}

--- a/test/e2e/flows/testdata/batch-job/resumed.yaml
+++ b/test/e2e/flows/testdata/batch-job/resumed.yaml
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A batch/v1 Job created already suspended. The resumed flow observes it Suspended, clears
+# spec.suspend, and the Job starts a fresh pod that inits then runs to completion. sleep 20
+# with a readiness probe gives a stable Initializing then Running window on the single run.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: karta-e2e-job-resumed
+  namespace: default
+spec:
+  suspend: true
+  parallelism: 1
+  completions: 1
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: worker
+          image: busybox:1.36
+          command: ["sh", "-c", "sleep 20"]
+          readinessProbe:
+            exec:
+              command: ["true"]
+            initialDelaySeconds: 6
+            periodSeconds: 2
+          resources:
+            requests: {cpu: 50m, memory: 32Mi}

--- a/test/e2e/flows/testdata/batch-job/running.yaml
+++ b/test/e2e/flows/testdata/batch-job/running.yaml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A batch/v1 Job that runs long. The running flow observes it initialize then reach Running (a pod
+# ready) and stops there; the pod sleeps well past the check so Running is stable. A readiness probe
+# gives a distinct Initializing then Running window.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: karta-e2e-job-running
+  namespace: default
+spec:
+  parallelism: 1
+  completions: 1
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: worker
+          image: busybox:1.36
+          command: ["sh", "-c", "sleep 300"]
+          readinessProbe:
+            exec:
+              command: ["true"]
+            initialDelaySeconds: 6
+            periodSeconds: 2
+          resources:
+            requests: {cpu: 50m, memory: 32Mi}

--- a/test/e2e/flows/testdata/batch-job/scaled.yaml
+++ b/test/e2e/flows/testdata/batch-job/scaled.yaml
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A Job with sleeping pods and no completions, so it runs indefinitely with `parallelism` pods and
+# never finishes. The scaled flow drives spec.parallelism 1 -> 3 -> 1; status.ready follows, and Karta
+# reads Running at each settled count with a different extraction (the scale changes).
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: karta-e2e-job-scaled
+  namespace: default
+spec:
+  parallelism: 1
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: worker
+          image: busybox:1.36
+          command: ["sh", "-c", "sleep infinity"]
+          resources:
+            requests: {cpu: 20m, memory: 32Mi}

--- a/test/e2e/flows/testdata/batch-job/suspended.yaml
+++ b/test/e2e/flows/testdata/batch-job/suspended.yaml
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A Job created suspended (spec.suspend=true). The controller creates no pods and sets the Suspended
+# condition, which the Karta library reads as Suspended.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: karta-e2e-job-suspended
+  namespace: default
+spec:
+  suspend: true
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: worker
+          image: busybox:1.36
+          command: ["true"]
+          resources:
+            requests: {cpu: 50m, memory: 32Mi}

--- a/test/e2e/recorded_data/batch-job/v1.34.0/batch-job-v1/completed.yaml
+++ b/test/e2e/recorded_data/batch-job/v1.34.0/batch-job-v1/completed.yaml
@@ -1,0 +1,298 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      creationTimestamp: "2026-08-18T12:39:43Z"
+      generation: 1
+      labels:
+        batch.kubernetes.io/controller-uid: fbec88b8-3d6f-46cb-8038-72773d133388
+        batch.kubernetes.io/job-name: karta-e2e-job-completed
+        controller-uid: fbec88b8-3d6f-46cb-8038-72773d133388
+        job-name: karta-e2e-job-completed
+      name: karta-e2e-job-completed
+      namespace: test-8m4bc
+      uid: fbec88b8-3d6f-46cb-8038-72773d133388
+    spec:
+      backoffLimit: 0
+      completionMode: NonIndexed
+      completions: 1
+      manualSelector: false
+      parallelism: 1
+      podReplacementPolicy: TerminatingOrFailed
+      selector:
+        matchLabels:
+          batch.kubernetes.io/controller-uid: fbec88b8-3d6f-46cb-8038-72773d133388
+      suspend: false
+      template:
+        metadata:
+          labels:
+            batch.kubernetes.io/controller-uid: fbec88b8-3d6f-46cb-8038-72773d133388
+            batch.kubernetes.io/job-name: karta-e2e-job-completed
+            controller-uid: fbec88b8-3d6f-46cb-8038-72773d133388
+            job-name: karta-e2e-job-completed
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep 20
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            readinessProbe:
+              exec:
+                command:
+                - "true"
+              failureThreshold: 3
+              initialDelaySeconds: 6
+              periodSeconds: 2
+              successThreshold: 1
+              timeoutSeconds: 1
+            resources:
+              requests:
+                cpu: 50m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      active: 1
+      ready: 0
+      startTime: "2026-08-18T12:39:43Z"
+      terminating: 0
+      uncountedTerminatedPods: {}
+  resourceVersion: "15602"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      creationTimestamp: "2026-08-18T12:39:43Z"
+      generation: 1
+      labels:
+        batch.kubernetes.io/controller-uid: fbec88b8-3d6f-46cb-8038-72773d133388
+        batch.kubernetes.io/job-name: karta-e2e-job-completed
+        controller-uid: fbec88b8-3d6f-46cb-8038-72773d133388
+        job-name: karta-e2e-job-completed
+      name: karta-e2e-job-completed
+      namespace: test-8m4bc
+      uid: fbec88b8-3d6f-46cb-8038-72773d133388
+    spec:
+      backoffLimit: 0
+      completionMode: NonIndexed
+      completions: 1
+      manualSelector: false
+      parallelism: 1
+      podReplacementPolicy: TerminatingOrFailed
+      selector:
+        matchLabels:
+          batch.kubernetes.io/controller-uid: fbec88b8-3d6f-46cb-8038-72773d133388
+      suspend: false
+      template:
+        metadata:
+          labels:
+            batch.kubernetes.io/controller-uid: fbec88b8-3d6f-46cb-8038-72773d133388
+            batch.kubernetes.io/job-name: karta-e2e-job-completed
+            controller-uid: fbec88b8-3d6f-46cb-8038-72773d133388
+            job-name: karta-e2e-job-completed
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep 20
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            readinessProbe:
+              exec:
+                command:
+                - "true"
+              failureThreshold: 3
+              initialDelaySeconds: 6
+              periodSeconds: 2
+              successThreshold: 1
+              timeoutSeconds: 1
+            resources:
+              requests:
+                cpu: 50m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      active: 1
+      ready: 1
+      startTime: "2026-08-18T12:39:43Z"
+      terminating: 0
+      uncountedTerminatedPods: {}
+  resourceVersion: "15681"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      creationTimestamp: "2026-08-18T12:39:43Z"
+      generation: 1
+      labels:
+        batch.kubernetes.io/controller-uid: fbec88b8-3d6f-46cb-8038-72773d133388
+        batch.kubernetes.io/job-name: karta-e2e-job-completed
+        controller-uid: fbec88b8-3d6f-46cb-8038-72773d133388
+        job-name: karta-e2e-job-completed
+      name: karta-e2e-job-completed
+      namespace: test-8m4bc
+      uid: fbec88b8-3d6f-46cb-8038-72773d133388
+    spec:
+      backoffLimit: 0
+      completionMode: NonIndexed
+      completions: 1
+      manualSelector: false
+      parallelism: 1
+      podReplacementPolicy: TerminatingOrFailed
+      selector:
+        matchLabels:
+          batch.kubernetes.io/controller-uid: fbec88b8-3d6f-46cb-8038-72773d133388
+      suspend: false
+      template:
+        metadata:
+          labels:
+            batch.kubernetes.io/controller-uid: fbec88b8-3d6f-46cb-8038-72773d133388
+            batch.kubernetes.io/job-name: karta-e2e-job-completed
+            controller-uid: fbec88b8-3d6f-46cb-8038-72773d133388
+            job-name: karta-e2e-job-completed
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep 20
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            readinessProbe:
+              exec:
+                command:
+                - "true"
+              failureThreshold: 3
+              initialDelaySeconds: 6
+              periodSeconds: 2
+              successThreshold: 1
+              timeoutSeconds: 1
+            resources:
+              requests:
+                cpu: 50m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      active: 1
+      ready: 0
+      startTime: "2026-08-18T12:39:43Z"
+      terminating: 0
+      uncountedTerminatedPods: {}
+  resourceVersion: "15806"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      creationTimestamp: "2026-08-18T12:39:43Z"
+      generation: 1
+      labels:
+        batch.kubernetes.io/controller-uid: fbec88b8-3d6f-46cb-8038-72773d133388
+        batch.kubernetes.io/job-name: karta-e2e-job-completed
+        controller-uid: fbec88b8-3d6f-46cb-8038-72773d133388
+        job-name: karta-e2e-job-completed
+      name: karta-e2e-job-completed
+      namespace: test-8m4bc
+      uid: fbec88b8-3d6f-46cb-8038-72773d133388
+    spec:
+      backoffLimit: 0
+      completionMode: NonIndexed
+      completions: 1
+      manualSelector: false
+      parallelism: 1
+      podReplacementPolicy: TerminatingOrFailed
+      selector:
+        matchLabels:
+          batch.kubernetes.io/controller-uid: fbec88b8-3d6f-46cb-8038-72773d133388
+      suspend: false
+      template:
+        metadata:
+          labels:
+            batch.kubernetes.io/controller-uid: fbec88b8-3d6f-46cb-8038-72773d133388
+            batch.kubernetes.io/job-name: karta-e2e-job-completed
+            controller-uid: fbec88b8-3d6f-46cb-8038-72773d133388
+            job-name: karta-e2e-job-completed
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep 20
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            readinessProbe:
+              exec:
+                command:
+                - "true"
+              failureThreshold: 3
+              initialDelaySeconds: 6
+              periodSeconds: 2
+              successThreshold: 1
+              timeoutSeconds: 1
+            resources:
+              requests:
+                cpu: 50m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      conditions:
+      - lastProbeTime: "2026-08-18T12:40:06Z"
+        lastTransitionTime: "2026-08-18T12:40:06Z"
+        message: Reached expected number of succeeded pods
+        reason: CompletionsReached
+        status: "True"
+        type: SuccessCriteriaMet
+      ready: 0
+      startTime: "2026-08-18T12:39:43Z"
+      terminating: 0
+      uncountedTerminatedPods:
+        succeeded:
+        - 685d4cad-4b40-4e6e-b7de-a479eca7d93a
+  resourceVersion: "15818"
+  state: Completed
+flow: completed
+kartaFile: docs/catalog/batch-job-v1.yaml
+kartaName: batch-job-v1
+operator: batch-job
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Completed

--- a/test/e2e/recorded_data/batch-job/v1.34.0/batch-job-v1/degraded.yaml
+++ b/test/e2e/recorded_data/batch-job/v1.34.0/batch-job-v1/degraded.yaml
@@ -1,0 +1,198 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      creationTimestamp: "2026-08-18T12:40:37Z"
+      generation: 1
+      labels:
+        batch.kubernetes.io/controller-uid: a2e51ec7-720f-48c5-8db8-be9e58a2569a
+        batch.kubernetes.io/job-name: karta-e2e-job-degraded
+        controller-uid: a2e51ec7-720f-48c5-8db8-be9e58a2569a
+        job-name: karta-e2e-job-degraded
+      name: karta-e2e-job-degraded
+      namespace: test-8m4bc
+      uid: a2e51ec7-720f-48c5-8db8-be9e58a2569a
+    spec:
+      backoffLimit: 0
+      completionMode: Indexed
+      completions: 2
+      manualSelector: false
+      parallelism: 2
+      podReplacementPolicy: TerminatingOrFailed
+      selector:
+        matchLabels:
+          batch.kubernetes.io/controller-uid: a2e51ec7-720f-48c5-8db8-be9e58a2569a
+      suspend: false
+      template:
+        metadata:
+          labels:
+            batch.kubernetes.io/controller-uid: a2e51ec7-720f-48c5-8db8-be9e58a2569a
+            batch.kubernetes.io/job-name: karta-e2e-job-degraded
+            controller-uid: a2e51ec7-720f-48c5-8db8-be9e58a2569a
+            job-name: karta-e2e-job-degraded
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - if [ "$JOB_COMPLETION_INDEX" = "0" ]; then true; else sleep infinity;
+              fi
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 50m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      active: 2
+      ready: 0
+      startTime: "2026-08-18T12:40:37Z"
+      terminating: 0
+      uncountedTerminatedPods: {}
+  resourceVersion: "16122"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      creationTimestamp: "2026-08-18T12:40:37Z"
+      generation: 1
+      labels:
+        batch.kubernetes.io/controller-uid: a2e51ec7-720f-48c5-8db8-be9e58a2569a
+        batch.kubernetes.io/job-name: karta-e2e-job-degraded
+        controller-uid: a2e51ec7-720f-48c5-8db8-be9e58a2569a
+        job-name: karta-e2e-job-degraded
+      name: karta-e2e-job-degraded
+      namespace: test-8m4bc
+      uid: a2e51ec7-720f-48c5-8db8-be9e58a2569a
+    spec:
+      backoffLimit: 0
+      completionMode: Indexed
+      completions: 2
+      manualSelector: false
+      parallelism: 2
+      podReplacementPolicy: TerminatingOrFailed
+      selector:
+        matchLabels:
+          batch.kubernetes.io/controller-uid: a2e51ec7-720f-48c5-8db8-be9e58a2569a
+      suspend: false
+      template:
+        metadata:
+          labels:
+            batch.kubernetes.io/controller-uid: a2e51ec7-720f-48c5-8db8-be9e58a2569a
+            batch.kubernetes.io/job-name: karta-e2e-job-degraded
+            controller-uid: a2e51ec7-720f-48c5-8db8-be9e58a2569a
+            job-name: karta-e2e-job-degraded
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - if [ "$JOB_COMPLETION_INDEX" = "0" ]; then true; else sleep infinity;
+              fi
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 50m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      active: 2
+      ready: 1
+      startTime: "2026-08-18T12:40:37Z"
+      terminating: 0
+      uncountedTerminatedPods: {}
+  resourceVersion: "16145"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      creationTimestamp: "2026-08-18T12:40:37Z"
+      generation: 1
+      labels:
+        batch.kubernetes.io/controller-uid: a2e51ec7-720f-48c5-8db8-be9e58a2569a
+        batch.kubernetes.io/job-name: karta-e2e-job-degraded
+        controller-uid: a2e51ec7-720f-48c5-8db8-be9e58a2569a
+        job-name: karta-e2e-job-degraded
+      name: karta-e2e-job-degraded
+      namespace: test-8m4bc
+      uid: a2e51ec7-720f-48c5-8db8-be9e58a2569a
+    spec:
+      backoffLimit: 0
+      completionMode: Indexed
+      completions: 2
+      manualSelector: false
+      parallelism: 2
+      podReplacementPolicy: TerminatingOrFailed
+      selector:
+        matchLabels:
+          batch.kubernetes.io/controller-uid: a2e51ec7-720f-48c5-8db8-be9e58a2569a
+      suspend: false
+      template:
+        metadata:
+          labels:
+            batch.kubernetes.io/controller-uid: a2e51ec7-720f-48c5-8db8-be9e58a2569a
+            batch.kubernetes.io/job-name: karta-e2e-job-degraded
+            controller-uid: a2e51ec7-720f-48c5-8db8-be9e58a2569a
+            job-name: karta-e2e-job-degraded
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - if [ "$JOB_COMPLETION_INDEX" = "0" ]; then true; else sleep infinity;
+              fi
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 50m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      active: 1
+      completedIndexes: "0"
+      ready: 1
+      startTime: "2026-08-18T12:40:37Z"
+      succeeded: 1
+      terminating: 0
+      uncountedTerminatedPods: {}
+  resourceVersion: "16165"
+  state: Degraded
+flow: degraded
+kartaFile: docs/catalog/batch-job-v1.yaml
+kartaName: batch-job-v1
+operator: batch-job
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Degraded

--- a/test/e2e/recorded_data/batch-job/v1.34.0/batch-job-v1/failed.yaml
+++ b/test/e2e/recorded_data/batch-job/v1.34.0/batch-job-v1/failed.yaml
@@ -1,0 +1,158 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      creationTimestamp: "2026-08-18T12:40:06Z"
+      generation: 1
+      labels:
+        batch.kubernetes.io/controller-uid: c7df7489-c269-41ef-a41b-4eb99ef720b3
+        batch.kubernetes.io/job-name: karta-e2e-job-failed
+        controller-uid: c7df7489-c269-41ef-a41b-4eb99ef720b3
+        job-name: karta-e2e-job-failed
+      name: karta-e2e-job-failed
+      namespace: test-8m4bc
+      uid: c7df7489-c269-41ef-a41b-4eb99ef720b3
+    spec:
+      backoffLimit: 0
+      completionMode: NonIndexed
+      completions: 1
+      manualSelector: false
+      parallelism: 1
+      podReplacementPolicy: TerminatingOrFailed
+      selector:
+        matchLabels:
+          batch.kubernetes.io/controller-uid: c7df7489-c269-41ef-a41b-4eb99ef720b3
+      suspend: false
+      template:
+        metadata:
+          labels:
+            batch.kubernetes.io/controller-uid: c7df7489-c269-41ef-a41b-4eb99ef720b3
+            batch.kubernetes.io/job-name: karta-e2e-job-failed
+            controller-uid: c7df7489-c269-41ef-a41b-4eb99ef720b3
+            job-name: karta-e2e-job-failed
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep 5; exit 1
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            readinessProbe:
+              exec:
+                command:
+                - "false"
+              failureThreshold: 3
+              initialDelaySeconds: 1
+              periodSeconds: 2
+              successThreshold: 1
+              timeoutSeconds: 1
+            resources:
+              requests:
+                cpu: 50m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      active: 1
+      ready: 0
+      startTime: "2026-08-18T12:40:06Z"
+      terminating: 0
+      uncountedTerminatedPods: {}
+  resourceVersion: "15828"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      creationTimestamp: "2026-08-18T12:40:06Z"
+      generation: 1
+      labels:
+        batch.kubernetes.io/controller-uid: c7df7489-c269-41ef-a41b-4eb99ef720b3
+        batch.kubernetes.io/job-name: karta-e2e-job-failed
+        controller-uid: c7df7489-c269-41ef-a41b-4eb99ef720b3
+        job-name: karta-e2e-job-failed
+      name: karta-e2e-job-failed
+      namespace: test-8m4bc
+      uid: c7df7489-c269-41ef-a41b-4eb99ef720b3
+    spec:
+      backoffLimit: 0
+      completionMode: NonIndexed
+      completions: 1
+      manualSelector: false
+      parallelism: 1
+      podReplacementPolicy: TerminatingOrFailed
+      selector:
+        matchLabels:
+          batch.kubernetes.io/controller-uid: c7df7489-c269-41ef-a41b-4eb99ef720b3
+      suspend: false
+      template:
+        metadata:
+          labels:
+            batch.kubernetes.io/controller-uid: c7df7489-c269-41ef-a41b-4eb99ef720b3
+            batch.kubernetes.io/job-name: karta-e2e-job-failed
+            controller-uid: c7df7489-c269-41ef-a41b-4eb99ef720b3
+            job-name: karta-e2e-job-failed
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep 5; exit 1
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            readinessProbe:
+              exec:
+                command:
+                - "false"
+              failureThreshold: 3
+              initialDelaySeconds: 1
+              periodSeconds: 2
+              successThreshold: 1
+              timeoutSeconds: 1
+            resources:
+              requests:
+                cpu: 50m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      conditions:
+      - lastProbeTime: "2026-08-18T12:40:14Z"
+        lastTransitionTime: "2026-08-18T12:40:14Z"
+        message: Job has reached the specified backoff limit
+        reason: BackoffLimitExceeded
+        status: "True"
+        type: FailureTarget
+      ready: 0
+      startTime: "2026-08-18T12:40:06Z"
+      terminating: 0
+      uncountedTerminatedPods:
+        failed:
+        - 23fb763c-33bf-4801-a123-323d09372043
+  resourceVersion: "15899"
+  state: Failed
+flow: failed
+kartaFile: docs/catalog/batch-job-v1.yaml
+kartaName: batch-job-v1
+operator: batch-job
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Failed

--- a/test/e2e/recorded_data/batch-job/v1.34.0/batch-job-v1/resumed.yaml
+++ b/test/e2e/recorded_data/batch-job/v1.34.0/batch-job-v1/resumed.yaml
@@ -1,0 +1,484 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      creationTimestamp: "2026-08-18T12:40:14Z"
+      generation: 1
+      labels:
+        batch.kubernetes.io/controller-uid: 6c345d41-2919-429a-8196-137d22043143
+        batch.kubernetes.io/job-name: karta-e2e-job-resumed
+        controller-uid: 6c345d41-2919-429a-8196-137d22043143
+        job-name: karta-e2e-job-resumed
+      name: karta-e2e-job-resumed
+      namespace: test-8m4bc
+      uid: 6c345d41-2919-429a-8196-137d22043143
+    spec:
+      backoffLimit: 0
+      completionMode: NonIndexed
+      completions: 1
+      manualSelector: false
+      parallelism: 1
+      podReplacementPolicy: TerminatingOrFailed
+      selector:
+        matchLabels:
+          batch.kubernetes.io/controller-uid: 6c345d41-2919-429a-8196-137d22043143
+      suspend: true
+      template:
+        metadata:
+          labels:
+            batch.kubernetes.io/controller-uid: 6c345d41-2919-429a-8196-137d22043143
+            batch.kubernetes.io/job-name: karta-e2e-job-resumed
+            controller-uid: 6c345d41-2919-429a-8196-137d22043143
+            job-name: karta-e2e-job-resumed
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep 20
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            readinessProbe:
+              exec:
+                command:
+                - "true"
+              failureThreshold: 3
+              initialDelaySeconds: 6
+              periodSeconds: 2
+              successThreshold: 1
+              timeoutSeconds: 1
+            resources:
+              requests:
+                cpu: 50m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      conditions:
+      - lastProbeTime: "2026-08-18T12:40:14Z"
+        lastTransitionTime: "2026-08-18T12:40:14Z"
+        message: Job suspended
+        reason: JobSuspended
+        status: "True"
+        type: Suspended
+      ready: 0
+      terminating: 0
+      uncountedTerminatedPods: {}
+  resourceVersion: "15907"
+  state: Suspended
+- action:
+    name: Resume
+    operation:
+      patchType: application/merge-patch+json
+      payload:
+        spec:
+          suspend: false
+      verb: PATCH
+  kind: ACTION
+- kind: STATE
+  object:
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      creationTimestamp: "2026-08-18T12:40:14Z"
+      generation: 2
+      labels:
+        batch.kubernetes.io/controller-uid: 6c345d41-2919-429a-8196-137d22043143
+        batch.kubernetes.io/job-name: karta-e2e-job-resumed
+        controller-uid: 6c345d41-2919-429a-8196-137d22043143
+        job-name: karta-e2e-job-resumed
+      name: karta-e2e-job-resumed
+      namespace: test-8m4bc
+      uid: 6c345d41-2919-429a-8196-137d22043143
+    spec:
+      backoffLimit: 0
+      completionMode: NonIndexed
+      completions: 1
+      manualSelector: false
+      parallelism: 1
+      podReplacementPolicy: TerminatingOrFailed
+      selector:
+        matchLabels:
+          batch.kubernetes.io/controller-uid: 6c345d41-2919-429a-8196-137d22043143
+      suspend: false
+      template:
+        metadata:
+          labels:
+            batch.kubernetes.io/controller-uid: 6c345d41-2919-429a-8196-137d22043143
+            batch.kubernetes.io/job-name: karta-e2e-job-resumed
+            controller-uid: 6c345d41-2919-429a-8196-137d22043143
+            job-name: karta-e2e-job-resumed
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep 20
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            readinessProbe:
+              exec:
+                command:
+                - "true"
+              failureThreshold: 3
+              initialDelaySeconds: 6
+              periodSeconds: 2
+              successThreshold: 1
+              timeoutSeconds: 1
+            resources:
+              requests:
+                cpu: 50m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      conditions:
+      - lastProbeTime: "2026-08-18T12:40:14Z"
+        lastTransitionTime: "2026-08-18T12:40:14Z"
+        message: Job suspended
+        reason: JobSuspended
+        status: "True"
+        type: Suspended
+      ready: 0
+      terminating: 0
+      uncountedTerminatedPods: {}
+  resourceVersion: "15909"
+  state: Suspended
+- kind: STATE
+  object:
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      creationTimestamp: "2026-08-18T12:40:14Z"
+      generation: 2
+      labels:
+        batch.kubernetes.io/controller-uid: 6c345d41-2919-429a-8196-137d22043143
+        batch.kubernetes.io/job-name: karta-e2e-job-resumed
+        controller-uid: 6c345d41-2919-429a-8196-137d22043143
+        job-name: karta-e2e-job-resumed
+      name: karta-e2e-job-resumed
+      namespace: test-8m4bc
+      uid: 6c345d41-2919-429a-8196-137d22043143
+    spec:
+      backoffLimit: 0
+      completionMode: NonIndexed
+      completions: 1
+      manualSelector: false
+      parallelism: 1
+      podReplacementPolicy: TerminatingOrFailed
+      selector:
+        matchLabels:
+          batch.kubernetes.io/controller-uid: 6c345d41-2919-429a-8196-137d22043143
+      suspend: false
+      template:
+        metadata:
+          labels:
+            batch.kubernetes.io/controller-uid: 6c345d41-2919-429a-8196-137d22043143
+            batch.kubernetes.io/job-name: karta-e2e-job-resumed
+            controller-uid: 6c345d41-2919-429a-8196-137d22043143
+            job-name: karta-e2e-job-resumed
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep 20
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            readinessProbe:
+              exec:
+                command:
+                - "true"
+              failureThreshold: 3
+              initialDelaySeconds: 6
+              periodSeconds: 2
+              successThreshold: 1
+              timeoutSeconds: 1
+            resources:
+              requests:
+                cpu: 50m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      active: 1
+      conditions:
+      - lastProbeTime: "2026-08-18T12:40:14Z"
+        lastTransitionTime: "2026-08-18T12:40:14Z"
+        message: Job resumed
+        reason: JobResumed
+        status: "False"
+        type: Suspended
+      ready: 0
+      startTime: "2026-08-18T12:40:14Z"
+      terminating: 0
+      uncountedTerminatedPods: {}
+  resourceVersion: "15913"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      creationTimestamp: "2026-08-18T12:40:14Z"
+      generation: 2
+      labels:
+        batch.kubernetes.io/controller-uid: 6c345d41-2919-429a-8196-137d22043143
+        batch.kubernetes.io/job-name: karta-e2e-job-resumed
+        controller-uid: 6c345d41-2919-429a-8196-137d22043143
+        job-name: karta-e2e-job-resumed
+      name: karta-e2e-job-resumed
+      namespace: test-8m4bc
+      uid: 6c345d41-2919-429a-8196-137d22043143
+    spec:
+      backoffLimit: 0
+      completionMode: NonIndexed
+      completions: 1
+      manualSelector: false
+      parallelism: 1
+      podReplacementPolicy: TerminatingOrFailed
+      selector:
+        matchLabels:
+          batch.kubernetes.io/controller-uid: 6c345d41-2919-429a-8196-137d22043143
+      suspend: false
+      template:
+        metadata:
+          labels:
+            batch.kubernetes.io/controller-uid: 6c345d41-2919-429a-8196-137d22043143
+            batch.kubernetes.io/job-name: karta-e2e-job-resumed
+            controller-uid: 6c345d41-2919-429a-8196-137d22043143
+            job-name: karta-e2e-job-resumed
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep 20
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            readinessProbe:
+              exec:
+                command:
+                - "true"
+              failureThreshold: 3
+              initialDelaySeconds: 6
+              periodSeconds: 2
+              successThreshold: 1
+              timeoutSeconds: 1
+            resources:
+              requests:
+                cpu: 50m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      active: 1
+      conditions:
+      - lastProbeTime: "2026-08-18T12:40:14Z"
+        lastTransitionTime: "2026-08-18T12:40:14Z"
+        message: Job resumed
+        reason: JobResumed
+        status: "False"
+        type: Suspended
+      ready: 1
+      startTime: "2026-08-18T12:40:14Z"
+      terminating: 0
+      uncountedTerminatedPods: {}
+  resourceVersion: "15978"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      creationTimestamp: "2026-08-18T12:40:14Z"
+      generation: 2
+      labels:
+        batch.kubernetes.io/controller-uid: 6c345d41-2919-429a-8196-137d22043143
+        batch.kubernetes.io/job-name: karta-e2e-job-resumed
+        controller-uid: 6c345d41-2919-429a-8196-137d22043143
+        job-name: karta-e2e-job-resumed
+      name: karta-e2e-job-resumed
+      namespace: test-8m4bc
+      uid: 6c345d41-2919-429a-8196-137d22043143
+    spec:
+      backoffLimit: 0
+      completionMode: NonIndexed
+      completions: 1
+      manualSelector: false
+      parallelism: 1
+      podReplacementPolicy: TerminatingOrFailed
+      selector:
+        matchLabels:
+          batch.kubernetes.io/controller-uid: 6c345d41-2919-429a-8196-137d22043143
+      suspend: false
+      template:
+        metadata:
+          labels:
+            batch.kubernetes.io/controller-uid: 6c345d41-2919-429a-8196-137d22043143
+            batch.kubernetes.io/job-name: karta-e2e-job-resumed
+            controller-uid: 6c345d41-2919-429a-8196-137d22043143
+            job-name: karta-e2e-job-resumed
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep 20
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            readinessProbe:
+              exec:
+                command:
+                - "true"
+              failureThreshold: 3
+              initialDelaySeconds: 6
+              periodSeconds: 2
+              successThreshold: 1
+              timeoutSeconds: 1
+            resources:
+              requests:
+                cpu: 50m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      active: 1
+      conditions:
+      - lastProbeTime: "2026-08-18T12:40:14Z"
+        lastTransitionTime: "2026-08-18T12:40:14Z"
+        message: Job resumed
+        reason: JobResumed
+        status: "False"
+        type: Suspended
+      ready: 0
+      startTime: "2026-08-18T12:40:14Z"
+      terminating: 0
+      uncountedTerminatedPods: {}
+  resourceVersion: "16103"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      creationTimestamp: "2026-08-18T12:40:14Z"
+      generation: 2
+      labels:
+        batch.kubernetes.io/controller-uid: 6c345d41-2919-429a-8196-137d22043143
+        batch.kubernetes.io/job-name: karta-e2e-job-resumed
+        controller-uid: 6c345d41-2919-429a-8196-137d22043143
+        job-name: karta-e2e-job-resumed
+      name: karta-e2e-job-resumed
+      namespace: test-8m4bc
+      uid: 6c345d41-2919-429a-8196-137d22043143
+    spec:
+      backoffLimit: 0
+      completionMode: NonIndexed
+      completions: 1
+      manualSelector: false
+      parallelism: 1
+      podReplacementPolicy: TerminatingOrFailed
+      selector:
+        matchLabels:
+          batch.kubernetes.io/controller-uid: 6c345d41-2919-429a-8196-137d22043143
+      suspend: false
+      template:
+        metadata:
+          labels:
+            batch.kubernetes.io/controller-uid: 6c345d41-2919-429a-8196-137d22043143
+            batch.kubernetes.io/job-name: karta-e2e-job-resumed
+            controller-uid: 6c345d41-2919-429a-8196-137d22043143
+            job-name: karta-e2e-job-resumed
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep 20
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            readinessProbe:
+              exec:
+                command:
+                - "true"
+              failureThreshold: 3
+              initialDelaySeconds: 6
+              periodSeconds: 2
+              successThreshold: 1
+              timeoutSeconds: 1
+            resources:
+              requests:
+                cpu: 50m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      conditions:
+      - lastProbeTime: "2026-08-18T12:40:14Z"
+        lastTransitionTime: "2026-08-18T12:40:14Z"
+        message: Job resumed
+        reason: JobResumed
+        status: "False"
+        type: Suspended
+      - lastProbeTime: "2026-08-18T12:40:37Z"
+        lastTransitionTime: "2026-08-18T12:40:37Z"
+        message: Reached expected number of succeeded pods
+        reason: CompletionsReached
+        status: "True"
+        type: SuccessCriteriaMet
+      ready: 0
+      startTime: "2026-08-18T12:40:14Z"
+      terminating: 0
+      uncountedTerminatedPods:
+        succeeded:
+        - ad7b0023-11d6-4312-9b39-533b386a556d
+  resourceVersion: "16109"
+  state: Completed
+flow: resumed
+kartaFile: docs/catalog/batch-job-v1.yaml
+kartaName: batch-job-v1
+operator: batch-job
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Completed

--- a/test/e2e/recorded_data/batch-job/v1.34.0/batch-job-v1/running.yaml
+++ b/test/e2e/recorded_data/batch-job/v1.34.0/batch-job-v1/running.yaml
@@ -1,0 +1,150 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      creationTimestamp: "2026-08-18T12:39:36Z"
+      generation: 1
+      labels:
+        batch.kubernetes.io/controller-uid: 0b58d157-dd73-4598-8ee4-52484958ad36
+        batch.kubernetes.io/job-name: karta-e2e-job-running
+        controller-uid: 0b58d157-dd73-4598-8ee4-52484958ad36
+        job-name: karta-e2e-job-running
+      name: karta-e2e-job-running
+      namespace: test-8m4bc
+      uid: 0b58d157-dd73-4598-8ee4-52484958ad36
+    spec:
+      backoffLimit: 0
+      completionMode: NonIndexed
+      completions: 1
+      manualSelector: false
+      parallelism: 1
+      podReplacementPolicy: TerminatingOrFailed
+      selector:
+        matchLabels:
+          batch.kubernetes.io/controller-uid: 0b58d157-dd73-4598-8ee4-52484958ad36
+      suspend: false
+      template:
+        metadata:
+          labels:
+            batch.kubernetes.io/controller-uid: 0b58d157-dd73-4598-8ee4-52484958ad36
+            batch.kubernetes.io/job-name: karta-e2e-job-running
+            controller-uid: 0b58d157-dd73-4598-8ee4-52484958ad36
+            job-name: karta-e2e-job-running
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep 300
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            readinessProbe:
+              exec:
+                command:
+                - "true"
+              failureThreshold: 3
+              initialDelaySeconds: 6
+              periodSeconds: 2
+              successThreshold: 1
+              timeoutSeconds: 1
+            resources:
+              requests:
+                cpu: 50m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      active: 1
+      ready: 0
+      startTime: "2026-08-18T12:39:36Z"
+      terminating: 0
+      uncountedTerminatedPods: {}
+  resourceVersion: "15540"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      creationTimestamp: "2026-08-18T12:39:36Z"
+      generation: 1
+      labels:
+        batch.kubernetes.io/controller-uid: 0b58d157-dd73-4598-8ee4-52484958ad36
+        batch.kubernetes.io/job-name: karta-e2e-job-running
+        controller-uid: 0b58d157-dd73-4598-8ee4-52484958ad36
+        job-name: karta-e2e-job-running
+      name: karta-e2e-job-running
+      namespace: test-8m4bc
+      uid: 0b58d157-dd73-4598-8ee4-52484958ad36
+    spec:
+      backoffLimit: 0
+      completionMode: NonIndexed
+      completions: 1
+      manualSelector: false
+      parallelism: 1
+      podReplacementPolicy: TerminatingOrFailed
+      selector:
+        matchLabels:
+          batch.kubernetes.io/controller-uid: 0b58d157-dd73-4598-8ee4-52484958ad36
+      suspend: false
+      template:
+        metadata:
+          labels:
+            batch.kubernetes.io/controller-uid: 0b58d157-dd73-4598-8ee4-52484958ad36
+            batch.kubernetes.io/job-name: karta-e2e-job-running
+            controller-uid: 0b58d157-dd73-4598-8ee4-52484958ad36
+            job-name: karta-e2e-job-running
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep 300
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            readinessProbe:
+              exec:
+                command:
+                - "true"
+              failureThreshold: 3
+              initialDelaySeconds: 6
+              periodSeconds: 2
+              successThreshold: 1
+              timeoutSeconds: 1
+            resources:
+              requests:
+                cpu: 50m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      active: 1
+      ready: 1
+      startTime: "2026-08-18T12:39:36Z"
+      terminating: 0
+      uncountedTerminatedPods: {}
+  resourceVersion: "15594"
+  state: Running
+flow: running
+kartaFile: docs/catalog/batch-job-v1.yaml
+kartaName: batch-job-v1
+operator: batch-job
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Running

--- a/test/e2e/recorded_data/batch-job/v1.34.0/batch-job-v1/scaled.yaml
+++ b/test/e2e/recorded_data/batch-job/v1.34.0/batch-job-v1/scaled.yaml
@@ -1,0 +1,508 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      creationTimestamp: "2026-08-18T12:40:40Z"
+      generation: 1
+      labels:
+        batch.kubernetes.io/controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+        batch.kubernetes.io/job-name: karta-e2e-job-scaled
+        controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+        job-name: karta-e2e-job-scaled
+      name: karta-e2e-job-scaled
+      namespace: test-8m4bc
+      uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+    spec:
+      backoffLimit: 0
+      completionMode: NonIndexed
+      manualSelector: false
+      parallelism: 1
+      podReplacementPolicy: TerminatingOrFailed
+      selector:
+        matchLabels:
+          batch.kubernetes.io/controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+      suspend: false
+      template:
+        metadata:
+          labels:
+            batch.kubernetes.io/controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+            batch.kubernetes.io/job-name: karta-e2e-job-scaled
+            controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+            job-name: karta-e2e-job-scaled
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      active: 1
+      ready: 0
+      startTime: "2026-08-18T12:40:40Z"
+      terminating: 0
+      uncountedTerminatedPods: {}
+  resourceVersion: "16181"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      creationTimestamp: "2026-08-18T12:40:40Z"
+      generation: 1
+      labels:
+        batch.kubernetes.io/controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+        batch.kubernetes.io/job-name: karta-e2e-job-scaled
+        controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+        job-name: karta-e2e-job-scaled
+      name: karta-e2e-job-scaled
+      namespace: test-8m4bc
+      uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+    spec:
+      backoffLimit: 0
+      completionMode: NonIndexed
+      manualSelector: false
+      parallelism: 1
+      podReplacementPolicy: TerminatingOrFailed
+      selector:
+        matchLabels:
+          batch.kubernetes.io/controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+      suspend: false
+      template:
+        metadata:
+          labels:
+            batch.kubernetes.io/controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+            batch.kubernetes.io/job-name: karta-e2e-job-scaled
+            controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+            job-name: karta-e2e-job-scaled
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      active: 1
+      ready: 1
+      startTime: "2026-08-18T12:40:40Z"
+      terminating: 0
+      uncountedTerminatedPods: {}
+  resourceVersion: "16192"
+  state: Running
+- action:
+    name: Scale
+    operation:
+      patchType: application/merge-patch+json
+      payload:
+        spec:
+          parallelism: 3
+      verb: PATCH
+  kind: ACTION
+- kind: STATE
+  object:
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      creationTimestamp: "2026-08-18T12:40:40Z"
+      generation: 2
+      labels:
+        batch.kubernetes.io/controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+        batch.kubernetes.io/job-name: karta-e2e-job-scaled
+        controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+        job-name: karta-e2e-job-scaled
+      name: karta-e2e-job-scaled
+      namespace: test-8m4bc
+      uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+    spec:
+      backoffLimit: 0
+      completionMode: NonIndexed
+      manualSelector: false
+      parallelism: 3
+      podReplacementPolicy: TerminatingOrFailed
+      selector:
+        matchLabels:
+          batch.kubernetes.io/controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+      suspend: false
+      template:
+        metadata:
+          labels:
+            batch.kubernetes.io/controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+            batch.kubernetes.io/job-name: karta-e2e-job-scaled
+            controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+            job-name: karta-e2e-job-scaled
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      active: 1
+      ready: 1
+      startTime: "2026-08-18T12:40:40Z"
+      terminating: 0
+      uncountedTerminatedPods: {}
+  resourceVersion: "16193"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      creationTimestamp: "2026-08-18T12:40:40Z"
+      generation: 2
+      labels:
+        batch.kubernetes.io/controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+        batch.kubernetes.io/job-name: karta-e2e-job-scaled
+        controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+        job-name: karta-e2e-job-scaled
+      name: karta-e2e-job-scaled
+      namespace: test-8m4bc
+      uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+    spec:
+      backoffLimit: 0
+      completionMode: NonIndexed
+      manualSelector: false
+      parallelism: 3
+      podReplacementPolicy: TerminatingOrFailed
+      selector:
+        matchLabels:
+          batch.kubernetes.io/controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+      suspend: false
+      template:
+        metadata:
+          labels:
+            batch.kubernetes.io/controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+            batch.kubernetes.io/job-name: karta-e2e-job-scaled
+            controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+            job-name: karta-e2e-job-scaled
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      active: 3
+      ready: 1
+      startTime: "2026-08-18T12:40:40Z"
+      terminating: 0
+      uncountedTerminatedPods: {}
+  resourceVersion: "16201"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      creationTimestamp: "2026-08-18T12:40:40Z"
+      generation: 2
+      labels:
+        batch.kubernetes.io/controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+        batch.kubernetes.io/job-name: karta-e2e-job-scaled
+        controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+        job-name: karta-e2e-job-scaled
+      name: karta-e2e-job-scaled
+      namespace: test-8m4bc
+      uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+    spec:
+      backoffLimit: 0
+      completionMode: NonIndexed
+      manualSelector: false
+      parallelism: 3
+      podReplacementPolicy: TerminatingOrFailed
+      selector:
+        matchLabels:
+          batch.kubernetes.io/controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+      suspend: false
+      template:
+        metadata:
+          labels:
+            batch.kubernetes.io/controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+            batch.kubernetes.io/job-name: karta-e2e-job-scaled
+            controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+            job-name: karta-e2e-job-scaled
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      active: 3
+      ready: 2
+      startTime: "2026-08-18T12:40:40Z"
+      terminating: 0
+      uncountedTerminatedPods: {}
+  resourceVersion: "16219"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      creationTimestamp: "2026-08-18T12:40:40Z"
+      generation: 2
+      labels:
+        batch.kubernetes.io/controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+        batch.kubernetes.io/job-name: karta-e2e-job-scaled
+        controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+        job-name: karta-e2e-job-scaled
+      name: karta-e2e-job-scaled
+      namespace: test-8m4bc
+      uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+    spec:
+      backoffLimit: 0
+      completionMode: NonIndexed
+      manualSelector: false
+      parallelism: 3
+      podReplacementPolicy: TerminatingOrFailed
+      selector:
+        matchLabels:
+          batch.kubernetes.io/controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+      suspend: false
+      template:
+        metadata:
+          labels:
+            batch.kubernetes.io/controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+            batch.kubernetes.io/job-name: karta-e2e-job-scaled
+            controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+            job-name: karta-e2e-job-scaled
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      active: 3
+      ready: 3
+      startTime: "2026-08-18T12:40:40Z"
+      terminating: 0
+      uncountedTerminatedPods: {}
+  resourceVersion: "16226"
+  state: Running
+- action:
+    name: Scale
+    operation:
+      patchType: application/merge-patch+json
+      payload:
+        spec:
+          parallelism: 1
+      verb: PATCH
+  kind: ACTION
+- kind: STATE
+  object:
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      creationTimestamp: "2026-08-18T12:40:40Z"
+      generation: 3
+      labels:
+        batch.kubernetes.io/controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+        batch.kubernetes.io/job-name: karta-e2e-job-scaled
+        controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+        job-name: karta-e2e-job-scaled
+      name: karta-e2e-job-scaled
+      namespace: test-8m4bc
+      uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+    spec:
+      backoffLimit: 0
+      completionMode: NonIndexed
+      manualSelector: false
+      parallelism: 1
+      podReplacementPolicy: TerminatingOrFailed
+      selector:
+        matchLabels:
+          batch.kubernetes.io/controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+      suspend: false
+      template:
+        metadata:
+          labels:
+            batch.kubernetes.io/controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+            batch.kubernetes.io/job-name: karta-e2e-job-scaled
+            controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+            job-name: karta-e2e-job-scaled
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      active: 3
+      ready: 3
+      startTime: "2026-08-18T12:40:40Z"
+      terminating: 0
+      uncountedTerminatedPods: {}
+  resourceVersion: "16227"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      creationTimestamp: "2026-08-18T12:40:40Z"
+      generation: 3
+      labels:
+        batch.kubernetes.io/controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+        batch.kubernetes.io/job-name: karta-e2e-job-scaled
+        controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+        job-name: karta-e2e-job-scaled
+      name: karta-e2e-job-scaled
+      namespace: test-8m4bc
+      uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+    spec:
+      backoffLimit: 0
+      completionMode: NonIndexed
+      manualSelector: false
+      parallelism: 1
+      podReplacementPolicy: TerminatingOrFailed
+      selector:
+        matchLabels:
+          batch.kubernetes.io/controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+      suspend: false
+      template:
+        metadata:
+          labels:
+            batch.kubernetes.io/controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+            batch.kubernetes.io/job-name: karta-e2e-job-scaled
+            controller-uid: 5ce28fcc-dc67-44f1-b472-a14fa299724f
+            job-name: karta-e2e-job-scaled
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      active: 1
+      ready: 1
+      startTime: "2026-08-18T12:40:40Z"
+      terminating: 2
+      uncountedTerminatedPods: {}
+  resourceVersion: "16235"
+  state: Running
+flow: scaled
+kartaFile: docs/catalog/batch-job-v1.yaml
+kartaName: batch-job-v1
+operator: batch-job
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Running

--- a/test/e2e/recorded_data/batch-job/v1.34.0/batch-job-v1/suspended.yaml
+++ b/test/e2e/recorded_data/batch-job/v1.34.0/batch-job-v1/suspended.yaml
@@ -1,0 +1,74 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      creationTimestamp: "2026-08-18T12:40:40Z"
+      generation: 1
+      labels:
+        batch.kubernetes.io/controller-uid: 2308bebd-a98f-484c-9214-9b1a9a72842b
+        batch.kubernetes.io/job-name: karta-e2e-job-suspended
+        controller-uid: 2308bebd-a98f-484c-9214-9b1a9a72842b
+        job-name: karta-e2e-job-suspended
+      name: karta-e2e-job-suspended
+      namespace: test-8m4bc
+      uid: 2308bebd-a98f-484c-9214-9b1a9a72842b
+    spec:
+      backoffLimit: 0
+      completionMode: NonIndexed
+      completions: 1
+      manualSelector: false
+      parallelism: 1
+      podReplacementPolicy: TerminatingOrFailed
+      selector:
+        matchLabels:
+          batch.kubernetes.io/controller-uid: 2308bebd-a98f-484c-9214-9b1a9a72842b
+      suspend: true
+      template:
+        metadata:
+          labels:
+            batch.kubernetes.io/controller-uid: 2308bebd-a98f-484c-9214-9b1a9a72842b
+            batch.kubernetes.io/job-name: karta-e2e-job-suspended
+            controller-uid: 2308bebd-a98f-484c-9214-9b1a9a72842b
+            job-name: karta-e2e-job-suspended
+        spec:
+          containers:
+          - command:
+            - "true"
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 50m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      conditions:
+      - lastProbeTime: "2026-08-18T12:40:40Z"
+        lastTransitionTime: "2026-08-18T12:40:40Z"
+        message: Job suspended
+        reason: JobSuspended
+        status: "True"
+        type: Suspended
+      ready: 0
+      terminating: 0
+      uncountedTerminatedPods: {}
+  resourceVersion: "16174"
+  state: Suspended
+flow: suspended
+kartaFile: docs/catalog/batch-job-v1.yaml
+kartaName: batch-job-v1
+operator: batch-job
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Suspended


### PR DESCRIPTION
Part of #139 - one workload type per PR, stacked. Adds the batch-job flow: its spec steps, the predicates it judges stable states with (from the workload's own fields), and its recorded fixtures. Replayed offline by the suite in #260; `make check` green at every layer.