### PR TITLE
test(e2e): add the mpijob flow and its recorded fixtures

### DIFF
--- a/test/e2e/flows/mpijob_test.go
+++ b/test/e2e/flows/mpijob_test.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package flows
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kartav1alpha1 "github.com/run-ai/karta/pkg/api/runai/v1alpha1"
+	"github.com/run-ai/karta/test/e2e/recorder"
+)
+
+var _ = Describe("MPIJob", Ordered, Label("kubeflow", "mpijob"), func() {
+	var rec *recorder.Recorder
+	var fx recorder.Fixture
+
+	BeforeAll(func(ctx SpecContext) {
+		installKarta(ctx, "../../docs/catalog/kubeflow-org-mpijob-v2beta1.yaml", "kubeflow-org-mpijob-v2beta1")
+		fx = recorder.Fixture{Operator: "kubeflow", Version: operatorVersion("kubeflow"), KartaName: "kubeflow-org-mpijob-v2beta1", KartaFile: "docs/catalog/kubeflow-org-mpijob-v2beta1.yaml"}
+		rec = recorder.New(cfg).
+			AddState(kartav1alpha1.InitializingStatus, CondTrue("Created")).
+			AddState(kartav1alpha1.RunningStatus, CondTrue("Running")).
+			AddState(kartav1alpha1.CompletedStatus, CondTrue("Succeeded")).
+			AddState(kartav1alpha1.FailedStatus, CondTrue("Failed")).
+			AddState(kartav1alpha1.SuspendedStatus, CondTrue("Suspended"))
+	})
+
+	It("running", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "running", "testdata/mpijob/running.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	// The launcher can finish before Running is observed (Optional), and Kubeflow keeps Created set so the
+	// CR reads Initializing again for a tick before the terminal.
+	It("completed", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "completed", "testdata/mpijob/completed.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.CompletedStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("failed", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "failed", "testdata/mpijob/failed.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.FailedStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("suspended", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "suspended", "testdata/mpijob/suspended.yaml").
+			Through(recorder.Reaches(kartav1alpha1.SuspendedStatus)).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("resumed", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "resumed", "testdata/mpijob/resumed.yaml").Through(
+			recorder.Reaches(kartav1alpha1.SuspendedStatus).Do(ResumeRunPolicy()),
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+})

--- a/test/e2e/flows/testdata/mpijob/completed.yaml
+++ b/test/e2e/flows/testdata/mpijob/completed.yaml
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A minimal MPIJob (kubeflow.org/v2beta1, served by the mpi-operator). The launcher runs `true`
+# and completes, so the job reaches a stable Succeeded condition on a CPU-only kind cluster.
+# cleanPodPolicy None keeps the worker pod so the component extraction still finds it.
+apiVersion: kubeflow.org/v2beta1
+kind: MPIJob
+metadata:
+  name: karta-e2e-mpi
+  namespace: default
+spec:
+  slotsPerWorker: 1
+  runPolicy:
+    cleanPodPolicy: None
+  mpiReplicaSpecs:
+    Launcher:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: mpi-launcher
+              image: busybox:1.36
+              command: ["true"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}
+    Worker:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: mpi-worker
+              image: busybox:1.36
+              command: ["sleep", "infinity"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}

--- a/test/e2e/flows/testdata/mpijob/failed.yaml
+++ b/test/e2e/flows/testdata/mpijob/failed.yaml
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A minimal MPIJob (kubeflow.org/v2beta1) whose launcher runs `false` and exits non-zero.
+# With backoffLimit 0 the mpi-operator gives up after the first failure and marks the job
+# Failed on a CPU-only kind cluster. cleanPodPolicy None keeps the worker pod for extraction.
+apiVersion: kubeflow.org/v2beta1
+kind: MPIJob
+metadata:
+  name: karta-e2e-mpi-failed
+  namespace: default
+spec:
+  slotsPerWorker: 1
+  runPolicy:
+    cleanPodPolicy: None
+    backoffLimit: 0
+  mpiReplicaSpecs:
+    Launcher:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: mpi-launcher
+              image: busybox:1.36
+              command: ["false"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}
+    Worker:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: mpi-worker
+              image: busybox:1.36
+              command: ["sleep", "infinity"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}

--- a/test/e2e/flows/testdata/mpijob/resumed.yaml
+++ b/test/e2e/flows/testdata/mpijob/resumed.yaml
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# An MPIJob created suspended (runPolicy.suspend true), then resumed by the e2e action clearing
+# spec.runPolicy.suspend. The launcher then sleeps and the mpi-operator marks it Running. The resumed
+# flow records Suspended -> Running.
+apiVersion: kubeflow.org/v2beta1
+kind: MPIJob
+metadata:
+  name: karta-e2e-mpi-resumed
+  namespace: default
+spec:
+  slotsPerWorker: 1
+  runPolicy:
+    cleanPodPolicy: None
+    suspend: true
+  mpiReplicaSpecs:
+    Launcher:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: mpi-launcher
+              image: busybox:1.36
+              command: ["sh", "-c", "sleep 300"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}
+    Worker:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: mpi-worker
+              image: busybox:1.36
+              command: ["sleep", "infinity"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}

--- a/test/e2e/flows/testdata/mpijob/running.yaml
+++ b/test/e2e/flows/testdata/mpijob/running.yaml
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# An MPIJob whose launcher sleeps for 5 minutes, so the mpi-operator holds it in the Running condition
+# long enough to record before it would finish. cleanPodPolicy None keeps the worker pod for extraction.
+apiVersion: kubeflow.org/v2beta1
+kind: MPIJob
+metadata:
+  name: karta-e2e-mpi-running
+  namespace: default
+spec:
+  slotsPerWorker: 1
+  runPolicy:
+    cleanPodPolicy: None
+  mpiReplicaSpecs:
+    Launcher:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: mpi-launcher
+              image: busybox:1.36
+              command: ["sh", "-c", "sleep 300"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}
+    Worker:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: mpi-worker
+              image: busybox:1.36
+              command: ["sleep", "infinity"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}

--- a/test/e2e/flows/testdata/mpijob/suspended.yaml
+++ b/test/e2e/flows/testdata/mpijob/suspended.yaml
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# An MPIJob created suspended (runPolicy.suspend true). The mpi-operator creates no pods and sets the
+# Suspended condition, which the definition reads as Suspended. Karta must read it as Suspended.
+apiVersion: kubeflow.org/v2beta1
+kind: MPIJob
+metadata:
+  name: karta-e2e-mpi-suspended
+  namespace: default
+spec:
+  slotsPerWorker: 1
+  runPolicy:
+    cleanPodPolicy: None
+    suspend: true
+  mpiReplicaSpecs:
+    Launcher:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: mpi-launcher
+              image: busybox:1.36
+              command: ["true"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}
+    Worker:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: mpi-worker
+              image: busybox:1.36
+              command: ["sleep", "infinity"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}

--- a/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-mpijob-v2beta1/completed.yaml
+++ b/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-mpijob-v2beta1/completed.yaml
@@ -1,0 +1,209 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:49Z"
+      generation: 1
+      name: karta-e2e-mpi
+      namespace: test-8m4bc
+      uid: 10169713-d8e0-4969-ae8e-a1b28b57f1a2
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - "true"
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:49Z"
+        lastUpdateTime: "2026-08-18T12:30:49Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      replicaStatuses:
+        Launcher: {}
+        Worker: {}
+      startTime: "2026-08-18T12:30:49Z"
+  resourceVersion: "9787"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:49Z"
+      generation: 1
+      name: karta-e2e-mpi
+      namespace: test-8m4bc
+      uid: 10169713-d8e0-4969-ae8e-a1b28b57f1a2
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - "true"
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:49Z"
+        lastUpdateTime: "2026-08-18T12:30:49Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      replicaStatuses:
+        Launcher: {}
+        Worker:
+          active: 1
+      startTime: "2026-08-18T12:30:49Z"
+  resourceVersion: "9814"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:49Z"
+      generation: 1
+      name: karta-e2e-mpi
+      namespace: test-8m4bc
+      uid: 10169713-d8e0-4969-ae8e-a1b28b57f1a2
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - "true"
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      completionTime: "2026-08-18T12:30:52Z"
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:49Z"
+        lastUpdateTime: "2026-08-18T12:30:49Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:30:52Z"
+        lastUpdateTime: "2026-08-18T12:30:52Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi successfully completed.
+        reason: MPIJobSucceeded
+        status: "True"
+        type: Succeeded
+      - lastTransitionTime: "2026-08-18T12:30:52Z"
+        lastUpdateTime: "2026-08-18T12:30:52Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi is finished but Running condition
+          was never set.
+        reason: MPIJobRunning
+        status: "False"
+        type: Running
+      replicaStatuses:
+        Launcher:
+          succeeded: 1
+        Worker: {}
+      startTime: "2026-08-18T12:30:49Z"
+  resourceVersion: "9840"
+  state: Completed
+flow: completed
+kartaFile: docs/catalog/kubeflow-org-mpijob-v2beta1.yaml
+kartaName: kubeflow-org-mpijob-v2beta1
+operator: kubeflow
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Completed

--- a/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-mpijob-v2beta1/failed.yaml
+++ b/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-mpijob-v2beta1/failed.yaml
@@ -1,0 +1,422 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:52Z"
+      generation: 1
+      name: karta-e2e-mpi-failed
+      namespace: test-8m4bc
+      uid: 8bbb958d-4a03-474a-8c81-1a974b74ffbf
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - "false"
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        backoffLimit: 0
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:52Z"
+        lastUpdateTime: "2026-08-18T12:30:52Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-failed is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      replicaStatuses:
+        Launcher: {}
+        Worker: {}
+      startTime: "2026-08-18T12:30:52Z"
+  resourceVersion: "9865"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:52Z"
+      generation: 1
+      name: karta-e2e-mpi-failed
+      namespace: test-8m4bc
+      uid: 8bbb958d-4a03-474a-8c81-1a974b74ffbf
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - "false"
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        backoffLimit: 0
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:52Z"
+        lastUpdateTime: "2026-08-18T12:30:52Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-failed is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      replicaStatuses:
+        Launcher: {}
+        Worker:
+          active: 1
+      startTime: "2026-08-18T12:30:52Z"
+  resourceVersion: "9890"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:52Z"
+      generation: 1
+      name: karta-e2e-mpi-failed
+      namespace: test-8m4bc
+      uid: 8bbb958d-4a03-474a-8c81-1a974b74ffbf
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - "false"
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        backoffLimit: 0
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:52Z"
+        lastUpdateTime: "2026-08-18T12:30:52Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-failed is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:30:53Z"
+        lastUpdateTime: "2026-08-18T12:30:53Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-failed is running.
+        reason: MPIJobRunning
+        status: "True"
+        type: Running
+      replicaStatuses:
+        Launcher:
+          active: 1
+        Worker:
+          active: 1
+      startTime: "2026-08-18T12:30:52Z"
+  resourceVersion: "9897"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:52Z"
+      generation: 1
+      name: karta-e2e-mpi-failed
+      namespace: test-8m4bc
+      uid: 8bbb958d-4a03-474a-8c81-1a974b74ffbf
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - "false"
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        backoffLimit: 0
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:52Z"
+        lastUpdateTime: "2026-08-18T12:30:52Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-failed is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:30:53Z"
+        lastUpdateTime: "2026-08-18T12:30:53Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-failed is running.
+        reason: MPIJobRunning
+        status: "True"
+        type: Running
+      replicaStatuses:
+        Launcher:
+          active: 1
+          failed: 1
+        Worker:
+          active: 1
+      startTime: "2026-08-18T12:30:52Z"
+  resourceVersion: "9941"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:52Z"
+      generation: 1
+      name: karta-e2e-mpi-failed
+      namespace: test-8m4bc
+      uid: 8bbb958d-4a03-474a-8c81-1a974b74ffbf
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - "false"
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        backoffLimit: 0
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:52Z"
+        lastUpdateTime: "2026-08-18T12:30:52Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-failed is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:30:53Z"
+        lastUpdateTime: "2026-08-18T12:30:53Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-failed is running.
+        reason: MPIJobRunning
+        status: "True"
+        type: Running
+      replicaStatuses:
+        Launcher:
+          failed: 1
+        Worker:
+          active: 1
+      startTime: "2026-08-18T12:30:52Z"
+  resourceVersion: "9946"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:52Z"
+      generation: 1
+      name: karta-e2e-mpi-failed
+      namespace: test-8m4bc
+      uid: 8bbb958d-4a03-474a-8c81-1a974b74ffbf
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - "false"
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        backoffLimit: 0
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      completionTime: "2026-08-18T12:30:56Z"
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:52Z"
+        lastUpdateTime: "2026-08-18T12:30:52Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-failed is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:30:53Z"
+        lastUpdateTime: "2026-08-18T12:30:53Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-failed is running.
+        reason: MPIJobRunning
+        status: "False"
+        type: Running
+      - lastTransitionTime: "2026-08-18T12:30:56Z"
+        lastUpdateTime: "2026-08-18T12:30:56Z"
+        message: Job has reached the specified backoff limit
+        reason: BackoffLimitExceeded
+        status: "True"
+        type: Failed
+      replicaStatuses:
+        Launcher:
+          failed: 1
+        Worker: {}
+      startTime: "2026-08-18T12:30:52Z"
+  resourceVersion: "9958"
+  state: Failed
+flow: failed
+kartaFile: docs/catalog/kubeflow-org-mpijob-v2beta1.yaml
+kartaName: kubeflow-org-mpijob-v2beta1
+operator: kubeflow
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Failed

--- a/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-mpijob-v2beta1/resumed.yaml
+++ b/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-mpijob-v2beta1/resumed.yaml
@@ -1,0 +1,396 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:56Z"
+      generation: 1
+      name: karta-e2e-mpi-resumed
+      namespace: test-8m4bc
+      uid: ef00bbaa-8a9d-4ae7-9b2e-40106aa0f038
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 300
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        cleanPodPolicy: None
+        suspend: true
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:56Z"
+        lastUpdateTime: "2026-08-18T12:30:56Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-resumed is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:30:56Z"
+        lastUpdateTime: "2026-08-18T12:30:56Z"
+        message: MPIJob suspended
+        reason: MPIJobSuspended
+        status: "True"
+        type: Suspended
+      - lastTransitionTime: "2026-08-18T12:30:56Z"
+        lastUpdateTime: "2026-08-18T12:30:56Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-resumed is suspended.
+        reason: MPIJobSuspended
+        status: "False"
+        type: Running
+      replicaStatuses:
+        Launcher: {}
+        Worker: {}
+  resourceVersion: "10006"
+  state: Suspended
+- action:
+    name: Resume
+    operation:
+      patchType: application/merge-patch+json
+      payload:
+        spec:
+          runPolicy:
+            suspend: false
+      verb: PATCH
+  kind: ACTION
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:56Z"
+      generation: 2
+      name: karta-e2e-mpi-resumed
+      namespace: test-8m4bc
+      uid: ef00bbaa-8a9d-4ae7-9b2e-40106aa0f038
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 300
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:56Z"
+        lastUpdateTime: "2026-08-18T12:30:56Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-resumed is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:30:56Z"
+        lastUpdateTime: "2026-08-18T12:30:56Z"
+        message: MPIJob suspended
+        reason: MPIJobSuspended
+        status: "True"
+        type: Suspended
+      - lastTransitionTime: "2026-08-18T12:30:56Z"
+        lastUpdateTime: "2026-08-18T12:30:56Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-resumed is suspended.
+        reason: MPIJobSuspended
+        status: "False"
+        type: Running
+      replicaStatuses:
+        Launcher: {}
+        Worker: {}
+  resourceVersion: "10007"
+  state: Suspended
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:56Z"
+      generation: 2
+      name: karta-e2e-mpi-resumed
+      namespace: test-8m4bc
+      uid: ef00bbaa-8a9d-4ae7-9b2e-40106aa0f038
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 300
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:56Z"
+        lastUpdateTime: "2026-08-18T12:30:56Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-resumed is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:30:56Z"
+        lastUpdateTime: "2026-08-18T12:30:56Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-resumed is suspended.
+        reason: MPIJobSuspended
+        status: "False"
+        type: Running
+      - lastTransitionTime: "2026-08-18T12:30:57Z"
+        lastUpdateTime: "2026-08-18T12:30:57Z"
+        message: MPIJob resumed
+        reason: MPIJobResumed
+        status: "False"
+        type: Suspended
+      replicaStatuses:
+        Launcher: {}
+        Worker: {}
+      startTime: "2026-08-18T12:30:57Z"
+  resourceVersion: "10020"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:56Z"
+      generation: 2
+      name: karta-e2e-mpi-resumed
+      namespace: test-8m4bc
+      uid: ef00bbaa-8a9d-4ae7-9b2e-40106aa0f038
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 300
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:56Z"
+        lastUpdateTime: "2026-08-18T12:30:56Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-resumed is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:30:56Z"
+        lastUpdateTime: "2026-08-18T12:30:56Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-resumed is suspended.
+        reason: MPIJobSuspended
+        status: "False"
+        type: Running
+      - lastTransitionTime: "2026-08-18T12:30:57Z"
+        lastUpdateTime: "2026-08-18T12:30:57Z"
+        message: MPIJob resumed
+        reason: MPIJobResumed
+        status: "False"
+        type: Suspended
+      replicaStatuses:
+        Launcher: {}
+        Worker:
+          active: 1
+      startTime: "2026-08-18T12:30:57Z"
+  resourceVersion: "10040"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:56Z"
+      generation: 2
+      name: karta-e2e-mpi-resumed
+      namespace: test-8m4bc
+      uid: ef00bbaa-8a9d-4ae7-9b2e-40106aa0f038
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 300
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:56Z"
+        lastUpdateTime: "2026-08-18T12:30:56Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-resumed is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:30:57Z"
+        lastUpdateTime: "2026-08-18T12:30:57Z"
+        message: MPIJob resumed
+        reason: MPIJobResumed
+        status: "False"
+        type: Suspended
+      - lastTransitionTime: "2026-08-18T12:30:59Z"
+        lastUpdateTime: "2026-08-18T12:30:59Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-resumed is running.
+        reason: MPIJobRunning
+        status: "True"
+        type: Running
+      replicaStatuses:
+        Launcher:
+          active: 1
+        Worker:
+          active: 1
+      startTime: "2026-08-18T12:30:57Z"
+  resourceVersion: "10056"
+  state: Running
+flow: resumed
+kartaFile: docs/catalog/kubeflow-org-mpijob-v2beta1.yaml
+kartaName: kubeflow-org-mpijob-v2beta1
+operator: kubeflow
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Running

--- a/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-mpijob-v2beta1/running.yaml
+++ b/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-mpijob-v2beta1/running.yaml
@@ -1,0 +1,208 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:47Z"
+      generation: 1
+      name: karta-e2e-mpi-running
+      namespace: test-8m4bc
+      uid: b8b542e8-7cbd-4749-b28d-96b52af8bf9e
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 300
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:47Z"
+        lastUpdateTime: "2026-08-18T12:30:47Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-running is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      replicaStatuses:
+        Launcher: {}
+        Worker: {}
+      startTime: "2026-08-18T12:30:47Z"
+  resourceVersion: "9726"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:47Z"
+      generation: 1
+      name: karta-e2e-mpi-running
+      namespace: test-8m4bc
+      uid: b8b542e8-7cbd-4749-b28d-96b52af8bf9e
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 300
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:47Z"
+        lastUpdateTime: "2026-08-18T12:30:47Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-running is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      replicaStatuses:
+        Launcher:
+          active: 1
+        Worker: {}
+      startTime: "2026-08-18T12:30:47Z"
+  resourceVersion: "9756"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:47Z"
+      generation: 1
+      name: karta-e2e-mpi-running
+      namespace: test-8m4bc
+      uid: b8b542e8-7cbd-4749-b28d-96b52af8bf9e
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 300
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:47Z"
+        lastUpdateTime: "2026-08-18T12:30:47Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-running is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:30:49Z"
+        lastUpdateTime: "2026-08-18T12:30:49Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-running is running.
+        reason: MPIJobRunning
+        status: "True"
+        type: Running
+      replicaStatuses:
+        Launcher:
+          active: 1
+        Worker:
+          active: 1
+      startTime: "2026-08-18T12:30:47Z"
+  resourceVersion: "9762"
+  state: Running
+flow: running
+kartaFile: docs/catalog/kubeflow-org-mpijob-v2beta1.yaml
+kartaName: kubeflow-org-mpijob-v2beta1
+operator: kubeflow
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Running

--- a/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-mpijob-v2beta1/suspended.yaml
+++ b/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-mpijob-v2beta1/suspended.yaml
@@ -1,0 +1,82 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:56Z"
+      generation: 1
+      name: karta-e2e-mpi-suspended
+      namespace: test-8m4bc
+      uid: 379fa2c4-f0d0-4bdb-a4a6-27dfe5edee7a
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - "true"
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        cleanPodPolicy: None
+        suspend: true
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:56Z"
+        lastUpdateTime: "2026-08-18T12:30:56Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-suspended is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:30:56Z"
+        lastUpdateTime: "2026-08-18T12:30:56Z"
+        message: MPIJob suspended
+        reason: MPIJobSuspended
+        status: "True"
+        type: Suspended
+      - lastTransitionTime: "2026-08-18T12:30:56Z"
+        lastUpdateTime: "2026-08-18T12:30:56Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-suspended is suspended.
+        reason: MPIJobSuspended
+        status: "False"
+        type: Running
+      replicaStatuses:
+        Launcher: {}
+        Worker: {}
+  resourceVersion: "9979"
+  state: Suspended
+flow: suspended
+kartaFile: docs/catalog/kubeflow-org-mpijob-v2beta1.yaml
+kartaName: kubeflow-org-mpijob-v2beta1
+operator: kubeflow
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Suspended


### PR DESCRIPTION
Part of #139 - one workload type per PR, stacked. Adds the mpijob flow: its spec steps, the predicates it judges stable states with (from the workload's own fields), and its recorded fixtures. Replayed offline by the suite in #260; `make check` green at every layer.