### PR TITLE
test(e2e): add the pytorchjob flow and its recorded fixtures

### DIFF
--- a/test/e2e/flows/pytorch_test.go
+++ b/test/e2e/flows/pytorch_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package flows
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kartav1alpha1 "github.com/run-ai/karta/pkg/api/runai/v1alpha1"
+	"github.com/run-ai/karta/test/e2e/recorder"
+)
+
+var _ = Describe("PyTorchJob", Ordered, Label("kubeflow", "pytorch"), func() {
+	var rec *recorder.Recorder
+	var fx recorder.Fixture
+
+	BeforeAll(func(ctx SpecContext) {
+		installKarta(ctx, "../../docs/catalog/kubeflow-org-pytorchjob-v1.yaml", "kubeflow-org-pytorchjob-v1")
+		fx = recorder.Fixture{Operator: "kubeflow", Version: operatorVersion("kubeflow"), KartaName: "kubeflow-org-pytorchjob-v1", KartaFile: "docs/catalog/kubeflow-org-pytorchjob-v1.yaml"}
+		rec = recorder.New(cfg).
+			SetTimeout(4*time.Minute).
+			AddState(kartav1alpha1.InitializingStatus, CondTrue("Created")).
+			AddState(kartav1alpha1.RunningStatus, CondTrue("Running")).
+			AddState(kartav1alpha1.CompletedStatus, CondTrue("Succeeded")).
+			AddState(kartav1alpha1.FailedStatus, CondTrue("Failed")).
+			AddState(kartav1alpha1.SuspendedStatus, CondTrue("Suspended"))
+	})
+
+	It("running", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "running", "testdata/pytorch/running.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("completed", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "completed", "testdata/pytorch/completed.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.CompletedStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("failed", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "failed", "testdata/pytorch/failed.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.FailedStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("suspended", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "suspended", "testdata/pytorch/suspended.yaml").
+			Through(recorder.Reaches(kartav1alpha1.SuspendedStatus)).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("resumed", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "resumed", "testdata/pytorch/resumed.yaml").Through(
+			recorder.Reaches(kartav1alpha1.SuspendedStatus).Do(ResumeRunPolicy()),
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+})

--- a/test/e2e/flows/testdata/pytorch/completed.yaml
+++ b/test/e2e/flows/testdata/pytorch/completed.yaml
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A PyTorchJob whose master sleeps briefly then exits 0, so the training-operator
+# marks it Running while it sleeps and Succeeded once it exits. The container must
+# be named "pytorch" for the operator to manage it.
+apiVersion: kubeflow.org/v1
+kind: PyTorchJob
+metadata:
+  name: karta-e2e-pytorch-completed
+  namespace: default
+spec:
+  pytorchReplicaSpecs:
+    Master:
+      replicas: 1
+      restartPolicy: Never
+      template:
+        spec:
+          containers:
+            - name: pytorch
+              image: busybox:1.36
+              command: ["sh", "-c", "sleep 15"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}

--- a/test/e2e/flows/testdata/pytorch/failed.yaml
+++ b/test/e2e/flows/testdata/pytorch/failed.yaml
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A PyTorchJob whose master sleeps briefly then exits 1, so the training-operator
+# marks it Running while it sleeps and Failed once it exits non-zero (restartPolicy
+# Never). The container must be named "pytorch" for the operator to manage it.
+apiVersion: kubeflow.org/v1
+kind: PyTorchJob
+metadata:
+  name: karta-e2e-pytorch-failed
+  namespace: default
+spec:
+  pytorchReplicaSpecs:
+    Master:
+      replicas: 1
+      restartPolicy: Never
+      template:
+        spec:
+          containers:
+            - name: pytorch
+              image: busybox:1.36
+              command: ["sh", "-c", "sleep 15; exit 1"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}

--- a/test/e2e/flows/testdata/pytorch/resumed.yaml
+++ b/test/e2e/flows/testdata/pytorch/resumed.yaml
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A PyTorchJob created suspended (runPolicy.suspend true), then resumed by the e2e action clearing
+# spec.runPolicy.suspend. The master then sleeps and the training-operator marks it Running. The
+# resumed flow records Suspended -> Running, the transition an operator will not make on its own.
+apiVersion: kubeflow.org/v1
+kind: PyTorchJob
+metadata:
+  name: karta-e2e-pytorch-resumed
+  namespace: default
+spec:
+  runPolicy:
+    suspend: true
+  pytorchReplicaSpecs:
+    Master:
+      replicas: 1
+      restartPolicy: Never
+      template:
+        spec:
+          containers:
+            - name: pytorch
+              image: busybox:1.36
+              command: ["sh", "-c", "sleep infinity"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}

--- a/test/e2e/flows/testdata/pytorch/running.yaml
+++ b/test/e2e/flows/testdata/pytorch/running.yaml
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A minimal PyTorchJob (1 master + 1 worker) whose containers sleep, so the
+# Kubeflow training-operator marks it Running on a CPU-only kind cluster. The
+# container must be named "pytorch" for the training-operator to manage it.
+apiVersion: kubeflow.org/v1
+kind: PyTorchJob
+metadata:
+  name: karta-e2e-pytorch
+  namespace: default
+spec:
+  pytorchReplicaSpecs:
+    Master:
+      replicas: 1
+      restartPolicy: Never
+      template:
+        spec:
+          containers:
+            - name: pytorch
+              image: busybox:1.36
+              command: ["sleep", "infinity"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}
+    Worker:
+      replicas: 1
+      restartPolicy: Never
+      template:
+        spec:
+          containers:
+            - name: pytorch
+              image: busybox:1.36
+              command: ["sleep", "infinity"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}

--- a/test/e2e/flows/testdata/pytorch/suspended.yaml
+++ b/test/e2e/flows/testdata/pytorch/suspended.yaml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A PyTorchJob created suspended (runPolicy.suspend true). The training-operator creates no pods and
+# sets the Suspended condition, which the definition reads as Suspended. Karta must read it as Suspended.
+apiVersion: kubeflow.org/v1
+kind: PyTorchJob
+metadata:
+  name: karta-e2e-pytorch-suspended
+  namespace: default
+spec:
+  runPolicy:
+    suspend: true
+  pytorchReplicaSpecs:
+    Master:
+      replicas: 1
+      restartPolicy: Never
+      template:
+        spec:
+          containers:
+            - name: pytorch
+              image: busybox:1.36
+              command: ["sh", "-c", "sleep infinity"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}

--- a/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-pytorchjob-v1/completed.yaml
+++ b/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-pytorchjob-v1/completed.yaml
@@ -1,0 +1,157 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:28:51Z"
+      generation: 1
+      name: karta-e2e-pytorch-completed
+      namespace: test-8m4bc
+      uid: 94beb090-b783-4615-a85a-973e05353d5a
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 15
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:28:51Z"
+        lastUpdateTime: "2026-08-18T12:28:51Z"
+        message: PyTorchJob karta-e2e-pytorch-completed is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      replicaStatuses:
+        Master:
+          selector: training.kubeflow.org/job-name=karta-e2e-pytorch-completed,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=master
+      startTime: "2026-08-18T12:28:51Z"
+  resourceVersion: "8313"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:28:51Z"
+      generation: 1
+      name: karta-e2e-pytorch-completed
+      namespace: test-8m4bc
+      uid: 94beb090-b783-4615-a85a-973e05353d5a
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 15
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:28:51Z"
+        lastUpdateTime: "2026-08-18T12:28:51Z"
+        message: PyTorchJob karta-e2e-pytorch-completed is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:28:52Z"
+        lastUpdateTime: "2026-08-18T12:28:52Z"
+        message: PyTorchJob karta-e2e-pytorch-completed is running.
+        reason: PyTorchJobRunning
+        status: "True"
+        type: Running
+      replicaStatuses:
+        Master:
+          active: 1
+          selector: training.kubeflow.org/job-name=karta-e2e-pytorch-completed,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=master
+      startTime: "2026-08-18T12:28:51Z"
+  resourceVersion: "8330"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:28:51Z"
+      generation: 1
+      name: karta-e2e-pytorch-completed
+      namespace: test-8m4bc
+      uid: 94beb090-b783-4615-a85a-973e05353d5a
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 15
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+    status:
+      completionTime: "2026-08-18T12:29:08Z"
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:28:51Z"
+        lastUpdateTime: "2026-08-18T12:28:51Z"
+        message: PyTorchJob karta-e2e-pytorch-completed is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:28:52Z"
+        lastUpdateTime: "2026-08-18T12:28:52Z"
+        message: PyTorchJob karta-e2e-pytorch-completed is running.
+        reason: PyTorchJobRunning
+        status: "False"
+        type: Running
+      - lastTransitionTime: "2026-08-18T12:29:08Z"
+        lastUpdateTime: "2026-08-18T12:29:08Z"
+        message: PyTorchJob karta-e2e-pytorch-completed is successfully completed.
+        reason: PyTorchJobSucceeded
+        status: "True"
+        type: Succeeded
+      replicaStatuses:
+        Master:
+          selector: training.kubeflow.org/job-name=karta-e2e-pytorch-completed,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=master
+          succeeded: 1
+      startTime: "2026-08-18T12:28:51Z"
+  resourceVersion: "8465"
+  state: Completed
+flow: completed
+kartaFile: docs/catalog/kubeflow-org-pytorchjob-v1.yaml
+kartaName: kubeflow-org-pytorchjob-v1
+operator: kubeflow
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Completed

--- a/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-pytorchjob-v1/failed.yaml
+++ b/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-pytorchjob-v1/failed.yaml
@@ -1,0 +1,158 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:29:08Z"
+      generation: 1
+      name: karta-e2e-pytorch-failed
+      namespace: test-8m4bc
+      uid: d5f1f1e6-7b0d-446e-945f-c60b6def2722
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 15; exit 1
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:29:08Z"
+        lastUpdateTime: "2026-08-18T12:29:08Z"
+        message: PyTorchJob karta-e2e-pytorch-failed is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      replicaStatuses:
+        Master:
+          selector: training.kubeflow.org/job-name=karta-e2e-pytorch-failed,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=master
+      startTime: "2026-08-18T12:29:08Z"
+  resourceVersion: "8485"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:29:08Z"
+      generation: 1
+      name: karta-e2e-pytorch-failed
+      namespace: test-8m4bc
+      uid: d5f1f1e6-7b0d-446e-945f-c60b6def2722
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 15; exit 1
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:29:08Z"
+        lastUpdateTime: "2026-08-18T12:29:08Z"
+        message: PyTorchJob karta-e2e-pytorch-failed is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:29:09Z"
+        lastUpdateTime: "2026-08-18T12:29:09Z"
+        message: PyTorchJob karta-e2e-pytorch-failed is running.
+        reason: PyTorchJobRunning
+        status: "True"
+        type: Running
+      replicaStatuses:
+        Master:
+          active: 1
+          selector: training.kubeflow.org/job-name=karta-e2e-pytorch-failed,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=master
+      startTime: "2026-08-18T12:29:08Z"
+  resourceVersion: "8498"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:29:08Z"
+      generation: 1
+      name: karta-e2e-pytorch-failed
+      namespace: test-8m4bc
+      uid: d5f1f1e6-7b0d-446e-945f-c60b6def2722
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 15; exit 1
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+    status:
+      completionTime: "2026-08-18T12:29:25Z"
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:29:08Z"
+        lastUpdateTime: "2026-08-18T12:29:08Z"
+        message: PyTorchJob karta-e2e-pytorch-failed is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:29:09Z"
+        lastUpdateTime: "2026-08-18T12:29:09Z"
+        message: PyTorchJob karta-e2e-pytorch-failed is running.
+        reason: PyTorchJobRunning
+        status: "False"
+        type: Running
+      - lastTransitionTime: "2026-08-18T12:29:25Z"
+        lastUpdateTime: "2026-08-18T12:29:25Z"
+        message: PyTorchJob karta-e2e-pytorch-failed is failed because 1 Master replica(s)
+          failed.
+        reason: PyTorchJobFailed
+        status: "True"
+        type: Failed
+      replicaStatuses:
+        Master:
+          failed: 1
+          selector: training.kubeflow.org/job-name=karta-e2e-pytorch-failed,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=master
+      startTime: "2026-08-18T12:29:08Z"
+  resourceVersion: "8637"
+  state: Failed
+flow: failed
+kartaFile: docs/catalog/kubeflow-org-pytorchjob-v1.yaml
+kartaName: kubeflow-org-pytorchjob-v1
+operator: kubeflow
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Failed

--- a/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-pytorchjob-v1/resumed.yaml
+++ b/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-pytorchjob-v1/resumed.yaml
@@ -1,0 +1,219 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:29:25Z"
+      generation: 1
+      name: karta-e2e-pytorch-resumed
+      namespace: test-8m4bc
+      uid: 90902c32-4091-4fbd-9249-d81eac7d604a
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep infinity
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runPolicy:
+        suspend: true
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:29:25Z"
+        lastUpdateTime: "2026-08-18T12:29:25Z"
+        message: PyTorchJob karta-e2e-pytorch-resumed is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:29:25Z"
+        lastUpdateTime: "2026-08-18T12:29:25Z"
+        message: PyTorchJob karta-e2e-pytorch-resumed is suspended.
+        reason: PyTorchJobSuspended
+        status: "True"
+        type: Suspended
+  resourceVersion: "8654"
+  state: Suspended
+- action:
+    name: Resume
+    operation:
+      patchType: application/merge-patch+json
+      payload:
+        spec:
+          runPolicy:
+            suspend: false
+      verb: PATCH
+  kind: ACTION
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:29:25Z"
+      generation: 2
+      name: karta-e2e-pytorch-resumed
+      namespace: test-8m4bc
+      uid: 90902c32-4091-4fbd-9249-d81eac7d604a
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep infinity
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runPolicy:
+        suspend: false
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:29:25Z"
+        lastUpdateTime: "2026-08-18T12:29:25Z"
+        message: PyTorchJob karta-e2e-pytorch-resumed is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:29:25Z"
+        lastUpdateTime: "2026-08-18T12:29:25Z"
+        message: PyTorchJob karta-e2e-pytorch-resumed is suspended.
+        reason: PyTorchJobSuspended
+        status: "True"
+        type: Suspended
+  resourceVersion: "8656"
+  state: Suspended
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:29:25Z"
+      generation: 2
+      name: karta-e2e-pytorch-resumed
+      namespace: test-8m4bc
+      uid: 90902c32-4091-4fbd-9249-d81eac7d604a
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep infinity
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runPolicy:
+        suspend: false
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:29:25Z"
+        lastUpdateTime: "2026-08-18T12:29:25Z"
+        message: PyTorchJob karta-e2e-pytorch-resumed is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:29:25Z"
+        lastUpdateTime: "2026-08-18T12:29:25Z"
+        message: PyTorchJob karta-e2e-pytorch-resumed is resumed.
+        reason: PyTorchJobResumed
+        status: "False"
+        type: Suspended
+      replicaStatuses:
+        Master:
+          selector: training.kubeflow.org/job-name=karta-e2e-pytorch-resumed,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=master
+      startTime: "2026-08-18T12:29:25Z"
+  resourceVersion: "8666"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:29:25Z"
+      generation: 2
+      name: karta-e2e-pytorch-resumed
+      namespace: test-8m4bc
+      uid: 90902c32-4091-4fbd-9249-d81eac7d604a
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep infinity
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runPolicy:
+        suspend: false
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:29:25Z"
+        lastUpdateTime: "2026-08-18T12:29:25Z"
+        message: PyTorchJob karta-e2e-pytorch-resumed is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:29:25Z"
+        lastUpdateTime: "2026-08-18T12:29:25Z"
+        message: PyTorchJob karta-e2e-pytorch-resumed is resumed.
+        reason: PyTorchJobResumed
+        status: "False"
+        type: Suspended
+      - lastTransitionTime: "2026-08-18T12:29:26Z"
+        lastUpdateTime: "2026-08-18T12:29:26Z"
+        message: PyTorchJob karta-e2e-pytorch-resumed is running.
+        reason: PyTorchJobRunning
+        status: "True"
+        type: Running
+      replicaStatuses:
+        Master:
+          active: 1
+          selector: training.kubeflow.org/job-name=karta-e2e-pytorch-resumed,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=master
+      startTime: "2026-08-18T12:29:25Z"
+  resourceVersion: "8682"
+  state: Running
+flow: resumed
+kartaFile: docs/catalog/kubeflow-org-pytorchjob-v1.yaml
+kartaName: kubeflow-org-pytorchjob-v1
+operator: kubeflow
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Running

--- a/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-pytorchjob-v1/running.yaml
+++ b/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-pytorchjob-v1/running.yaml
@@ -1,0 +1,133 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:28:51Z"
+      generation: 1
+      name: karta-e2e-pytorch
+      namespace: test-8m4bc
+      uid: b3e9e72f-a735-41e4-af36-a263afece952
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:28:51Z"
+        lastUpdateTime: "2026-08-18T12:28:51Z"
+        message: PyTorchJob karta-e2e-pytorch is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      replicaStatuses:
+        Master:
+          selector: training.kubeflow.org/job-name=karta-e2e-pytorch,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=master
+        Worker:
+          selector: training.kubeflow.org/job-name=karta-e2e-pytorch,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=worker
+      startTime: "2026-08-18T12:28:51Z"
+  resourceVersion: "8282"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:28:51Z"
+      generation: 1
+      name: karta-e2e-pytorch
+      namespace: test-8m4bc
+      uid: b3e9e72f-a735-41e4-af36-a263afece952
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:28:51Z"
+        lastUpdateTime: "2026-08-18T12:28:51Z"
+        message: PyTorchJob karta-e2e-pytorch is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:28:51Z"
+        lastUpdateTime: "2026-08-18T12:28:51Z"
+        message: PyTorchJob karta-e2e-pytorch is running.
+        reason: PyTorchJobRunning
+        status: "True"
+        type: Running
+      replicaStatuses:
+        Master:
+          active: 1
+          selector: training.kubeflow.org/job-name=karta-e2e-pytorch,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=master
+        Worker:
+          selector: training.kubeflow.org/job-name=karta-e2e-pytorch,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=worker
+      startTime: "2026-08-18T12:28:51Z"
+  resourceVersion: "8295"
+  state: Running
+flow: running
+kartaFile: docs/catalog/kubeflow-org-pytorchjob-v1.yaml
+kartaName: kubeflow-org-pytorchjob-v1
+operator: kubeflow
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Running

--- a/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-pytorchjob-v1/suspended.yaml
+++ b/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-pytorchjob-v1/suspended.yaml
@@ -1,0 +1,56 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:29:25Z"
+      generation: 1
+      name: karta-e2e-pytorch-suspended
+      namespace: test-8m4bc
+      uid: 9d5f034f-0ae1-42a8-ae67-dc9d5dea2d9d
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep infinity
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runPolicy:
+        suspend: true
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:29:25Z"
+        lastUpdateTime: "2026-08-18T12:29:25Z"
+        message: PyTorchJob karta-e2e-pytorch-suspended is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:29:25Z"
+        lastUpdateTime: "2026-08-18T12:29:25Z"
+        message: PyTorchJob karta-e2e-pytorch-suspended is suspended.
+        reason: PyTorchJobSuspended
+        status: "True"
+        type: Suspended
+  resourceVersion: "8648"
+  state: Suspended
+flow: suspended
+kartaFile: docs/catalog/kubeflow-org-pytorchjob-v1.yaml
+kartaName: kubeflow-org-pytorchjob-v1
+operator: kubeflow
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Suspended


### PR DESCRIPTION
Part of #139 - one workload type per PR, stacked. Adds the pytorchjob flow: its spec steps, the predicates it judges stable states with (from the workload's own fields), and its recorded fixtures. Replayed offline by the suite in #260; `make check` green at every layer.