### PR TITLE
test(e2e): add the deployment flow and its recorded fixtures

### DIFF
--- a/test/e2e/flows/deployment_test.go
+++ b/test/e2e/flows/deployment_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package flows
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kartav1alpha1 "github.com/run-ai/karta/pkg/api/runai/v1alpha1"
+	"github.com/run-ai/karta/test/e2e/recorder"
+)
+
+var _ = Describe("Deployment (built-in)", Ordered, Label("deployment", "builtin"), func() {
+	var rec *recorder.Recorder
+	var fx recorder.Fixture
+
+	BeforeAll(func(ctx SpecContext) {
+		installKarta(ctx, "../../docs/catalog/apps-deployment-v1.yaml", "apps-deployment-v1")
+		fx = recorder.Fixture{Operator: "deployment", Version: operatorVersion("deployment"), KartaName: "apps-deployment-v1", KartaFile: "docs/catalog/apps-deployment-v1.yaml"}
+		rec = recorder.New(cfg).
+			AddState(kartav1alpha1.InitializingStatus, AllOf(CondTrue("Progressing"), CondNotTrue("Available"))).
+			AddState(kartav1alpha1.RunningStatus, CondReason("Progressing", "NewReplicaSetAvailable")).
+			AddState(kartav1alpha1.FailedStatus, CondFalse("Progressing"))
+	})
+
+	It("scaled", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "scaled", "testdata/deployment/running.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus).Optional(), // startup, before the first Running (Deployment stays Running while scaling)
+			recorder.Reaches(kartav1alpha1.RunningStatus).With(ReplicasReady(1)).Do(ScaleReplicas(3)),
+			recorder.Reaches(kartav1alpha1.RunningStatus).With(ReplicasReady(3)).Do(ScaleReplicas(1)),
+			recorder.Reaches(kartav1alpha1.RunningStatus).With(ReplicasReady(1)),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	// Bad image, no progress deadline: Progressing stays True with Available False, read as Initializing.
+	It("initializing", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "initializing", "testdata/deployment/initializing.yaml").
+			Through(recorder.Reaches(kartav1alpha1.InitializingStatus)).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	// Pinned to a nonexistent node with a 10s progress deadline: Progressing=False/ProgressDeadlineExceeded,
+	// read as Failed. It passes through Initializing first.
+	It("failed", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "failed", "testdata/deployment/failed.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.FailedStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+})

--- a/test/e2e/flows/predicates.go
+++ b/test/e2e/flows/predicates.go
@@ -9,6 +9,21 @@ import (
 	"github.com/run-ai/karta/test/e2e/recorder"
 )
 
+// State predicates: each reads a workload's own fields to recognise one state, never Karta.
+
+// AllOf matches when every check matches, for a state read from more than one condition (a Deployment
+// is initializing while Progressing is True and Available is False).
+func AllOf(checks ...recorder.StateCheck) recorder.StateCheck {
+	return func(u *unstructured.Unstructured) bool {
+		for _, c := range checks {
+			if !c(u) {
+				return false
+			}
+		}
+		return len(checks) > 0
+	}
+}
+
 // CondTrue matches when any of the given condition types is present with status True.
 func CondTrue(condTypes ...string) recorder.StateCheck {
 	return func(u *unstructured.Unstructured) bool {
@@ -22,6 +37,48 @@ func CondTrue(condTypes ...string) recorder.StateCheck {
 				if m["type"] == t {
 					return true
 				}
+			}
+		}
+		return false
+	}
+}
+
+// CondFalse matches when a condition of the given type is present and False.
+func CondFalse(condType string) recorder.StateCheck {
+	return func(u *unstructured.Unstructured) bool {
+		conds, _, _ := unstructured.NestedSlice(u.Object, "status", "conditions")
+		for _, c := range conds {
+			m, ok := c.(map[string]any)
+			if ok && m["type"] == condType && m["status"] == "False" {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// CondNotTrue matches when no condition of condType is present with status True (absent or non-True). A
+// just-created Deployment is Progressing with no Available condition yet, still initializing.
+func CondNotTrue(condType string) recorder.StateCheck {
+	return func(u *unstructured.Unstructured) bool {
+		conds, _, _ := unstructured.NestedSlice(u.Object, "status", "conditions")
+		for _, c := range conds {
+			if m, ok := c.(map[string]any); ok && m["type"] == condType && m["status"] == "True" {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+// CondReason matches when the condition of the given type is True with the given reason. A Deployment is
+// Running only when Progressing is True with reason NewReplicaSetAvailable, so status alone is not enough.
+func CondReason(condType, reason string) recorder.StateCheck {
+	return func(u *unstructured.Unstructured) bool {
+		conds, _, _ := unstructured.NestedSlice(u.Object, "status", "conditions")
+		for _, c := range conds {
+			if m, ok := c.(map[string]any); ok && m["type"] == condType && m["status"] == "True" && m["reason"] == reason {
+				return true
 			}
 		}
 		return false
@@ -48,6 +105,17 @@ func IntEq(n int64, path ...string) recorder.StateCheck {
 	return func(u *unstructured.Unstructured) bool {
 		got, found, err := unstructured.NestedInt64(u.Object, path...)
 		return err == nil && found && got == n
+	}
+}
+
+// ReplicasReady matches a workload settled at exactly n replicas: status.replicas and status.readyReplicas
+// both equal n. It gates a scale flow's step so each replica count is captured only once the controller
+// has finished scaling to it, not mid-rollout.
+func ReplicasReady(n int64) recorder.StateCheck {
+	return func(u *unstructured.Unstructured) bool {
+		replicas, ok, _ := unstructured.NestedInt64(u.Object, "status", "replicas")
+		ready, _, _ := unstructured.NestedInt64(u.Object, "status", "readyReplicas")
+		return ok && replicas == n && ready == n
 	}
 }
 

--- a/test/e2e/flows/testdata/deployment/failed.yaml
+++ b/test/e2e/flows/testdata/deployment/failed.yaml
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A Deployment pinned to a nonexistent node via nodeSelector, so its pod can never schedule. With
+# progressDeadlineSeconds 10 the controller gives up quickly and sets Progressing=False with reason
+# ProgressDeadlineExceeded, which the Karta library reads as Failed.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: karta-e2e-deploy-failed
+  namespace: default
+spec:
+  replicas: 1
+  progressDeadlineSeconds: 10
+  selector:
+    matchLabels: {app: karta-e2e-deploy-failed}
+  template:
+    metadata:
+      labels: {app: karta-e2e-deploy-failed}
+    spec:
+      nodeSelector:
+        karta-e2e/nonexistent: "true"
+      containers:
+        - name: worker
+          image: busybox:1.36
+          command: ["sh", "-c", "sleep infinity"]
+          resources:
+            requests: {cpu: 50m, memory: 32Mi}

--- a/test/e2e/flows/testdata/deployment/initializing.yaml
+++ b/test/e2e/flows/testdata/deployment/initializing.yaml
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A Deployment referencing a nonexistent image tag, so its pod stays in ImagePullBackOff and never
+# becomes ready. With no progressDeadlineSeconds the controller keeps Progressing True while Available
+# stays False, which the Karta library reads as Initializing - a workload still rolling out (here,
+# permanently). Karta must read it as Initializing, not Running or Failed.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: karta-e2e-deploy-initializing
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {app: karta-e2e-deploy-initializing}
+  template:
+    metadata:
+      labels: {app: karta-e2e-deploy-initializing}
+    spec:
+      containers:
+        - name: worker
+          image: busybox:99.99.99
+          command: ["sh", "-c", "sleep infinity"]
+          resources:
+            requests: {cpu: 20m, memory: 32Mi}

--- a/test/e2e/flows/testdata/deployment/running.yaml
+++ b/test/e2e/flows/testdata/deployment/running.yaml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A minimal Deployment (built-in, no operator) that sleeps, so it rolls out to Available and
+# scales cleanly. The scaled flow drives it 1 -> 3 -> 1 replicas; Karta reads Running at each
+# settled count with a different extraction (the replica count changes).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: karta-e2e-deploy
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: karta-e2e-deploy
+  template:
+    metadata:
+      labels:
+        app: karta-e2e-deploy
+    spec:
+      containers:
+        - name: worker
+          image: busybox:1.36
+          command: ["sh", "-c", "sleep infinity"]
+          resources:
+            requests:
+              cpu: 20m
+              memory: 32Mi

--- a/test/e2e/recorded_data/deployment/v1.34.0/apps-deployment-v1/failed.yaml
+++ b/test/e2e/recorded_data/deployment/v1.34.0/apps-deployment-v1/failed.yaml
@@ -1,0 +1,278 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        deployment.kubernetes.io/revision: "1"
+      creationTimestamp: "2026-08-18T12:39:16Z"
+      generation: 1
+      name: karta-e2e-deploy-failed
+      namespace: test-8m4bc
+      uid: 19582b0b-e276-4ba8-8412-bc5630b34125
+    spec:
+      progressDeadlineSeconds: 10
+      replicas: 1
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: karta-e2e-deploy-failed
+      strategy:
+        rollingUpdate:
+          maxSurge: 25%
+          maxUnavailable: 25%
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            app: karta-e2e-deploy-failed
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 50m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          nodeSelector:
+            karta-e2e/nonexistent: "true"
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:39:16Z"
+        lastUpdateTime: "2026-08-18T12:39:16Z"
+        message: Created new replica set "karta-e2e-deploy-failed-86c976d7f4"
+        reason: NewReplicaSetCreated
+        status: "True"
+        type: Progressing
+  resourceVersion: "15227"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        deployment.kubernetes.io/revision: "1"
+      creationTimestamp: "2026-08-18T12:39:16Z"
+      generation: 1
+      name: karta-e2e-deploy-failed
+      namespace: test-8m4bc
+      uid: 19582b0b-e276-4ba8-8412-bc5630b34125
+    spec:
+      progressDeadlineSeconds: 10
+      replicas: 1
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: karta-e2e-deploy-failed
+      strategy:
+        rollingUpdate:
+          maxSurge: 25%
+          maxUnavailable: 25%
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            app: karta-e2e-deploy-failed
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 50m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          nodeSelector:
+            karta-e2e/nonexistent: "true"
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:39:16Z"
+        lastUpdateTime: "2026-08-18T12:39:16Z"
+        message: Created new replica set "karta-e2e-deploy-failed-86c976d7f4"
+        reason: NewReplicaSetCreated
+        status: "True"
+        type: Progressing
+      - lastTransitionTime: "2026-08-18T12:39:16Z"
+        lastUpdateTime: "2026-08-18T12:39:16Z"
+        message: Deployment does not have minimum availability.
+        reason: MinimumReplicasUnavailable
+        status: "False"
+        type: Available
+      observedGeneration: 1
+      unavailableReplicas: 1
+  resourceVersion: "15233"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        deployment.kubernetes.io/revision: "1"
+      creationTimestamp: "2026-08-18T12:39:16Z"
+      generation: 1
+      name: karta-e2e-deploy-failed
+      namespace: test-8m4bc
+      uid: 19582b0b-e276-4ba8-8412-bc5630b34125
+    spec:
+      progressDeadlineSeconds: 10
+      replicas: 1
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: karta-e2e-deploy-failed
+      strategy:
+        rollingUpdate:
+          maxSurge: 25%
+          maxUnavailable: 25%
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            app: karta-e2e-deploy-failed
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 50m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          nodeSelector:
+            karta-e2e/nonexistent: "true"
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:39:16Z"
+        lastUpdateTime: "2026-08-18T12:39:16Z"
+        message: Deployment does not have minimum availability.
+        reason: MinimumReplicasUnavailable
+        status: "False"
+        type: Available
+      - lastTransitionTime: "2026-08-18T12:39:16Z"
+        lastUpdateTime: "2026-08-18T12:39:16Z"
+        message: ReplicaSet "karta-e2e-deploy-failed-86c976d7f4" is progressing.
+        reason: ReplicaSetUpdated
+        status: "True"
+        type: Progressing
+      observedGeneration: 1
+      replicas: 1
+      unavailableReplicas: 1
+      updatedReplicas: 1
+  resourceVersion: "15235"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        deployment.kubernetes.io/revision: "1"
+      creationTimestamp: "2026-08-18T12:39:16Z"
+      generation: 1
+      name: karta-e2e-deploy-failed
+      namespace: test-8m4bc
+      uid: 19582b0b-e276-4ba8-8412-bc5630b34125
+    spec:
+      progressDeadlineSeconds: 10
+      replicas: 1
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: karta-e2e-deploy-failed
+      strategy:
+        rollingUpdate:
+          maxSurge: 25%
+          maxUnavailable: 25%
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            app: karta-e2e-deploy-failed
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 50m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          nodeSelector:
+            karta-e2e/nonexistent: "true"
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:39:16Z"
+        lastUpdateTime: "2026-08-18T12:39:16Z"
+        message: Deployment does not have minimum availability.
+        reason: MinimumReplicasUnavailable
+        status: "False"
+        type: Available
+      - lastTransitionTime: "2026-08-18T12:39:27Z"
+        lastUpdateTime: "2026-08-18T12:39:27Z"
+        message: ReplicaSet "karta-e2e-deploy-failed-86c976d7f4" has timed out progressing.
+        reason: ProgressDeadlineExceeded
+        status: "False"
+        type: Progressing
+      observedGeneration: 1
+      replicas: 1
+      unavailableReplicas: 1
+      updatedReplicas: 1
+  resourceVersion: "15326"
+  state: Failed
+flow: failed
+kartaFile: docs/catalog/apps-deployment-v1.yaml
+kartaName: apps-deployment-v1
+operator: deployment
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Failed

--- a/test/e2e/recorded_data/deployment/v1.34.0/apps-deployment-v1/initializing.yaml
+++ b/test/e2e/recorded_data/deployment/v1.34.0/apps-deployment-v1/initializing.yaml
@@ -1,0 +1,68 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        deployment.kubernetes.io/revision: "1"
+      creationTimestamp: "2026-08-18T12:39:16Z"
+      generation: 1
+      name: karta-e2e-deploy-initializing
+      namespace: test-8m4bc
+      uid: 7a7ad163-8296-44dd-89b8-a492f49e52c1
+    spec:
+      progressDeadlineSeconds: 600
+      replicas: 1
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: karta-e2e-deploy-initializing
+      strategy:
+        rollingUpdate:
+          maxSurge: 25%
+          maxUnavailable: 25%
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            app: karta-e2e-deploy-initializing
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:99.99.99
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:39:16Z"
+        lastUpdateTime: "2026-08-18T12:39:16Z"
+        message: Created new replica set "karta-e2e-deploy-initializing-5f5996cdc5"
+        reason: NewReplicaSetCreated
+        status: "True"
+        type: Progressing
+  resourceVersion: "15213"
+  state: Initializing
+flow: initializing
+kartaFile: docs/catalog/apps-deployment-v1.yaml
+kartaName: apps-deployment-v1
+operator: deployment
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Initializing

--- a/test/e2e/recorded_data/deployment/v1.34.0/apps-deployment-v1/scaled.yaml
+++ b/test/e2e/recorded_data/deployment/v1.34.0/apps-deployment-v1/scaled.yaml
@@ -1,0 +1,915 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        deployment.kubernetes.io/revision: "1"
+      creationTimestamp: "2026-08-18T12:39:14Z"
+      generation: 1
+      name: karta-e2e-deploy
+      namespace: test-8m4bc
+      uid: 477ea29c-4c46-41ab-a01f-8205c027b93e
+    spec:
+      progressDeadlineSeconds: 600
+      replicas: 1
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: karta-e2e-deploy
+      strategy:
+        rollingUpdate:
+          maxSurge: 25%
+          maxUnavailable: 25%
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            app: karta-e2e-deploy
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:39:14Z"
+        lastUpdateTime: "2026-08-18T12:39:14Z"
+        message: Created new replica set "karta-e2e-deploy-fd98c5489"
+        reason: NewReplicaSetCreated
+        status: "True"
+        type: Progressing
+  resourceVersion: "15117"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        deployment.kubernetes.io/revision: "1"
+      creationTimestamp: "2026-08-18T12:39:14Z"
+      generation: 1
+      name: karta-e2e-deploy
+      namespace: test-8m4bc
+      uid: 477ea29c-4c46-41ab-a01f-8205c027b93e
+    spec:
+      progressDeadlineSeconds: 600
+      replicas: 1
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: karta-e2e-deploy
+      strategy:
+        rollingUpdate:
+          maxSurge: 25%
+          maxUnavailable: 25%
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            app: karta-e2e-deploy
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:39:14Z"
+        lastUpdateTime: "2026-08-18T12:39:14Z"
+        message: Created new replica set "karta-e2e-deploy-fd98c5489"
+        reason: NewReplicaSetCreated
+        status: "True"
+        type: Progressing
+      - lastTransitionTime: "2026-08-18T12:39:14Z"
+        lastUpdateTime: "2026-08-18T12:39:14Z"
+        message: Deployment does not have minimum availability.
+        reason: MinimumReplicasUnavailable
+        status: "False"
+        type: Available
+      observedGeneration: 1
+      unavailableReplicas: 1
+  resourceVersion: "15122"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        deployment.kubernetes.io/revision: "1"
+      creationTimestamp: "2026-08-18T12:39:14Z"
+      generation: 1
+      name: karta-e2e-deploy
+      namespace: test-8m4bc
+      uid: 477ea29c-4c46-41ab-a01f-8205c027b93e
+    spec:
+      progressDeadlineSeconds: 600
+      replicas: 1
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: karta-e2e-deploy
+      strategy:
+        rollingUpdate:
+          maxSurge: 25%
+          maxUnavailable: 25%
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            app: karta-e2e-deploy
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:39:14Z"
+        lastUpdateTime: "2026-08-18T12:39:14Z"
+        message: Deployment does not have minimum availability.
+        reason: MinimumReplicasUnavailable
+        status: "False"
+        type: Available
+      - lastTransitionTime: "2026-08-18T12:39:14Z"
+        lastUpdateTime: "2026-08-18T12:39:14Z"
+        message: ReplicaSet "karta-e2e-deploy-fd98c5489" is progressing.
+        reason: ReplicaSetUpdated
+        status: "True"
+        type: Progressing
+      observedGeneration: 1
+      replicas: 1
+      unavailableReplicas: 1
+      updatedReplicas: 1
+  resourceVersion: "15126"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        deployment.kubernetes.io/revision: "1"
+      creationTimestamp: "2026-08-18T12:39:14Z"
+      generation: 1
+      name: karta-e2e-deploy
+      namespace: test-8m4bc
+      uid: 477ea29c-4c46-41ab-a01f-8205c027b93e
+    spec:
+      progressDeadlineSeconds: 600
+      replicas: 1
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: karta-e2e-deploy
+      strategy:
+        rollingUpdate:
+          maxSurge: 25%
+          maxUnavailable: 25%
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            app: karta-e2e-deploy
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      availableReplicas: 1
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:39:15Z"
+        lastUpdateTime: "2026-08-18T12:39:15Z"
+        message: Deployment has minimum availability.
+        reason: MinimumReplicasAvailable
+        status: "True"
+        type: Available
+      - lastTransitionTime: "2026-08-18T12:39:14Z"
+        lastUpdateTime: "2026-08-18T12:39:15Z"
+        message: ReplicaSet "karta-e2e-deploy-fd98c5489" has successfully progressed.
+        reason: NewReplicaSetAvailable
+        status: "True"
+        type: Progressing
+      observedGeneration: 1
+      readyReplicas: 1
+      replicas: 1
+      updatedReplicas: 1
+  resourceVersion: "15145"
+  state: Running
+- action:
+    name: Scale
+    operation:
+      patchType: application/merge-patch+json
+      payload:
+        spec:
+          replicas: 3
+      verb: PATCH
+  kind: ACTION
+- kind: STATE
+  object:
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        deployment.kubernetes.io/revision: "1"
+      creationTimestamp: "2026-08-18T12:39:14Z"
+      generation: 2
+      name: karta-e2e-deploy
+      namespace: test-8m4bc
+      uid: 477ea29c-4c46-41ab-a01f-8205c027b93e
+    spec:
+      progressDeadlineSeconds: 600
+      replicas: 3
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: karta-e2e-deploy
+      strategy:
+        rollingUpdate:
+          maxSurge: 25%
+          maxUnavailable: 25%
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            app: karta-e2e-deploy
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      availableReplicas: 1
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:39:15Z"
+        lastUpdateTime: "2026-08-18T12:39:15Z"
+        message: Deployment has minimum availability.
+        reason: MinimumReplicasAvailable
+        status: "True"
+        type: Available
+      - lastTransitionTime: "2026-08-18T12:39:14Z"
+        lastUpdateTime: "2026-08-18T12:39:15Z"
+        message: ReplicaSet "karta-e2e-deploy-fd98c5489" has successfully progressed.
+        reason: NewReplicaSetAvailable
+        status: "True"
+        type: Progressing
+      observedGeneration: 1
+      readyReplicas: 1
+      replicas: 1
+      updatedReplicas: 1
+  resourceVersion: "15146"
+  staleObservedGeneration: true
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        deployment.kubernetes.io/revision: "1"
+      creationTimestamp: "2026-08-18T12:39:14Z"
+      generation: 2
+      name: karta-e2e-deploy
+      namespace: test-8m4bc
+      uid: 477ea29c-4c46-41ab-a01f-8205c027b93e
+    spec:
+      progressDeadlineSeconds: 600
+      replicas: 3
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: karta-e2e-deploy
+      strategy:
+        rollingUpdate:
+          maxSurge: 25%
+          maxUnavailable: 25%
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            app: karta-e2e-deploy
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      availableReplicas: 1
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:39:14Z"
+        lastUpdateTime: "2026-08-18T12:39:15Z"
+        message: ReplicaSet "karta-e2e-deploy-fd98c5489" has successfully progressed.
+        reason: NewReplicaSetAvailable
+        status: "True"
+        type: Progressing
+      - lastTransitionTime: "2026-08-18T12:39:15Z"
+        lastUpdateTime: "2026-08-18T12:39:15Z"
+        message: Deployment does not have minimum availability.
+        reason: MinimumReplicasUnavailable
+        status: "False"
+        type: Available
+      observedGeneration: 2
+      readyReplicas: 1
+      replicas: 1
+      updatedReplicas: 1
+  resourceVersion: "15151"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        deployment.kubernetes.io/revision: "1"
+      creationTimestamp: "2026-08-18T12:39:14Z"
+      generation: 2
+      name: karta-e2e-deploy
+      namespace: test-8m4bc
+      uid: 477ea29c-4c46-41ab-a01f-8205c027b93e
+    spec:
+      progressDeadlineSeconds: 600
+      replicas: 3
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: karta-e2e-deploy
+      strategy:
+        rollingUpdate:
+          maxSurge: 25%
+          maxUnavailable: 25%
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            app: karta-e2e-deploy
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      availableReplicas: 1
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:39:14Z"
+        lastUpdateTime: "2026-08-18T12:39:15Z"
+        message: ReplicaSet "karta-e2e-deploy-fd98c5489" has successfully progressed.
+        reason: NewReplicaSetAvailable
+        status: "True"
+        type: Progressing
+      - lastTransitionTime: "2026-08-18T12:39:15Z"
+        lastUpdateTime: "2026-08-18T12:39:15Z"
+        message: Deployment does not have minimum availability.
+        reason: MinimumReplicasUnavailable
+        status: "False"
+        type: Available
+      observedGeneration: 2
+      readyReplicas: 1
+      replicas: 1
+      unavailableReplicas: 2
+      updatedReplicas: 1
+  resourceVersion: "15161"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        deployment.kubernetes.io/revision: "1"
+      creationTimestamp: "2026-08-18T12:39:14Z"
+      generation: 2
+      name: karta-e2e-deploy
+      namespace: test-8m4bc
+      uid: 477ea29c-4c46-41ab-a01f-8205c027b93e
+    spec:
+      progressDeadlineSeconds: 600
+      replicas: 3
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: karta-e2e-deploy
+      strategy:
+        rollingUpdate:
+          maxSurge: 25%
+          maxUnavailable: 25%
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            app: karta-e2e-deploy
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      availableReplicas: 1
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:39:14Z"
+        lastUpdateTime: "2026-08-18T12:39:15Z"
+        message: ReplicaSet "karta-e2e-deploy-fd98c5489" has successfully progressed.
+        reason: NewReplicaSetAvailable
+        status: "True"
+        type: Progressing
+      - lastTransitionTime: "2026-08-18T12:39:15Z"
+        lastUpdateTime: "2026-08-18T12:39:15Z"
+        message: Deployment does not have minimum availability.
+        reason: MinimumReplicasUnavailable
+        status: "False"
+        type: Available
+      observedGeneration: 2
+      readyReplicas: 1
+      replicas: 3
+      unavailableReplicas: 2
+      updatedReplicas: 3
+  resourceVersion: "15171"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        deployment.kubernetes.io/revision: "1"
+      creationTimestamp: "2026-08-18T12:39:14Z"
+      generation: 2
+      name: karta-e2e-deploy
+      namespace: test-8m4bc
+      uid: 477ea29c-4c46-41ab-a01f-8205c027b93e
+    spec:
+      progressDeadlineSeconds: 600
+      replicas: 3
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: karta-e2e-deploy
+      strategy:
+        rollingUpdate:
+          maxSurge: 25%
+          maxUnavailable: 25%
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            app: karta-e2e-deploy
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      availableReplicas: 2
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:39:14Z"
+        lastUpdateTime: "2026-08-18T12:39:15Z"
+        message: ReplicaSet "karta-e2e-deploy-fd98c5489" has successfully progressed.
+        reason: NewReplicaSetAvailable
+        status: "True"
+        type: Progressing
+      - lastTransitionTime: "2026-08-18T12:39:15Z"
+        lastUpdateTime: "2026-08-18T12:39:15Z"
+        message: Deployment does not have minimum availability.
+        reason: MinimumReplicasUnavailable
+        status: "False"
+        type: Available
+      observedGeneration: 2
+      readyReplicas: 2
+      replicas: 3
+      unavailableReplicas: 1
+      updatedReplicas: 3
+  resourceVersion: "15189"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        deployment.kubernetes.io/revision: "1"
+      creationTimestamp: "2026-08-18T12:39:14Z"
+      generation: 2
+      name: karta-e2e-deploy
+      namespace: test-8m4bc
+      uid: 477ea29c-4c46-41ab-a01f-8205c027b93e
+    spec:
+      progressDeadlineSeconds: 600
+      replicas: 3
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: karta-e2e-deploy
+      strategy:
+        rollingUpdate:
+          maxSurge: 25%
+          maxUnavailable: 25%
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            app: karta-e2e-deploy
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      availableReplicas: 3
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:39:14Z"
+        lastUpdateTime: "2026-08-18T12:39:15Z"
+        message: ReplicaSet "karta-e2e-deploy-fd98c5489" has successfully progressed.
+        reason: NewReplicaSetAvailable
+        status: "True"
+        type: Progressing
+      - lastTransitionTime: "2026-08-18T12:39:16Z"
+        lastUpdateTime: "2026-08-18T12:39:16Z"
+        message: Deployment has minimum availability.
+        reason: MinimumReplicasAvailable
+        status: "True"
+        type: Available
+      observedGeneration: 2
+      readyReplicas: 3
+      replicas: 3
+      updatedReplicas: 3
+  resourceVersion: "15194"
+  state: Running
+- action:
+    name: Scale
+    operation:
+      patchType: application/merge-patch+json
+      payload:
+        spec:
+          replicas: 1
+      verb: PATCH
+  kind: ACTION
+- kind: STATE
+  object:
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        deployment.kubernetes.io/revision: "1"
+      creationTimestamp: "2026-08-18T12:39:14Z"
+      generation: 3
+      name: karta-e2e-deploy
+      namespace: test-8m4bc
+      uid: 477ea29c-4c46-41ab-a01f-8205c027b93e
+    spec:
+      progressDeadlineSeconds: 600
+      replicas: 1
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: karta-e2e-deploy
+      strategy:
+        rollingUpdate:
+          maxSurge: 25%
+          maxUnavailable: 25%
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            app: karta-e2e-deploy
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      availableReplicas: 3
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:39:14Z"
+        lastUpdateTime: "2026-08-18T12:39:15Z"
+        message: ReplicaSet "karta-e2e-deploy-fd98c5489" has successfully progressed.
+        reason: NewReplicaSetAvailable
+        status: "True"
+        type: Progressing
+      - lastTransitionTime: "2026-08-18T12:39:16Z"
+        lastUpdateTime: "2026-08-18T12:39:16Z"
+        message: Deployment has minimum availability.
+        reason: MinimumReplicasAvailable
+        status: "True"
+        type: Available
+      observedGeneration: 2
+      readyReplicas: 3
+      replicas: 3
+      updatedReplicas: 3
+  resourceVersion: "15195"
+  staleObservedGeneration: true
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        deployment.kubernetes.io/revision: "1"
+      creationTimestamp: "2026-08-18T12:39:14Z"
+      generation: 3
+      name: karta-e2e-deploy
+      namespace: test-8m4bc
+      uid: 477ea29c-4c46-41ab-a01f-8205c027b93e
+    spec:
+      progressDeadlineSeconds: 600
+      replicas: 1
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: karta-e2e-deploy
+      strategy:
+        rollingUpdate:
+          maxSurge: 25%
+          maxUnavailable: 25%
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            app: karta-e2e-deploy
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      availableReplicas: 3
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:39:14Z"
+        lastUpdateTime: "2026-08-18T12:39:15Z"
+        message: ReplicaSet "karta-e2e-deploy-fd98c5489" has successfully progressed.
+        reason: NewReplicaSetAvailable
+        status: "True"
+        type: Progressing
+      - lastTransitionTime: "2026-08-18T12:39:16Z"
+        lastUpdateTime: "2026-08-18T12:39:16Z"
+        message: Deployment has minimum availability.
+        reason: MinimumReplicasAvailable
+        status: "True"
+        type: Available
+      observedGeneration: 3
+      readyReplicas: 3
+      replicas: 3
+      updatedReplicas: 3
+  resourceVersion: "15197"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        deployment.kubernetes.io/revision: "1"
+      creationTimestamp: "2026-08-18T12:39:14Z"
+      generation: 3
+      name: karta-e2e-deploy
+      namespace: test-8m4bc
+      uid: 477ea29c-4c46-41ab-a01f-8205c027b93e
+    spec:
+      progressDeadlineSeconds: 600
+      replicas: 1
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: karta-e2e-deploy
+      strategy:
+        rollingUpdate:
+          maxSurge: 25%
+          maxUnavailable: 25%
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            app: karta-e2e-deploy
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+    status:
+      availableReplicas: 1
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:39:14Z"
+        lastUpdateTime: "2026-08-18T12:39:15Z"
+        message: ReplicaSet "karta-e2e-deploy-fd98c5489" has successfully progressed.
+        reason: NewReplicaSetAvailable
+        status: "True"
+        type: Progressing
+      - lastTransitionTime: "2026-08-18T12:39:16Z"
+        lastUpdateTime: "2026-08-18T12:39:16Z"
+        message: Deployment has minimum availability.
+        reason: MinimumReplicasAvailable
+        status: "True"
+        type: Available
+      observedGeneration: 3
+      readyReplicas: 1
+      replicas: 1
+      updatedReplicas: 1
+  resourceVersion: "15207"
+  state: Running
+flow: scaled
+kartaFile: docs/catalog/apps-deployment-v1.yaml
+kartaName: apps-deployment-v1
+operator: deployment
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Running


### PR DESCRIPTION
Part of #139 - one workload type per PR, stacked. Adds the deployment flow: its spec steps, the predicates it judges stable states with (from the workload's own fields), and its recorded fixtures. Replayed offline by the suite in #260; `make check` green at every layer.