### PR TITLE
test(e2e): add the statefulset flow and its recorded fixtures

### DIFF
--- a/test/e2e/flows/predicates.go
+++ b/test/e2e/flows/predicates.go
@@ -119,6 +119,21 @@ func ReplicasReady(n int64) recorder.StateCheck {
 	}
 }
 
+// FullyAvailable matches when every desired replica is created and ready (readyReplicas == updatedReplicas
+// == spec.replicas), Karta's Running for a StatefulSet. Compares to spec.replicas, not the lagging
+// status.replicas, so a gradually-scaled StatefulSet never reads Running mid-ramp.
+func FullyAvailable() recorder.StateCheck {
+	return func(u *unstructured.Unstructured) bool {
+		desired, ok, _ := unstructured.NestedInt64(u.Object, "spec", "replicas")
+		if !ok {
+			desired = 1 // Karta defaults `.spec.replicas // 1`
+		}
+		ready, _, _ := unstructured.NestedInt64(u.Object, "status", "readyReplicas")
+		updated, _, _ := unstructured.NestedInt64(u.Object, "status", "updatedReplicas")
+		return desired > 0 && ready == desired && updated == desired
+	}
+}
+
 // ReplicasDegraded matches a settled-degraded workload: every desired replica created (updatedReplicas ==
 // spec.replicas) but some not ready (0 < readyReplicas < spec.replicas).
 func ReplicasDegraded() recorder.StateCheck {
@@ -130,6 +145,21 @@ func ReplicasDegraded() recorder.StateCheck {
 		ready, _, _ := unstructured.NestedInt64(u.Object, "status", "readyReplicas")
 		updated, _, _ := unstructured.NestedInt64(u.Object, "status", "updatedReplicas")
 		return desired > 0 && updated == desired && ready > 0 && ready < desired
+	}
+}
+
+// ReplicasInitializing matches a StatefulSet still converging: spec.replicas > 0 and either nothing ready
+// (readyReplicas == 0), not all created (updatedReplicas != spec.replicas), or more ready than desired
+// (readyReplicas > spec.replicas, a scale-down still shedding pods).
+func ReplicasInitializing() recorder.StateCheck {
+	return func(u *unstructured.Unstructured) bool {
+		desired, ok, _ := unstructured.NestedInt64(u.Object, "spec", "replicas")
+		if !ok {
+			desired = 1
+		}
+		ready, _, _ := unstructured.NestedInt64(u.Object, "status", "readyReplicas")
+		updated, _, _ := unstructured.NestedInt64(u.Object, "status", "updatedReplicas")
+		return desired > 0 && (ready == 0 || ready > desired || updated != desired)
 	}
 }
 

--- a/test/e2e/flows/statefulset_test.go
+++ b/test/e2e/flows/statefulset_test.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package flows
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kartav1alpha1 "github.com/run-ai/karta/pkg/api/runai/v1alpha1"
+	"github.com/run-ai/karta/test/e2e/recorder"
+)
+
+var _ = Describe("StatefulSet (built-in)", Ordered, Label("statefulset", "builtin"), func() {
+	var rec *recorder.Recorder
+	var fx recorder.Fixture
+
+	BeforeAll(func(ctx SpecContext) {
+		installKarta(ctx, "../../docs/catalog/apps-statefulset-v1.yaml", "apps-statefulset-v1")
+		fx = recorder.Fixture{Operator: "statefulset", Version: operatorVersion("statefulset"), KartaName: "apps-statefulset-v1", KartaFile: "docs/catalog/apps-statefulset-v1.yaml"}
+		rec = recorder.New(cfg).
+			AddState(kartav1alpha1.InitializingStatus, ReplicasInitializing()).
+			AddState(kartav1alpha1.RunningStatus, FullyAvailable()).
+			AddState(kartav1alpha1.DegradedStatus, ReplicasDegraded())
+	})
+
+	// A StatefulSet takes transient Initializing/Degraded dips while scaling; the Optional steps declare them
+	// so the order check tolerates them, and the recorder only stops at the ReplicasReady gates.
+	It("scaled", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "scaled", "testdata/statefulset/running.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.RunningStatus).With(ReplicasReady(1)).Do(ScaleReplicas(3)),
+			recorder.Reaches(kartav1alpha1.InitializingStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.DegradedStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.RunningStatus).With(ReplicasReady(3)).Do(ScaleReplicas(1)),
+			recorder.Reaches(kartav1alpha1.InitializingStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.RunningStatus).With(ReplicasReady(1)),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	// 3 replicas + hostname antiAffinity on 2 nodes: one stays pending, so readyReplicas settles below
+	// replicas with updatedReplicas == replicas, read as Degraded.
+	It("degraded", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "degraded", "testdata/statefulset/degraded.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.DegradedStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+})

--- a/test/e2e/flows/testdata/statefulset/degraded.yaml
+++ b/test/e2e/flows/testdata/statefulset/degraded.yaml
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A StatefulSet of 3 replicas with hostname podAntiAffinity on a 2-worker cluster: two pods schedule
+# (one per node), the third can never place. podManagementPolicy Parallel creates all three at once,
+# so readyReplicas settles at 2 while updatedReplicas == replicas == 3 - a settled partial the Karta
+# library reads as Degraded.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: karta-e2e-sts-degraded
+  namespace: default
+spec:
+  serviceName: karta-e2e-sts-degraded
+  replicas: 3
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels: {app: karta-e2e-sts-degraded}
+  template:
+    metadata:
+      labels: {app: karta-e2e-sts-degraded}
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels: {app: karta-e2e-sts-degraded}
+              topologyKey: kubernetes.io/hostname
+      containers:
+        - name: worker
+          image: busybox:1.36
+          command: ["sh", "-c", "sleep infinity"]
+          resources:
+            requests: {cpu: 50m, memory: 32Mi}

--- a/test/e2e/flows/testdata/statefulset/running.yaml
+++ b/test/e2e/flows/testdata/statefulset/running.yaml
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A minimal StatefulSet (built-in, no operator) that sleeps. serviceName points at a headless
+# service that need not exist for sleeping pods. The scaled flow drives it 1 -> 3 -> 1 replicas;
+# Karta reads Running at each settled count with a different extraction.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: karta-e2e-sts
+  namespace: default
+spec:
+  serviceName: karta-e2e-sts
+  replicas: 1
+  selector:
+    matchLabels:
+      app: karta-e2e-sts
+  template:
+    metadata:
+      labels:
+        app: karta-e2e-sts
+    spec:
+      containers:
+        - name: worker
+          image: busybox:1.36
+          command: ["sh", "-c", "sleep infinity"]
+          resources:
+            requests:
+              cpu: 20m
+              memory: 32Mi

--- a/test/e2e/recorded_data/statefulset/v1.34.0/apps-statefulset-v1/degraded.yaml
+++ b/test/e2e/recorded_data/statefulset/v1.34.0/apps-statefulset-v1/degraded.yaml
@@ -1,0 +1,210 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:35:59Z"
+      generation: 1
+      name: karta-e2e-sts-degraded
+      namespace: test-8m4bc
+      uid: 89761d5b-4f7f-4966-9613-235430a87d50
+    spec:
+      persistentVolumeClaimRetentionPolicy:
+        whenDeleted: Retain
+        whenScaled: Retain
+      podManagementPolicy: Parallel
+      replicas: 3
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: karta-e2e-sts-degraded
+      serviceName: karta-e2e-sts-degraded
+      template:
+        metadata:
+          labels:
+            app: karta-e2e-sts-degraded
+        spec:
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchLabels:
+                    app: karta-e2e-sts-degraded
+                topologyKey: kubernetes.io/hostname
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 50m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+      updateStrategy:
+        rollingUpdate:
+          partition: 0
+        type: RollingUpdate
+    status:
+      availableReplicas: 0
+      collisionCount: 0
+      currentRevision: karta-e2e-sts-degraded-5fb8d9544d
+      observedGeneration: 1
+      replicas: 0
+      updateRevision: karta-e2e-sts-degraded-5fb8d9544d
+  resourceVersion: "13201"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:35:59Z"
+      generation: 1
+      name: karta-e2e-sts-degraded
+      namespace: test-8m4bc
+      uid: 89761d5b-4f7f-4966-9613-235430a87d50
+    spec:
+      persistentVolumeClaimRetentionPolicy:
+        whenDeleted: Retain
+        whenScaled: Retain
+      podManagementPolicy: Parallel
+      replicas: 3
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: karta-e2e-sts-degraded
+      serviceName: karta-e2e-sts-degraded
+      template:
+        metadata:
+          labels:
+            app: karta-e2e-sts-degraded
+        spec:
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchLabels:
+                    app: karta-e2e-sts-degraded
+                topologyKey: kubernetes.io/hostname
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 50m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+      updateStrategy:
+        rollingUpdate:
+          partition: 0
+        type: RollingUpdate
+    status:
+      availableReplicas: 0
+      collisionCount: 0
+      currentReplicas: 3
+      currentRevision: karta-e2e-sts-degraded-5fb8d9544d
+      observedGeneration: 1
+      replicas: 3
+      updateRevision: karta-e2e-sts-degraded-5fb8d9544d
+      updatedReplicas: 3
+  resourceVersion: "13210"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:35:59Z"
+      generation: 1
+      name: karta-e2e-sts-degraded
+      namespace: test-8m4bc
+      uid: 89761d5b-4f7f-4966-9613-235430a87d50
+    spec:
+      persistentVolumeClaimRetentionPolicy:
+        whenDeleted: Retain
+        whenScaled: Retain
+      podManagementPolicy: Parallel
+      replicas: 3
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: karta-e2e-sts-degraded
+      serviceName: karta-e2e-sts-degraded
+      template:
+        metadata:
+          labels:
+            app: karta-e2e-sts-degraded
+        spec:
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchLabels:
+                    app: karta-e2e-sts-degraded
+                topologyKey: kubernetes.io/hostname
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 50m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+      updateStrategy:
+        rollingUpdate:
+          partition: 0
+        type: RollingUpdate
+    status:
+      availableReplicas: 1
+      collisionCount: 0
+      currentReplicas: 3
+      currentRevision: karta-e2e-sts-degraded-5fb8d9544d
+      observedGeneration: 1
+      readyReplicas: 1
+      replicas: 3
+      updateRevision: karta-e2e-sts-degraded-5fb8d9544d
+      updatedReplicas: 3
+  resourceVersion: "13225"
+  state: Degraded
+flow: degraded
+kartaFile: docs/catalog/apps-statefulset-v1.yaml
+kartaName: apps-statefulset-v1
+operator: statefulset
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Degraded

--- a/test/e2e/recorded_data/statefulset/v1.34.0/apps-statefulset-v1/scaled.yaml
+++ b/test/e2e/recorded_data/statefulset/v1.34.0/apps-statefulset-v1/scaled.yaml
@@ -1,0 +1,1063 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:34:54Z"
+      generation: 1
+      name: karta-e2e-sts
+      namespace: test-8m4bc
+      uid: 915d7ead-d4b1-453c-9bd4-a34121becbfe
+    spec:
+      persistentVolumeClaimRetentionPolicy:
+        whenDeleted: Retain
+        whenScaled: Retain
+      podManagementPolicy: OrderedReady
+      replicas: 1
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: karta-e2e-sts
+      serviceName: karta-e2e-sts
+      template:
+        metadata:
+          labels:
+            app: karta-e2e-sts
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+      updateStrategy:
+        rollingUpdate:
+          partition: 0
+        type: RollingUpdate
+    status:
+      availableReplicas: 0
+      collisionCount: 0
+      currentRevision: karta-e2e-sts-7775b6b476
+      observedGeneration: 1
+      replicas: 0
+      updateRevision: karta-e2e-sts-7775b6b476
+  resourceVersion: "12606"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:34:54Z"
+      generation: 1
+      name: karta-e2e-sts
+      namespace: test-8m4bc
+      uid: 915d7ead-d4b1-453c-9bd4-a34121becbfe
+    spec:
+      persistentVolumeClaimRetentionPolicy:
+        whenDeleted: Retain
+        whenScaled: Retain
+      podManagementPolicy: OrderedReady
+      replicas: 1
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: karta-e2e-sts
+      serviceName: karta-e2e-sts
+      template:
+        metadata:
+          labels:
+            app: karta-e2e-sts
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+      updateStrategy:
+        rollingUpdate:
+          partition: 0
+        type: RollingUpdate
+    status:
+      availableReplicas: 0
+      collisionCount: 0
+      currentReplicas: 1
+      currentRevision: karta-e2e-sts-7775b6b476
+      observedGeneration: 1
+      replicas: 1
+      updateRevision: karta-e2e-sts-7775b6b476
+      updatedReplicas: 1
+  resourceVersion: "12608"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:34:54Z"
+      generation: 1
+      name: karta-e2e-sts
+      namespace: test-8m4bc
+      uid: 915d7ead-d4b1-453c-9bd4-a34121becbfe
+    spec:
+      persistentVolumeClaimRetentionPolicy:
+        whenDeleted: Retain
+        whenScaled: Retain
+      podManagementPolicy: OrderedReady
+      replicas: 1
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: karta-e2e-sts
+      serviceName: karta-e2e-sts
+      template:
+        metadata:
+          labels:
+            app: karta-e2e-sts
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+      updateStrategy:
+        rollingUpdate:
+          partition: 0
+        type: RollingUpdate
+    status:
+      availableReplicas: 1
+      collisionCount: 0
+      currentReplicas: 1
+      currentRevision: karta-e2e-sts-7775b6b476
+      observedGeneration: 1
+      readyReplicas: 1
+      replicas: 1
+      updateRevision: karta-e2e-sts-7775b6b476
+      updatedReplicas: 1
+  resourceVersion: "12632"
+  state: Running
+- action:
+    name: Scale
+    operation:
+      patchType: application/merge-patch+json
+      payload:
+        spec:
+          replicas: 3
+      verb: PATCH
+  kind: ACTION
+- kind: STATE
+  object:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:34:54Z"
+      generation: 2
+      name: karta-e2e-sts
+      namespace: test-8m4bc
+      uid: 915d7ead-d4b1-453c-9bd4-a34121becbfe
+    spec:
+      persistentVolumeClaimRetentionPolicy:
+        whenDeleted: Retain
+        whenScaled: Retain
+      podManagementPolicy: OrderedReady
+      replicas: 3
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: karta-e2e-sts
+      serviceName: karta-e2e-sts
+      template:
+        metadata:
+          labels:
+            app: karta-e2e-sts
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+      updateStrategy:
+        rollingUpdate:
+          partition: 0
+        type: RollingUpdate
+    status:
+      availableReplicas: 1
+      collisionCount: 0
+      currentReplicas: 1
+      currentRevision: karta-e2e-sts-7775b6b476
+      observedGeneration: 1
+      readyReplicas: 1
+      replicas: 1
+      updateRevision: karta-e2e-sts-7775b6b476
+      updatedReplicas: 1
+  resourceVersion: "12633"
+  staleObservedGeneration: true
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:34:54Z"
+      generation: 2
+      name: karta-e2e-sts
+      namespace: test-8m4bc
+      uid: 915d7ead-d4b1-453c-9bd4-a34121becbfe
+    spec:
+      persistentVolumeClaimRetentionPolicy:
+        whenDeleted: Retain
+        whenScaled: Retain
+      podManagementPolicy: OrderedReady
+      replicas: 3
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: karta-e2e-sts
+      serviceName: karta-e2e-sts
+      template:
+        metadata:
+          labels:
+            app: karta-e2e-sts
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+      updateStrategy:
+        rollingUpdate:
+          partition: 0
+        type: RollingUpdate
+    status:
+      availableReplicas: 1
+      collisionCount: 0
+      currentReplicas: 1
+      currentRevision: karta-e2e-sts-7775b6b476
+      observedGeneration: 2
+      readyReplicas: 1
+      replicas: 1
+      updateRevision: karta-e2e-sts-7775b6b476
+      updatedReplicas: 1
+  resourceVersion: "12637"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:34:54Z"
+      generation: 2
+      name: karta-e2e-sts
+      namespace: test-8m4bc
+      uid: 915d7ead-d4b1-453c-9bd4-a34121becbfe
+    spec:
+      persistentVolumeClaimRetentionPolicy:
+        whenDeleted: Retain
+        whenScaled: Retain
+      podManagementPolicy: OrderedReady
+      replicas: 3
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: karta-e2e-sts
+      serviceName: karta-e2e-sts
+      template:
+        metadata:
+          labels:
+            app: karta-e2e-sts
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+      updateStrategy:
+        rollingUpdate:
+          partition: 0
+        type: RollingUpdate
+    status:
+      availableReplicas: 1
+      collisionCount: 0
+      currentReplicas: 2
+      currentRevision: karta-e2e-sts-7775b6b476
+      observedGeneration: 2
+      readyReplicas: 1
+      replicas: 2
+      updateRevision: karta-e2e-sts-7775b6b476
+      updatedReplicas: 2
+  resourceVersion: "12640"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:34:54Z"
+      generation: 2
+      name: karta-e2e-sts
+      namespace: test-8m4bc
+      uid: 915d7ead-d4b1-453c-9bd4-a34121becbfe
+    spec:
+      persistentVolumeClaimRetentionPolicy:
+        whenDeleted: Retain
+        whenScaled: Retain
+      podManagementPolicy: OrderedReady
+      replicas: 3
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: karta-e2e-sts
+      serviceName: karta-e2e-sts
+      template:
+        metadata:
+          labels:
+            app: karta-e2e-sts
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+      updateStrategy:
+        rollingUpdate:
+          partition: 0
+        type: RollingUpdate
+    status:
+      availableReplicas: 2
+      collisionCount: 0
+      currentReplicas: 2
+      currentRevision: karta-e2e-sts-7775b6b476
+      observedGeneration: 2
+      readyReplicas: 2
+      replicas: 2
+      updateRevision: karta-e2e-sts-7775b6b476
+      updatedReplicas: 2
+  resourceVersion: "12651"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:34:54Z"
+      generation: 2
+      name: karta-e2e-sts
+      namespace: test-8m4bc
+      uid: 915d7ead-d4b1-453c-9bd4-a34121becbfe
+    spec:
+      persistentVolumeClaimRetentionPolicy:
+        whenDeleted: Retain
+        whenScaled: Retain
+      podManagementPolicy: OrderedReady
+      replicas: 3
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: karta-e2e-sts
+      serviceName: karta-e2e-sts
+      template:
+        metadata:
+          labels:
+            app: karta-e2e-sts
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+      updateStrategy:
+        rollingUpdate:
+          partition: 0
+        type: RollingUpdate
+    status:
+      availableReplicas: 2
+      collisionCount: 0
+      currentReplicas: 3
+      currentRevision: karta-e2e-sts-7775b6b476
+      observedGeneration: 2
+      readyReplicas: 2
+      replicas: 3
+      updateRevision: karta-e2e-sts-7775b6b476
+      updatedReplicas: 3
+  resourceVersion: "12655"
+  state: Degraded
+- kind: STATE
+  object:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:34:54Z"
+      generation: 2
+      name: karta-e2e-sts
+      namespace: test-8m4bc
+      uid: 915d7ead-d4b1-453c-9bd4-a34121becbfe
+    spec:
+      persistentVolumeClaimRetentionPolicy:
+        whenDeleted: Retain
+        whenScaled: Retain
+      podManagementPolicy: OrderedReady
+      replicas: 3
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: karta-e2e-sts
+      serviceName: karta-e2e-sts
+      template:
+        metadata:
+          labels:
+            app: karta-e2e-sts
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+      updateStrategy:
+        rollingUpdate:
+          partition: 0
+        type: RollingUpdate
+    status:
+      availableReplicas: 3
+      collisionCount: 0
+      currentReplicas: 3
+      currentRevision: karta-e2e-sts-7775b6b476
+      observedGeneration: 2
+      readyReplicas: 3
+      replicas: 3
+      updateRevision: karta-e2e-sts-7775b6b476
+      updatedReplicas: 3
+  resourceVersion: "12670"
+  state: Running
+- action:
+    name: Scale
+    operation:
+      patchType: application/merge-patch+json
+      payload:
+        spec:
+          replicas: 1
+      verb: PATCH
+  kind: ACTION
+- kind: STATE
+  object:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:34:54Z"
+      generation: 3
+      name: karta-e2e-sts
+      namespace: test-8m4bc
+      uid: 915d7ead-d4b1-453c-9bd4-a34121becbfe
+    spec:
+      persistentVolumeClaimRetentionPolicy:
+        whenDeleted: Retain
+        whenScaled: Retain
+      podManagementPolicy: OrderedReady
+      replicas: 1
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: karta-e2e-sts
+      serviceName: karta-e2e-sts
+      template:
+        metadata:
+          labels:
+            app: karta-e2e-sts
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+      updateStrategy:
+        rollingUpdate:
+          partition: 0
+        type: RollingUpdate
+    status:
+      availableReplicas: 3
+      collisionCount: 0
+      currentReplicas: 3
+      currentRevision: karta-e2e-sts-7775b6b476
+      observedGeneration: 2
+      readyReplicas: 3
+      replicas: 3
+      updateRevision: karta-e2e-sts-7775b6b476
+      updatedReplicas: 3
+  resourceVersion: "12671"
+  staleObservedGeneration: true
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:34:54Z"
+      generation: 3
+      name: karta-e2e-sts
+      namespace: test-8m4bc
+      uid: 915d7ead-d4b1-453c-9bd4-a34121becbfe
+    spec:
+      persistentVolumeClaimRetentionPolicy:
+        whenDeleted: Retain
+        whenScaled: Retain
+      podManagementPolicy: OrderedReady
+      replicas: 1
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: karta-e2e-sts
+      serviceName: karta-e2e-sts
+      template:
+        metadata:
+          labels:
+            app: karta-e2e-sts
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+      updateStrategy:
+        rollingUpdate:
+          partition: 0
+        type: RollingUpdate
+    status:
+      availableReplicas: 3
+      collisionCount: 0
+      currentReplicas: 3
+      currentRevision: karta-e2e-sts-7775b6b476
+      observedGeneration: 3
+      readyReplicas: 3
+      replicas: 3
+      updateRevision: karta-e2e-sts-7775b6b476
+      updatedReplicas: 3
+  resourceVersion: "12673"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:34:54Z"
+      generation: 3
+      name: karta-e2e-sts
+      namespace: test-8m4bc
+      uid: 915d7ead-d4b1-453c-9bd4-a34121becbfe
+    spec:
+      persistentVolumeClaimRetentionPolicy:
+        whenDeleted: Retain
+        whenScaled: Retain
+      podManagementPolicy: OrderedReady
+      replicas: 1
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: karta-e2e-sts
+      serviceName: karta-e2e-sts
+      template:
+        metadata:
+          labels:
+            app: karta-e2e-sts
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+      updateStrategy:
+        rollingUpdate:
+          partition: 0
+        type: RollingUpdate
+    status:
+      availableReplicas: 3
+      collisionCount: 0
+      currentReplicas: 2
+      currentRevision: karta-e2e-sts-7775b6b476
+      observedGeneration: 3
+      readyReplicas: 3
+      replicas: 3
+      updateRevision: karta-e2e-sts-7775b6b476
+      updatedReplicas: 2
+  resourceVersion: "12675"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:34:54Z"
+      generation: 3
+      name: karta-e2e-sts
+      namespace: test-8m4bc
+      uid: 915d7ead-d4b1-453c-9bd4-a34121becbfe
+    spec:
+      persistentVolumeClaimRetentionPolicy:
+        whenDeleted: Retain
+        whenScaled: Retain
+      podManagementPolicy: OrderedReady
+      replicas: 1
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: karta-e2e-sts
+      serviceName: karta-e2e-sts
+      template:
+        metadata:
+          labels:
+            app: karta-e2e-sts
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+      updateStrategy:
+        rollingUpdate:
+          partition: 0
+        type: RollingUpdate
+    status:
+      availableReplicas: 2
+      collisionCount: 0
+      currentReplicas: 2
+      currentRevision: karta-e2e-sts-7775b6b476
+      observedGeneration: 3
+      readyReplicas: 2
+      replicas: 3
+      updateRevision: karta-e2e-sts-7775b6b476
+      updatedReplicas: 2
+  resourceVersion: "12928"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:34:54Z"
+      generation: 3
+      name: karta-e2e-sts
+      namespace: test-8m4bc
+      uid: 915d7ead-d4b1-453c-9bd4-a34121becbfe
+    spec:
+      persistentVolumeClaimRetentionPolicy:
+        whenDeleted: Retain
+        whenScaled: Retain
+      podManagementPolicy: OrderedReady
+      replicas: 1
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: karta-e2e-sts
+      serviceName: karta-e2e-sts
+      template:
+        metadata:
+          labels:
+            app: karta-e2e-sts
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+      updateStrategy:
+        rollingUpdate:
+          partition: 0
+        type: RollingUpdate
+    status:
+      availableReplicas: 2
+      collisionCount: 0
+      currentReplicas: 2
+      currentRevision: karta-e2e-sts-7775b6b476
+      observedGeneration: 3
+      readyReplicas: 2
+      replicas: 2
+      updateRevision: karta-e2e-sts-7775b6b476
+      updatedReplicas: 2
+  resourceVersion: "12945"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:34:54Z"
+      generation: 3
+      name: karta-e2e-sts
+      namespace: test-8m4bc
+      uid: 915d7ead-d4b1-453c-9bd4-a34121becbfe
+    spec:
+      persistentVolumeClaimRetentionPolicy:
+        whenDeleted: Retain
+        whenScaled: Retain
+      podManagementPolicy: OrderedReady
+      replicas: 1
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: karta-e2e-sts
+      serviceName: karta-e2e-sts
+      template:
+        metadata:
+          labels:
+            app: karta-e2e-sts
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+      updateStrategy:
+        rollingUpdate:
+          partition: 0
+        type: RollingUpdate
+    status:
+      availableReplicas: 2
+      collisionCount: 0
+      currentReplicas: 1
+      currentRevision: karta-e2e-sts-7775b6b476
+      observedGeneration: 3
+      readyReplicas: 2
+      replicas: 2
+      updateRevision: karta-e2e-sts-7775b6b476
+      updatedReplicas: 1
+  resourceVersion: "12948"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:34:54Z"
+      generation: 3
+      name: karta-e2e-sts
+      namespace: test-8m4bc
+      uid: 915d7ead-d4b1-453c-9bd4-a34121becbfe
+    spec:
+      persistentVolumeClaimRetentionPolicy:
+        whenDeleted: Retain
+        whenScaled: Retain
+      podManagementPolicy: OrderedReady
+      replicas: 1
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: karta-e2e-sts
+      serviceName: karta-e2e-sts
+      template:
+        metadata:
+          labels:
+            app: karta-e2e-sts
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+      updateStrategy:
+        rollingUpdate:
+          partition: 0
+        type: RollingUpdate
+    status:
+      availableReplicas: 1
+      collisionCount: 0
+      currentReplicas: 1
+      currentRevision: karta-e2e-sts-7775b6b476
+      observedGeneration: 3
+      readyReplicas: 1
+      replicas: 2
+      updateRevision: karta-e2e-sts-7775b6b476
+      updatedReplicas: 1
+  resourceVersion: "13184"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:34:54Z"
+      generation: 3
+      name: karta-e2e-sts
+      namespace: test-8m4bc
+      uid: 915d7ead-d4b1-453c-9bd4-a34121becbfe
+    spec:
+      persistentVolumeClaimRetentionPolicy:
+        whenDeleted: Retain
+        whenScaled: Retain
+      podManagementPolicy: OrderedReady
+      replicas: 1
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: karta-e2e-sts
+      serviceName: karta-e2e-sts
+      template:
+        metadata:
+          labels:
+            app: karta-e2e-sts
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - sleep infinity
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: worker
+            resources:
+              requests:
+                cpu: 20m
+                memory: 32Mi
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+      updateStrategy:
+        rollingUpdate:
+          partition: 0
+        type: RollingUpdate
+    status:
+      availableReplicas: 1
+      collisionCount: 0
+      currentReplicas: 1
+      currentRevision: karta-e2e-sts-7775b6b476
+      observedGeneration: 3
+      readyReplicas: 1
+      replicas: 1
+      updateRevision: karta-e2e-sts-7775b6b476
+      updatedReplicas: 1
+  resourceVersion: "13187"
+  state: Running
+flow: scaled
+kartaFile: docs/catalog/apps-statefulset-v1.yaml
+kartaName: apps-statefulset-v1
+operator: statefulset
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Running


### PR DESCRIPTION
Part of #139 - one workload type per PR, stacked. Adds the statefulset flow: its spec steps, the predicates it judges stable states with (from the workload's own fields), and its recorded fixtures. Replayed offline by the suite in #260; `make check` green at every layer.