### PR TITLE
test(e2e): add the rayjob flow and its recorded fixtures

### DIFF
--- a/test/e2e/flows/cronjob_test.go
+++ b/test/e2e/flows/cronjob_test.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package flows
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kartav1alpha1 "github.com/run-ai/karta/pkg/api/runai/v1alpha1"
+	"github.com/run-ai/karta/test/e2e/recorder"
+)
+
+var _ = Describe("CronJob (built-in)", Ordered, Label("cronjob", "builtin"), func() {
+	var rec *recorder.Recorder
+	var fx recorder.Fixture
+
+	BeforeAll(func(ctx SpecContext) {
+		installKarta(ctx, "../../docs/catalog/batch-cronjob-v1.yaml", "batch-cronjob-v1")
+		fx = recorder.Fixture{Operator: "cronjob", Version: operatorVersion("cronjob"), KartaName: "batch-cronjob-v1", KartaFile: "docs/catalog/batch-cronjob-v1.yaml"}
+		rec = recorder.New(cfg).
+			AddState(kartav1alpha1.InitializingStatus, Absent("status", "lastScheduleTime")).
+			AddState(kartav1alpha1.RunningStatus, CronjobFired()).
+			AddState(kartav1alpha1.SuspendedStatus, BoolTrue("spec", "suspend"))
+	})
+
+	It("initializing", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "initializing", "testdata/cronjob/initializing.yaml").
+			Through(recorder.Reaches(kartav1alpha1.InitializingStatus)).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("running", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "running", "testdata/cronjob/running.yaml").
+			Through(recorder.Reaches(kartav1alpha1.RunningStatus)).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("suspended", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "suspended", "testdata/cronjob/suspended.yaml").
+			Through(recorder.Reaches(kartav1alpha1.SuspendedStatus)).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+})

--- a/test/e2e/flows/mpijob_test.go
+++ b/test/e2e/flows/mpijob_test.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package flows
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kartav1alpha1 "github.com/run-ai/karta/pkg/api/runai/v1alpha1"
+	"github.com/run-ai/karta/test/e2e/recorder"
+)
+
+var _ = Describe("MPIJob", Ordered, Label("kubeflow", "mpijob"), func() {
+	var rec *recorder.Recorder
+	var fx recorder.Fixture
+
+	BeforeAll(func(ctx SpecContext) {
+		installKarta(ctx, "../../docs/catalog/kubeflow-org-mpijob-v2beta1.yaml", "kubeflow-org-mpijob-v2beta1")
+		fx = recorder.Fixture{Operator: "kubeflow", Version: operatorVersion("kubeflow"), KartaName: "kubeflow-org-mpijob-v2beta1", KartaFile: "docs/catalog/kubeflow-org-mpijob-v2beta1.yaml"}
+		rec = recorder.New(cfg).
+			AddState(kartav1alpha1.InitializingStatus, CondTrue("Created")).
+			AddState(kartav1alpha1.RunningStatus, CondTrue("Running")).
+			AddState(kartav1alpha1.CompletedStatus, CondTrue("Succeeded")).
+			AddState(kartav1alpha1.FailedStatus, CondTrue("Failed")).
+			AddState(kartav1alpha1.SuspendedStatus, CondTrue("Suspended"))
+	})
+
+	It("running", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "running", "testdata/mpijob/running.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	// The launcher can finish before Running is observed (Optional), and Kubeflow keeps Created set so the
+	// CR reads Initializing again for a tick before the terminal.
+	It("completed", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "completed", "testdata/mpijob/completed.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.CompletedStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("failed", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "failed", "testdata/mpijob/failed.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.FailedStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("suspended", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "suspended", "testdata/mpijob/suspended.yaml").
+			Through(recorder.Reaches(kartav1alpha1.SuspendedStatus)).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("resumed", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "resumed", "testdata/mpijob/resumed.yaml").Through(
+			recorder.Reaches(kartav1alpha1.SuspendedStatus).Do(ResumeRunPolicy()),
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+})

--- a/test/e2e/flows/predicates.go
+++ b/test/e2e/flows/predicates.go
@@ -108,6 +108,22 @@ func IntEq(n int64, path ...string) recorder.StateCheck {
 	}
 }
 
+func BoolTrue(path ...string) recorder.StateCheck {
+	return func(u *unstructured.Unstructured) bool {
+		got, found, err := unstructured.NestedBool(u.Object, path...)
+		return err == nil && found && got
+	}
+}
+
+// Absent matches when the field at the given path is not present (a CronJob that has not scheduled yet
+// has no status.lastScheduleTime).
+func Absent(path ...string) recorder.StateCheck {
+	return func(u *unstructured.Unstructured) bool {
+		_, found, _ := unstructured.NestedFieldNoCopy(u.Object, path...)
+		return !found
+	}
+}
+
 // ReplicasReady matches a workload settled at exactly n replicas: status.replicas and status.readyReplicas
 // both equal n. It gates a scale flow's step so each replica count is captured only once the controller
 // has finished scaling to it, not mid-rollout.
@@ -160,6 +176,15 @@ func ReplicasInitializing() recorder.StateCheck {
 		ready, _, _ := unstructured.NestedInt64(u.Object, "status", "readyReplicas")
 		updated, _, _ := unstructured.NestedInt64(u.Object, "status", "updatedReplicas")
 		return desired > 0 && (ready == 0 || ready > desired || updated != desired)
+	}
+}
+
+// CronjobFired matches a CronJob that has scheduled at least once (status.lastScheduleTime set). Karta reads
+// a fired, enabled CronJob as Running (suspended wins via the registry order).
+func CronjobFired() recorder.StateCheck {
+	return func(u *unstructured.Unstructured) bool {
+		_, scheduled, _ := unstructured.NestedFieldNoCopy(u.Object, "status", "lastScheduleTime")
+		return scheduled
 	}
 }
 

--- a/test/e2e/flows/predicates.go
+++ b/test/e2e/flows/predicates.go
@@ -92,6 +92,20 @@ func PhaseEq(want string, path ...string) recorder.StateCheck {
 	}
 }
 
+// PhaseAny matches when the string at the path equals any of wants (some operators map one state from
+// several phase strings).
+func PhaseAny(wants []string, path ...string) recorder.StateCheck {
+	return func(u *unstructured.Unstructured) bool {
+		got, _, _ := unstructured.NestedString(u.Object, path...)
+		for _, w := range wants {
+			if got == w {
+				return true
+			}
+		}
+		return false
+	}
+}
+
 func IntAtLeast(n int64, path ...string) recorder.StateCheck {
 	return func(u *unstructured.Unstructured) bool {
 		got, found, err := unstructured.NestedInt64(u.Object, path...)
@@ -250,5 +264,21 @@ func JobsetInitializing() recorder.StateCheck {
 			}
 		}
 		return true
+	}
+}
+
+// RayJobInitializing matches a RayJob before its job runs: jobStatus PENDING, or empty while the RayJob
+// brings up its cluster and it is not suspended (jobDeploymentStatus Initializing/Running, or empty).
+func RayJobInitializing() recorder.StateCheck {
+	return func(u *unstructured.Unstructured) bool {
+		js, _, _ := unstructured.NestedString(u.Object, "status", "jobStatus")
+		if js == "PENDING" {
+			return true
+		}
+		if js != "" {
+			return false
+		}
+		ds, _, _ := unstructured.NestedString(u.Object, "status", "jobDeploymentStatus")
+		return ds != "Suspended" && ds != "Suspending"
 	}
 }

--- a/test/e2e/flows/pytorch_test.go
+++ b/test/e2e/flows/pytorch_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package flows
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kartav1alpha1 "github.com/run-ai/karta/pkg/api/runai/v1alpha1"
+	"github.com/run-ai/karta/test/e2e/recorder"
+)
+
+var _ = Describe("PyTorchJob", Ordered, Label("kubeflow", "pytorch"), func() {
+	var rec *recorder.Recorder
+	var fx recorder.Fixture
+
+	BeforeAll(func(ctx SpecContext) {
+		installKarta(ctx, "../../docs/catalog/kubeflow-org-pytorchjob-v1.yaml", "kubeflow-org-pytorchjob-v1")
+		fx = recorder.Fixture{Operator: "kubeflow", Version: operatorVersion("kubeflow"), KartaName: "kubeflow-org-pytorchjob-v1", KartaFile: "docs/catalog/kubeflow-org-pytorchjob-v1.yaml"}
+		rec = recorder.New(cfg).
+			SetTimeout(4*time.Minute).
+			AddState(kartav1alpha1.InitializingStatus, CondTrue("Created")).
+			AddState(kartav1alpha1.RunningStatus, CondTrue("Running")).
+			AddState(kartav1alpha1.CompletedStatus, CondTrue("Succeeded")).
+			AddState(kartav1alpha1.FailedStatus, CondTrue("Failed")).
+			AddState(kartav1alpha1.SuspendedStatus, CondTrue("Suspended"))
+	})
+
+	It("running", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "running", "testdata/pytorch/running.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("completed", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "completed", "testdata/pytorch/completed.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.CompletedStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("failed", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "failed", "testdata/pytorch/failed.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.FailedStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("suspended", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "suspended", "testdata/pytorch/suspended.yaml").
+			Through(recorder.Reaches(kartav1alpha1.SuspendedStatus)).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("resumed", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "resumed", "testdata/pytorch/resumed.yaml").Through(
+			recorder.Reaches(kartav1alpha1.SuspendedStatus).Do(ResumeRunPolicy()),
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+})

--- a/test/e2e/flows/rayjob_test.go
+++ b/test/e2e/flows/rayjob_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package flows
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kartav1alpha1 "github.com/run-ai/karta/pkg/api/runai/v1alpha1"
+	"github.com/run-ai/karta/test/e2e/recorder"
+)
+
+var _ = Describe("RayJob", Ordered, Label("kuberay", "rayjob"), func() {
+	var rec *recorder.Recorder
+	var fx recorder.Fixture
+
+	BeforeAll(func(ctx SpecContext) {
+		installKarta(ctx, "../../docs/catalog/ray-io-rayjob-v1.yaml", "ray-io-rayjob-v1")
+		fx = recorder.Fixture{Operator: "kuberay", Version: operatorVersion("kuberay"), KartaName: "ray-io-rayjob-v1", KartaFile: "docs/catalog/ray-io-rayjob-v1.yaml"}
+		rec = recorder.New(cfg).
+			SetTimeout(6*time.Minute).
+			AddState(kartav1alpha1.InitializingStatus, RayJobInitializing()).
+			AddState(kartav1alpha1.RunningStatus, PhaseEq("RUNNING", "status", "jobStatus")).
+			AddState(kartav1alpha1.CompletedStatus, PhaseEq("SUCCEEDED", "status", "jobStatus")).
+			AddState(kartav1alpha1.FailedStatus, PhaseEq("FAILED", "status", "jobStatus")).
+			AddState(kartav1alpha1.SuspendedStatus, PhaseAny([]string{"Suspended", "Suspending"}, "status", "jobDeploymentStatus"))
+	})
+
+	// jobStatus jumps between PENDING/RUNNING/SUCCEEDED/FAILED; a fast job can skip intermediates, so
+	// Initializing and (for terminal flows) Running are Optional.
+	It("running", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "running", "testdata/rayjob/running.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.RunningStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("completed", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "completed", "testdata/rayjob/completed.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.RunningStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.CompletedStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("failed", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "failed", "testdata/rayjob/failed.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.RunningStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.FailedStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("suspended", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "suspended", "testdata/rayjob/suspended.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.SuspendedStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("resumed", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "resumed", "testdata/rayjob/resumed.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.SuspendedStatus).Do(Resume()),
+			recorder.Reaches(kartav1alpha1.InitializingStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.RunningStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+})

--- a/test/e2e/flows/testdata/cronjob/initializing.yaml
+++ b/test/e2e/flows/testdata/cronjob/initializing.yaml
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A built-in batch/v1 CronJob with a schedule far in the future (Jan 1), so it never
+# fires during the test and status.lastScheduleTime stays unset. The Karta library
+# reads an enabled, never-scheduled CronJob as Initializing.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: karta-e2e-cronjob
+  namespace: default
+spec:
+  schedule: "0 0 1 1 *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: worker
+              image: busybox:1.36
+              command: ["true"]
+              resources:
+                requests: {cpu: 50m, memory: 32Mi}

--- a/test/e2e/flows/testdata/cronjob/running.yaml
+++ b/test/e2e/flows/testdata/cronjob/running.yaml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A CronJob scheduled every minute. Once it fires, its Job runs `true` and finishes,
+# so status.lastScheduleTime is set and status.active is empty. The Karta library
+# reads a fired, enabled CronJob as Running (lastScheduleTime != null). A distinct
+# name keeps it from colliding with the other CronJob flows.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: karta-e2e-cronjob-running
+  namespace: default
+spec:
+  schedule: "* * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: worker
+              image: busybox:1.36
+              command: ["true"]
+              resources:
+                requests: {cpu: 50m, memory: 32Mi}

--- a/test/e2e/flows/testdata/cronjob/suspended.yaml
+++ b/test/e2e/flows/testdata/cronjob/suspended.yaml
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A CronJob created suspended (spec.suspend=true). The Karta library reads it as
+# Suspended. A distinct name keeps it from colliding with the initializing CronJob.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: karta-e2e-cronjob-suspended
+  namespace: default
+spec:
+  schedule: "0 0 1 1 *"
+  suspend: true
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: worker
+              image: busybox:1.36
+              command: ["true"]
+              resources:
+                requests: {cpu: 50m, memory: 32Mi}

--- a/test/e2e/flows/testdata/mpijob/completed.yaml
+++ b/test/e2e/flows/testdata/mpijob/completed.yaml
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A minimal MPIJob (kubeflow.org/v2beta1, served by the mpi-operator). The launcher runs `true`
+# and completes, so the job reaches a stable Succeeded condition on a CPU-only kind cluster.
+# cleanPodPolicy None keeps the worker pod so the component extraction still finds it.
+apiVersion: kubeflow.org/v2beta1
+kind: MPIJob
+metadata:
+  name: karta-e2e-mpi
+  namespace: default
+spec:
+  slotsPerWorker: 1
+  runPolicy:
+    cleanPodPolicy: None
+  mpiReplicaSpecs:
+    Launcher:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: mpi-launcher
+              image: busybox:1.36
+              command: ["true"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}
+    Worker:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: mpi-worker
+              image: busybox:1.36
+              command: ["sleep", "infinity"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}

--- a/test/e2e/flows/testdata/mpijob/failed.yaml
+++ b/test/e2e/flows/testdata/mpijob/failed.yaml
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A minimal MPIJob (kubeflow.org/v2beta1) whose launcher runs `false` and exits non-zero.
+# With backoffLimit 0 the mpi-operator gives up after the first failure and marks the job
+# Failed on a CPU-only kind cluster. cleanPodPolicy None keeps the worker pod for extraction.
+apiVersion: kubeflow.org/v2beta1
+kind: MPIJob
+metadata:
+  name: karta-e2e-mpi-failed
+  namespace: default
+spec:
+  slotsPerWorker: 1
+  runPolicy:
+    cleanPodPolicy: None
+    backoffLimit: 0
+  mpiReplicaSpecs:
+    Launcher:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: mpi-launcher
+              image: busybox:1.36
+              command: ["false"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}
+    Worker:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: mpi-worker
+              image: busybox:1.36
+              command: ["sleep", "infinity"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}

--- a/test/e2e/flows/testdata/mpijob/resumed.yaml
+++ b/test/e2e/flows/testdata/mpijob/resumed.yaml
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# An MPIJob created suspended (runPolicy.suspend true), then resumed by the e2e action clearing
+# spec.runPolicy.suspend. The launcher then sleeps and the mpi-operator marks it Running. The resumed
+# flow records Suspended -> Running.
+apiVersion: kubeflow.org/v2beta1
+kind: MPIJob
+metadata:
+  name: karta-e2e-mpi-resumed
+  namespace: default
+spec:
+  slotsPerWorker: 1
+  runPolicy:
+    cleanPodPolicy: None
+    suspend: true
+  mpiReplicaSpecs:
+    Launcher:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: mpi-launcher
+              image: busybox:1.36
+              command: ["sh", "-c", "sleep 300"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}
+    Worker:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: mpi-worker
+              image: busybox:1.36
+              command: ["sleep", "infinity"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}

--- a/test/e2e/flows/testdata/mpijob/running.yaml
+++ b/test/e2e/flows/testdata/mpijob/running.yaml
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# An MPIJob whose launcher sleeps for 5 minutes, so the mpi-operator holds it in the Running condition
+# long enough to record before it would finish. cleanPodPolicy None keeps the worker pod for extraction.
+apiVersion: kubeflow.org/v2beta1
+kind: MPIJob
+metadata:
+  name: karta-e2e-mpi-running
+  namespace: default
+spec:
+  slotsPerWorker: 1
+  runPolicy:
+    cleanPodPolicy: None
+  mpiReplicaSpecs:
+    Launcher:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: mpi-launcher
+              image: busybox:1.36
+              command: ["sh", "-c", "sleep 300"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}
+    Worker:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: mpi-worker
+              image: busybox:1.36
+              command: ["sleep", "infinity"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}

--- a/test/e2e/flows/testdata/mpijob/suspended.yaml
+++ b/test/e2e/flows/testdata/mpijob/suspended.yaml
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# An MPIJob created suspended (runPolicy.suspend true). The mpi-operator creates no pods and sets the
+# Suspended condition, which the definition reads as Suspended. Karta must read it as Suspended.
+apiVersion: kubeflow.org/v2beta1
+kind: MPIJob
+metadata:
+  name: karta-e2e-mpi-suspended
+  namespace: default
+spec:
+  slotsPerWorker: 1
+  runPolicy:
+    cleanPodPolicy: None
+    suspend: true
+  mpiReplicaSpecs:
+    Launcher:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: mpi-launcher
+              image: busybox:1.36
+              command: ["true"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}
+    Worker:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: mpi-worker
+              image: busybox:1.36
+              command: ["sleep", "infinity"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}

--- a/test/e2e/flows/testdata/pytorch/completed.yaml
+++ b/test/e2e/flows/testdata/pytorch/completed.yaml
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A PyTorchJob whose master sleeps briefly then exits 0, so the training-operator
+# marks it Running while it sleeps and Succeeded once it exits. The container must
+# be named "pytorch" for the operator to manage it.
+apiVersion: kubeflow.org/v1
+kind: PyTorchJob
+metadata:
+  name: karta-e2e-pytorch-completed
+  namespace: default
+spec:
+  pytorchReplicaSpecs:
+    Master:
+      replicas: 1
+      restartPolicy: Never
+      template:
+        spec:
+          containers:
+            - name: pytorch
+              image: busybox:1.36
+              command: ["sh", "-c", "sleep 15"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}

--- a/test/e2e/flows/testdata/pytorch/failed.yaml
+++ b/test/e2e/flows/testdata/pytorch/failed.yaml
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A PyTorchJob whose master sleeps briefly then exits 1, so the training-operator
+# marks it Running while it sleeps and Failed once it exits non-zero (restartPolicy
+# Never). The container must be named "pytorch" for the operator to manage it.
+apiVersion: kubeflow.org/v1
+kind: PyTorchJob
+metadata:
+  name: karta-e2e-pytorch-failed
+  namespace: default
+spec:
+  pytorchReplicaSpecs:
+    Master:
+      replicas: 1
+      restartPolicy: Never
+      template:
+        spec:
+          containers:
+            - name: pytorch
+              image: busybox:1.36
+              command: ["sh", "-c", "sleep 15; exit 1"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}

--- a/test/e2e/flows/testdata/pytorch/resumed.yaml
+++ b/test/e2e/flows/testdata/pytorch/resumed.yaml
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A PyTorchJob created suspended (runPolicy.suspend true), then resumed by the e2e action clearing
+# spec.runPolicy.suspend. The master then sleeps and the training-operator marks it Running. The
+# resumed flow records Suspended -> Running, the transition an operator will not make on its own.
+apiVersion: kubeflow.org/v1
+kind: PyTorchJob
+metadata:
+  name: karta-e2e-pytorch-resumed
+  namespace: default
+spec:
+  runPolicy:
+    suspend: true
+  pytorchReplicaSpecs:
+    Master:
+      replicas: 1
+      restartPolicy: Never
+      template:
+        spec:
+          containers:
+            - name: pytorch
+              image: busybox:1.36
+              command: ["sh", "-c", "sleep infinity"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}

--- a/test/e2e/flows/testdata/pytorch/running.yaml
+++ b/test/e2e/flows/testdata/pytorch/running.yaml
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A minimal PyTorchJob (1 master + 1 worker) whose containers sleep, so the
+# Kubeflow training-operator marks it Running on a CPU-only kind cluster. The
+# container must be named "pytorch" for the training-operator to manage it.
+apiVersion: kubeflow.org/v1
+kind: PyTorchJob
+metadata:
+  name: karta-e2e-pytorch
+  namespace: default
+spec:
+  pytorchReplicaSpecs:
+    Master:
+      replicas: 1
+      restartPolicy: Never
+      template:
+        spec:
+          containers:
+            - name: pytorch
+              image: busybox:1.36
+              command: ["sleep", "infinity"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}
+    Worker:
+      replicas: 1
+      restartPolicy: Never
+      template:
+        spec:
+          containers:
+            - name: pytorch
+              image: busybox:1.36
+              command: ["sleep", "infinity"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}

--- a/test/e2e/flows/testdata/pytorch/suspended.yaml
+++ b/test/e2e/flows/testdata/pytorch/suspended.yaml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A PyTorchJob created suspended (runPolicy.suspend true). The training-operator creates no pods and
+# sets the Suspended condition, which the definition reads as Suspended. Karta must read it as Suspended.
+apiVersion: kubeflow.org/v1
+kind: PyTorchJob
+metadata:
+  name: karta-e2e-pytorch-suspended
+  namespace: default
+spec:
+  runPolicy:
+    suspend: true
+  pytorchReplicaSpecs:
+    Master:
+      replicas: 1
+      restartPolicy: Never
+      template:
+        spec:
+          containers:
+            - name: pytorch
+              image: busybox:1.36
+              command: ["sh", "-c", "sleep infinity"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}

--- a/test/e2e/flows/testdata/rayjob/completed.yaml
+++ b/test/e2e/flows/testdata/rayjob/completed.yaml
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A real RayJob driven to completion by KubeRay. The submitter runs the trivial
+# entrypoint on a single-node cluster and KubeRay reports .status.jobStatus.
+#
+# Two things make this reliable on local kind (see hack/e2e/up.sh):
+#   - the Ray image is pre-loaded into kind as ray-e2e:local (arch-native: the
+#     amd64 image under qemu crash-loops when running a job), so there is no
+#     ~3GB Docker Hub pull mid-test;
+#   - KubeRay 1.6.2 does not recreate the RayCluster on transient submitter
+#     hiccups the way 1.2.x did.
+# The head keeps num-cpus=1 so the job's driver has somewhere to run; no workers.
+apiVersion: ray.io/v1
+kind: RayJob
+metadata:
+  name: karta-e2e-rayjob
+  namespace: default
+spec:
+  entrypoint: 'python -c "print(''karta e2e ok'')"'
+  shutdownAfterJobFinishes: false
+  backoffLimit: 12
+  rayClusterSpec:
+    rayVersion: "2.40.0"
+    headGroupSpec:
+      rayStartParams:
+        num-cpus: "1"
+      template:
+        spec:
+          containers:
+            - name: ray-head
+              image: ray-e2e:local
+              imagePullPolicy: IfNotPresent
+              resources:
+                requests: {cpu: 500m, memory: 2Gi}
+                limits: {cpu: "2", memory: 3Gi}
+              readinessProbe:
+                tcpSocket: {port: 8265}
+                initialDelaySeconds: 15
+                periodSeconds: 5
+                failureThreshold: 90
+    workerGroupSpecs:
+      - groupName: small
+        replicas: 0
+        minReplicas: 0
+        maxReplicas: 0
+        rayStartParams: {}
+        template:
+          spec:
+            containers:
+              - name: ray-worker
+                image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                resources:
+                  requests: {cpu: 250m, memory: 512Mi}

--- a/test/e2e/flows/testdata/rayjob/failed.yaml
+++ b/test/e2e/flows/testdata/rayjob/failed.yaml
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A RayJob whose entrypoint exits non-zero. With backoffLimit 0 KubeRay does not retry,
+# so the driver's failure lands as .status.jobStatus=FAILED, which the definition reads as
+# Failed. Same single-node ray-e2e:local cluster shape as completed.yaml.
+apiVersion: ray.io/v1
+kind: RayJob
+metadata:
+  name: karta-e2e-rayjob-failed
+  namespace: default
+spec:
+  entrypoint: 'python -c "import sys; sys.exit(1)"'
+  shutdownAfterJobFinishes: false
+  backoffLimit: 0
+  rayClusterSpec:
+    rayVersion: "2.40.0"
+    headGroupSpec:
+      rayStartParams:
+        num-cpus: "1"
+      template:
+        spec:
+          containers:
+            - name: ray-head
+              image: ray-e2e:local
+              imagePullPolicy: IfNotPresent
+              resources:
+                requests: {cpu: 500m, memory: 2Gi}
+                limits: {cpu: "2", memory: 3Gi}
+              readinessProbe:
+                tcpSocket: {port: 8265}
+                initialDelaySeconds: 15
+                periodSeconds: 5
+                failureThreshold: 90
+    workerGroupSpecs:
+      - groupName: small
+        replicas: 0
+        minReplicas: 0
+        maxReplicas: 0
+        rayStartParams: {}
+        template:
+          spec:
+            containers:
+              - name: ray-worker
+                image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                resources:
+                  requests: {cpu: 250m, memory: 512Mi}

--- a/test/e2e/flows/testdata/rayjob/resumed.yaml
+++ b/test/e2e/flows/testdata/rayjob/resumed.yaml
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A RayJob created suspended (spec.suspend true), then resumed by the e2e action clearing spec.suspend.
+# KubeRay then brings up the cluster and the sleeping entrypoint runs, so jobStatus becomes RUNNING.
+# The resumed flow records Suspended -> Running.
+apiVersion: ray.io/v1
+kind: RayJob
+metadata:
+  name: karta-e2e-rayjob-resumed
+  namespace: default
+spec:
+  entrypoint: 'python -c "import time; time.sleep(300)"'
+  suspend: true
+  # KubeRay rejects a suspended RayJob unless shutdownAfterJobFinishes is true. The sleeping
+  # entrypoint keeps it RUNNING long enough to record after the resume, well before it would finish.
+  shutdownAfterJobFinishes: true
+  backoffLimit: 0
+  rayClusterSpec:
+    rayVersion: "2.40.0"
+    headGroupSpec:
+      rayStartParams:
+        num-cpus: "1"
+      template:
+        spec:
+          containers:
+            - name: ray-head
+              image: ray-e2e:local
+              imagePullPolicy: IfNotPresent
+              resources:
+                requests: {cpu: 500m, memory: 2Gi}
+                limits: {cpu: "2", memory: 3Gi}
+              readinessProbe:
+                tcpSocket: {port: 8265}
+                initialDelaySeconds: 15
+                periodSeconds: 5
+                failureThreshold: 90
+    workerGroupSpecs:
+      - groupName: small
+        replicas: 0
+        minReplicas: 0
+        maxReplicas: 0
+        rayStartParams: {}
+        template:
+          spec:
+            containers:
+              - name: ray-worker
+                image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                resources:
+                  requests: {cpu: 250m, memory: 512Mi}

--- a/test/e2e/flows/testdata/rayjob/running.yaml
+++ b/test/e2e/flows/testdata/rayjob/running.yaml
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A RayJob whose entrypoint sleeps for 5 minutes, so KubeRay holds status.jobStatus=RUNNING long
+# enough to record before it would finish. Same single-node ray-e2e:local cluster as completed.yaml.
+apiVersion: ray.io/v1
+kind: RayJob
+metadata:
+  name: karta-e2e-rayjob-running
+  namespace: default
+spec:
+  entrypoint: 'python -c "import time; time.sleep(300)"'
+  shutdownAfterJobFinishes: false
+  backoffLimit: 0
+  rayClusterSpec:
+    rayVersion: "2.40.0"
+    headGroupSpec:
+      rayStartParams:
+        num-cpus: "1"
+      template:
+        spec:
+          containers:
+            - name: ray-head
+              image: ray-e2e:local
+              imagePullPolicy: IfNotPresent
+              resources:
+                requests: {cpu: 500m, memory: 2Gi}
+                limits: {cpu: "2", memory: 3Gi}
+              readinessProbe:
+                tcpSocket: {port: 8265}
+                initialDelaySeconds: 15
+                periodSeconds: 5
+                failureThreshold: 90
+    workerGroupSpecs:
+      - groupName: small
+        replicas: 0
+        minReplicas: 0
+        maxReplicas: 0
+        rayStartParams: {}
+        template:
+          spec:
+            containers:
+              - name: ray-worker
+                image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                resources:
+                  requests: {cpu: 250m, memory: 512Mi}

--- a/test/e2e/flows/testdata/rayjob/suspended.yaml
+++ b/test/e2e/flows/testdata/rayjob/suspended.yaml
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A RayJob created suspended (spec.suspend=true): the operator creates no RayCluster
+# and sets status.jobDeploymentStatus=Suspended. The Karta library reads it as
+# Suspended. Because no cluster is created, this is cleaner than the running fixture.
+apiVersion: ray.io/v1
+kind: RayJob
+metadata:
+  name: karta-e2e-rayjob-suspended
+  namespace: default
+spec:
+  entrypoint: 'python -c "print(1)"'
+  suspend: true
+  shutdownAfterJobFinishes: true
+  rayClusterSpec:
+    rayVersion: "2.40.0"
+    headGroupSpec:
+      rayStartParams: {num-cpus: "1"}
+      template:
+        spec:
+          containers:
+            - name: ray-head
+              image: ray-e2e:local
+              imagePullPolicy: IfNotPresent
+              resources:
+                requests: {cpu: 500m, memory: 2Gi}
+    workerGroupSpecs:
+      - groupName: small
+        replicas: 0
+        minReplicas: 0
+        maxReplicas: 0
+        rayStartParams: {}
+        template:
+          spec:
+            containers:
+              - name: ray-worker
+                image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                resources:
+                  requests: {cpu: 250m, memory: 512Mi}

--- a/test/e2e/recorded_data/cronjob/v1.34.0/batch-cronjob-v1/initializing.yaml
+++ b/test/e2e/recorded_data/cronjob/v1.34.0/batch-cronjob-v1/initializing.yaml
@@ -1,0 +1,52 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: batch/v1
+    kind: CronJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:36:02Z"
+      generation: 1
+      name: karta-e2e-cronjob
+      namespace: test-8m4bc
+      uid: 601b3398-4070-4c27-a139-5dc120c78d1d
+    spec:
+      concurrencyPolicy: Allow
+      failedJobsHistoryLimit: 1
+      jobTemplate:
+        metadata: {}
+        spec:
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - command:
+                - "true"
+                image: busybox:1.36
+                imagePullPolicy: IfNotPresent
+                name: worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 32Mi
+                terminationMessagePath: /dev/termination-log
+                terminationMessagePolicy: File
+              dnsPolicy: ClusterFirst
+              restartPolicy: Never
+              schedulerName: default-scheduler
+              securityContext: {}
+              terminationGracePeriodSeconds: 30
+      schedule: 0 0 1 1 *
+      successfulJobsHistoryLimit: 3
+      suspend: false
+    status: {}
+  resourceVersion: "13251"
+  state: Initializing
+flow: initializing
+kartaFile: docs/catalog/batch-cronjob-v1.yaml
+kartaName: batch-cronjob-v1
+operator: cronjob
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Initializing

--- a/test/e2e/recorded_data/cronjob/v1.34.0/batch-cronjob-v1/running.yaml
+++ b/test/e2e/recorded_data/cronjob/v1.34.0/batch-cronjob-v1/running.yaml
@@ -1,0 +1,60 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: batch/v1
+    kind: CronJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:36:02Z"
+      generation: 1
+      name: karta-e2e-cronjob-running
+      namespace: test-8m4bc
+      uid: e200e284-7710-454d-8d9b-3a2499ac1d70
+    spec:
+      concurrencyPolicy: Allow
+      failedJobsHistoryLimit: 1
+      jobTemplate:
+        metadata: {}
+        spec:
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - command:
+                - "true"
+                image: busybox:1.36
+                imagePullPolicy: IfNotPresent
+                name: worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 32Mi
+                terminationMessagePath: /dev/termination-log
+                terminationMessagePolicy: File
+              dnsPolicy: ClusterFirst
+              restartPolicy: Never
+              schedulerName: default-scheduler
+              securityContext: {}
+              terminationGracePeriodSeconds: 30
+      schedule: '* * * * *'
+      successfulJobsHistoryLimit: 3
+      suspend: false
+    status:
+      active:
+      - apiVersion: batch/v1
+        kind: Job
+        name: karta-e2e-cronjob-running-29784277
+        namespace: test-8m4bc
+        resourceVersion: "13711"
+        uid: 08bfd067-15d8-47e2-a58b-5d6513930e1d
+      lastScheduleTime: "2026-08-18T12:37:00Z"
+  resourceVersion: "13713"
+  state: Running
+flow: running
+kartaFile: docs/catalog/batch-cronjob-v1.yaml
+kartaName: batch-cronjob-v1
+operator: cronjob
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Running

--- a/test/e2e/recorded_data/cronjob/v1.34.0/batch-cronjob-v1/suspended.yaml
+++ b/test/e2e/recorded_data/cronjob/v1.34.0/batch-cronjob-v1/suspended.yaml
@@ -1,0 +1,52 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: batch/v1
+    kind: CronJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:37:00Z"
+      generation: 1
+      name: karta-e2e-cronjob-suspended
+      namespace: test-8m4bc
+      uid: 977fbc85-c404-4416-8f50-3574dd27733a
+    spec:
+      concurrencyPolicy: Allow
+      failedJobsHistoryLimit: 1
+      jobTemplate:
+        metadata: {}
+        spec:
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - command:
+                - "true"
+                image: busybox:1.36
+                imagePullPolicy: IfNotPresent
+                name: worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 32Mi
+                terminationMessagePath: /dev/termination-log
+                terminationMessagePolicy: File
+              dnsPolicy: ClusterFirst
+              restartPolicy: Never
+              schedulerName: default-scheduler
+              securityContext: {}
+              terminationGracePeriodSeconds: 30
+      schedule: 0 0 1 1 *
+      successfulJobsHistoryLimit: 3
+      suspend: true
+    status: {}
+  resourceVersion: "13724"
+  state: Suspended
+flow: suspended
+kartaFile: docs/catalog/batch-cronjob-v1.yaml
+kartaName: batch-cronjob-v1
+operator: cronjob
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Suspended

--- a/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-mpijob-v2beta1/completed.yaml
+++ b/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-mpijob-v2beta1/completed.yaml
@@ -1,0 +1,209 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:49Z"
+      generation: 1
+      name: karta-e2e-mpi
+      namespace: test-8m4bc
+      uid: 10169713-d8e0-4969-ae8e-a1b28b57f1a2
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - "true"
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:49Z"
+        lastUpdateTime: "2026-08-18T12:30:49Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      replicaStatuses:
+        Launcher: {}
+        Worker: {}
+      startTime: "2026-08-18T12:30:49Z"
+  resourceVersion: "9787"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:49Z"
+      generation: 1
+      name: karta-e2e-mpi
+      namespace: test-8m4bc
+      uid: 10169713-d8e0-4969-ae8e-a1b28b57f1a2
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - "true"
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:49Z"
+        lastUpdateTime: "2026-08-18T12:30:49Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      replicaStatuses:
+        Launcher: {}
+        Worker:
+          active: 1
+      startTime: "2026-08-18T12:30:49Z"
+  resourceVersion: "9814"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:49Z"
+      generation: 1
+      name: karta-e2e-mpi
+      namespace: test-8m4bc
+      uid: 10169713-d8e0-4969-ae8e-a1b28b57f1a2
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - "true"
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      completionTime: "2026-08-18T12:30:52Z"
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:49Z"
+        lastUpdateTime: "2026-08-18T12:30:49Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:30:52Z"
+        lastUpdateTime: "2026-08-18T12:30:52Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi successfully completed.
+        reason: MPIJobSucceeded
+        status: "True"
+        type: Succeeded
+      - lastTransitionTime: "2026-08-18T12:30:52Z"
+        lastUpdateTime: "2026-08-18T12:30:52Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi is finished but Running condition
+          was never set.
+        reason: MPIJobRunning
+        status: "False"
+        type: Running
+      replicaStatuses:
+        Launcher:
+          succeeded: 1
+        Worker: {}
+      startTime: "2026-08-18T12:30:49Z"
+  resourceVersion: "9840"
+  state: Completed
+flow: completed
+kartaFile: docs/catalog/kubeflow-org-mpijob-v2beta1.yaml
+kartaName: kubeflow-org-mpijob-v2beta1
+operator: kubeflow
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Completed

--- a/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-mpijob-v2beta1/failed.yaml
+++ b/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-mpijob-v2beta1/failed.yaml
@@ -1,0 +1,422 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:52Z"
+      generation: 1
+      name: karta-e2e-mpi-failed
+      namespace: test-8m4bc
+      uid: 8bbb958d-4a03-474a-8c81-1a974b74ffbf
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - "false"
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        backoffLimit: 0
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:52Z"
+        lastUpdateTime: "2026-08-18T12:30:52Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-failed is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      replicaStatuses:
+        Launcher: {}
+        Worker: {}
+      startTime: "2026-08-18T12:30:52Z"
+  resourceVersion: "9865"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:52Z"
+      generation: 1
+      name: karta-e2e-mpi-failed
+      namespace: test-8m4bc
+      uid: 8bbb958d-4a03-474a-8c81-1a974b74ffbf
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - "false"
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        backoffLimit: 0
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:52Z"
+        lastUpdateTime: "2026-08-18T12:30:52Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-failed is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      replicaStatuses:
+        Launcher: {}
+        Worker:
+          active: 1
+      startTime: "2026-08-18T12:30:52Z"
+  resourceVersion: "9890"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:52Z"
+      generation: 1
+      name: karta-e2e-mpi-failed
+      namespace: test-8m4bc
+      uid: 8bbb958d-4a03-474a-8c81-1a974b74ffbf
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - "false"
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        backoffLimit: 0
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:52Z"
+        lastUpdateTime: "2026-08-18T12:30:52Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-failed is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:30:53Z"
+        lastUpdateTime: "2026-08-18T12:30:53Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-failed is running.
+        reason: MPIJobRunning
+        status: "True"
+        type: Running
+      replicaStatuses:
+        Launcher:
+          active: 1
+        Worker:
+          active: 1
+      startTime: "2026-08-18T12:30:52Z"
+  resourceVersion: "9897"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:52Z"
+      generation: 1
+      name: karta-e2e-mpi-failed
+      namespace: test-8m4bc
+      uid: 8bbb958d-4a03-474a-8c81-1a974b74ffbf
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - "false"
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        backoffLimit: 0
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:52Z"
+        lastUpdateTime: "2026-08-18T12:30:52Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-failed is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:30:53Z"
+        lastUpdateTime: "2026-08-18T12:30:53Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-failed is running.
+        reason: MPIJobRunning
+        status: "True"
+        type: Running
+      replicaStatuses:
+        Launcher:
+          active: 1
+          failed: 1
+        Worker:
+          active: 1
+      startTime: "2026-08-18T12:30:52Z"
+  resourceVersion: "9941"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:52Z"
+      generation: 1
+      name: karta-e2e-mpi-failed
+      namespace: test-8m4bc
+      uid: 8bbb958d-4a03-474a-8c81-1a974b74ffbf
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - "false"
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        backoffLimit: 0
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:52Z"
+        lastUpdateTime: "2026-08-18T12:30:52Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-failed is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:30:53Z"
+        lastUpdateTime: "2026-08-18T12:30:53Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-failed is running.
+        reason: MPIJobRunning
+        status: "True"
+        type: Running
+      replicaStatuses:
+        Launcher:
+          failed: 1
+        Worker:
+          active: 1
+      startTime: "2026-08-18T12:30:52Z"
+  resourceVersion: "9946"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:52Z"
+      generation: 1
+      name: karta-e2e-mpi-failed
+      namespace: test-8m4bc
+      uid: 8bbb958d-4a03-474a-8c81-1a974b74ffbf
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - "false"
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        backoffLimit: 0
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      completionTime: "2026-08-18T12:30:56Z"
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:52Z"
+        lastUpdateTime: "2026-08-18T12:30:52Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-failed is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:30:53Z"
+        lastUpdateTime: "2026-08-18T12:30:53Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-failed is running.
+        reason: MPIJobRunning
+        status: "False"
+        type: Running
+      - lastTransitionTime: "2026-08-18T12:30:56Z"
+        lastUpdateTime: "2026-08-18T12:30:56Z"
+        message: Job has reached the specified backoff limit
+        reason: BackoffLimitExceeded
+        status: "True"
+        type: Failed
+      replicaStatuses:
+        Launcher:
+          failed: 1
+        Worker: {}
+      startTime: "2026-08-18T12:30:52Z"
+  resourceVersion: "9958"
+  state: Failed
+flow: failed
+kartaFile: docs/catalog/kubeflow-org-mpijob-v2beta1.yaml
+kartaName: kubeflow-org-mpijob-v2beta1
+operator: kubeflow
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Failed

--- a/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-mpijob-v2beta1/resumed.yaml
+++ b/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-mpijob-v2beta1/resumed.yaml
@@ -1,0 +1,396 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:56Z"
+      generation: 1
+      name: karta-e2e-mpi-resumed
+      namespace: test-8m4bc
+      uid: ef00bbaa-8a9d-4ae7-9b2e-40106aa0f038
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 300
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        cleanPodPolicy: None
+        suspend: true
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:56Z"
+        lastUpdateTime: "2026-08-18T12:30:56Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-resumed is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:30:56Z"
+        lastUpdateTime: "2026-08-18T12:30:56Z"
+        message: MPIJob suspended
+        reason: MPIJobSuspended
+        status: "True"
+        type: Suspended
+      - lastTransitionTime: "2026-08-18T12:30:56Z"
+        lastUpdateTime: "2026-08-18T12:30:56Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-resumed is suspended.
+        reason: MPIJobSuspended
+        status: "False"
+        type: Running
+      replicaStatuses:
+        Launcher: {}
+        Worker: {}
+  resourceVersion: "10006"
+  state: Suspended
+- action:
+    name: Resume
+    operation:
+      patchType: application/merge-patch+json
+      payload:
+        spec:
+          runPolicy:
+            suspend: false
+      verb: PATCH
+  kind: ACTION
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:56Z"
+      generation: 2
+      name: karta-e2e-mpi-resumed
+      namespace: test-8m4bc
+      uid: ef00bbaa-8a9d-4ae7-9b2e-40106aa0f038
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 300
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:56Z"
+        lastUpdateTime: "2026-08-18T12:30:56Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-resumed is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:30:56Z"
+        lastUpdateTime: "2026-08-18T12:30:56Z"
+        message: MPIJob suspended
+        reason: MPIJobSuspended
+        status: "True"
+        type: Suspended
+      - lastTransitionTime: "2026-08-18T12:30:56Z"
+        lastUpdateTime: "2026-08-18T12:30:56Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-resumed is suspended.
+        reason: MPIJobSuspended
+        status: "False"
+        type: Running
+      replicaStatuses:
+        Launcher: {}
+        Worker: {}
+  resourceVersion: "10007"
+  state: Suspended
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:56Z"
+      generation: 2
+      name: karta-e2e-mpi-resumed
+      namespace: test-8m4bc
+      uid: ef00bbaa-8a9d-4ae7-9b2e-40106aa0f038
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 300
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:56Z"
+        lastUpdateTime: "2026-08-18T12:30:56Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-resumed is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:30:56Z"
+        lastUpdateTime: "2026-08-18T12:30:56Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-resumed is suspended.
+        reason: MPIJobSuspended
+        status: "False"
+        type: Running
+      - lastTransitionTime: "2026-08-18T12:30:57Z"
+        lastUpdateTime: "2026-08-18T12:30:57Z"
+        message: MPIJob resumed
+        reason: MPIJobResumed
+        status: "False"
+        type: Suspended
+      replicaStatuses:
+        Launcher: {}
+        Worker: {}
+      startTime: "2026-08-18T12:30:57Z"
+  resourceVersion: "10020"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:56Z"
+      generation: 2
+      name: karta-e2e-mpi-resumed
+      namespace: test-8m4bc
+      uid: ef00bbaa-8a9d-4ae7-9b2e-40106aa0f038
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 300
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:56Z"
+        lastUpdateTime: "2026-08-18T12:30:56Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-resumed is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:30:56Z"
+        lastUpdateTime: "2026-08-18T12:30:56Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-resumed is suspended.
+        reason: MPIJobSuspended
+        status: "False"
+        type: Running
+      - lastTransitionTime: "2026-08-18T12:30:57Z"
+        lastUpdateTime: "2026-08-18T12:30:57Z"
+        message: MPIJob resumed
+        reason: MPIJobResumed
+        status: "False"
+        type: Suspended
+      replicaStatuses:
+        Launcher: {}
+        Worker:
+          active: 1
+      startTime: "2026-08-18T12:30:57Z"
+  resourceVersion: "10040"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:56Z"
+      generation: 2
+      name: karta-e2e-mpi-resumed
+      namespace: test-8m4bc
+      uid: ef00bbaa-8a9d-4ae7-9b2e-40106aa0f038
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 300
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:56Z"
+        lastUpdateTime: "2026-08-18T12:30:56Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-resumed is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:30:57Z"
+        lastUpdateTime: "2026-08-18T12:30:57Z"
+        message: MPIJob resumed
+        reason: MPIJobResumed
+        status: "False"
+        type: Suspended
+      - lastTransitionTime: "2026-08-18T12:30:59Z"
+        lastUpdateTime: "2026-08-18T12:30:59Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-resumed is running.
+        reason: MPIJobRunning
+        status: "True"
+        type: Running
+      replicaStatuses:
+        Launcher:
+          active: 1
+        Worker:
+          active: 1
+      startTime: "2026-08-18T12:30:57Z"
+  resourceVersion: "10056"
+  state: Running
+flow: resumed
+kartaFile: docs/catalog/kubeflow-org-mpijob-v2beta1.yaml
+kartaName: kubeflow-org-mpijob-v2beta1
+operator: kubeflow
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Running

--- a/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-mpijob-v2beta1/running.yaml
+++ b/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-mpijob-v2beta1/running.yaml
@@ -1,0 +1,208 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:47Z"
+      generation: 1
+      name: karta-e2e-mpi-running
+      namespace: test-8m4bc
+      uid: b8b542e8-7cbd-4749-b28d-96b52af8bf9e
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 300
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:47Z"
+        lastUpdateTime: "2026-08-18T12:30:47Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-running is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      replicaStatuses:
+        Launcher: {}
+        Worker: {}
+      startTime: "2026-08-18T12:30:47Z"
+  resourceVersion: "9726"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:47Z"
+      generation: 1
+      name: karta-e2e-mpi-running
+      namespace: test-8m4bc
+      uid: b8b542e8-7cbd-4749-b28d-96b52af8bf9e
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 300
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:47Z"
+        lastUpdateTime: "2026-08-18T12:30:47Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-running is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      replicaStatuses:
+        Launcher:
+          active: 1
+        Worker: {}
+      startTime: "2026-08-18T12:30:47Z"
+  resourceVersion: "9756"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:47Z"
+      generation: 1
+      name: karta-e2e-mpi-running
+      namespace: test-8m4bc
+      uid: b8b542e8-7cbd-4749-b28d-96b52af8bf9e
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 300
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:47Z"
+        lastUpdateTime: "2026-08-18T12:30:47Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-running is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:30:49Z"
+        lastUpdateTime: "2026-08-18T12:30:49Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-running is running.
+        reason: MPIJobRunning
+        status: "True"
+        type: Running
+      replicaStatuses:
+        Launcher:
+          active: 1
+        Worker:
+          active: 1
+      startTime: "2026-08-18T12:30:47Z"
+  resourceVersion: "9762"
+  state: Running
+flow: running
+kartaFile: docs/catalog/kubeflow-org-mpijob-v2beta1.yaml
+kartaName: kubeflow-org-mpijob-v2beta1
+operator: kubeflow
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Running

--- a/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-mpijob-v2beta1/suspended.yaml
+++ b/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-mpijob-v2beta1/suspended.yaml
@@ -1,0 +1,82 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:30:56Z"
+      generation: 1
+      name: karta-e2e-mpi-suspended
+      namespace: test-8m4bc
+      uid: 379fa2c4-f0d0-4bdb-a4a6-27dfe5edee7a
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - "true"
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        cleanPodPolicy: None
+        suspend: true
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:56Z"
+        lastUpdateTime: "2026-08-18T12:30:56Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-suspended is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:30:56Z"
+        lastUpdateTime: "2026-08-18T12:30:56Z"
+        message: MPIJob suspended
+        reason: MPIJobSuspended
+        status: "True"
+        type: Suspended
+      - lastTransitionTime: "2026-08-18T12:30:56Z"
+        lastUpdateTime: "2026-08-18T12:30:56Z"
+        message: MPIJob test-8m4bc/karta-e2e-mpi-suspended is suspended.
+        reason: MPIJobSuspended
+        status: "False"
+        type: Running
+      replicaStatuses:
+        Launcher: {}
+        Worker: {}
+  resourceVersion: "9979"
+  state: Suspended
+flow: suspended
+kartaFile: docs/catalog/kubeflow-org-mpijob-v2beta1.yaml
+kartaName: kubeflow-org-mpijob-v2beta1
+operator: kubeflow
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Suspended

--- a/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-pytorchjob-v1/completed.yaml
+++ b/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-pytorchjob-v1/completed.yaml
@@ -1,0 +1,157 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:28:51Z"
+      generation: 1
+      name: karta-e2e-pytorch-completed
+      namespace: test-8m4bc
+      uid: 94beb090-b783-4615-a85a-973e05353d5a
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 15
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:28:51Z"
+        lastUpdateTime: "2026-08-18T12:28:51Z"
+        message: PyTorchJob karta-e2e-pytorch-completed is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      replicaStatuses:
+        Master:
+          selector: training.kubeflow.org/job-name=karta-e2e-pytorch-completed,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=master
+      startTime: "2026-08-18T12:28:51Z"
+  resourceVersion: "8313"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:28:51Z"
+      generation: 1
+      name: karta-e2e-pytorch-completed
+      namespace: test-8m4bc
+      uid: 94beb090-b783-4615-a85a-973e05353d5a
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 15
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:28:51Z"
+        lastUpdateTime: "2026-08-18T12:28:51Z"
+        message: PyTorchJob karta-e2e-pytorch-completed is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:28:52Z"
+        lastUpdateTime: "2026-08-18T12:28:52Z"
+        message: PyTorchJob karta-e2e-pytorch-completed is running.
+        reason: PyTorchJobRunning
+        status: "True"
+        type: Running
+      replicaStatuses:
+        Master:
+          active: 1
+          selector: training.kubeflow.org/job-name=karta-e2e-pytorch-completed,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=master
+      startTime: "2026-08-18T12:28:51Z"
+  resourceVersion: "8330"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:28:51Z"
+      generation: 1
+      name: karta-e2e-pytorch-completed
+      namespace: test-8m4bc
+      uid: 94beb090-b783-4615-a85a-973e05353d5a
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 15
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+    status:
+      completionTime: "2026-08-18T12:29:08Z"
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:28:51Z"
+        lastUpdateTime: "2026-08-18T12:28:51Z"
+        message: PyTorchJob karta-e2e-pytorch-completed is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:28:52Z"
+        lastUpdateTime: "2026-08-18T12:28:52Z"
+        message: PyTorchJob karta-e2e-pytorch-completed is running.
+        reason: PyTorchJobRunning
+        status: "False"
+        type: Running
+      - lastTransitionTime: "2026-08-18T12:29:08Z"
+        lastUpdateTime: "2026-08-18T12:29:08Z"
+        message: PyTorchJob karta-e2e-pytorch-completed is successfully completed.
+        reason: PyTorchJobSucceeded
+        status: "True"
+        type: Succeeded
+      replicaStatuses:
+        Master:
+          selector: training.kubeflow.org/job-name=karta-e2e-pytorch-completed,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=master
+          succeeded: 1
+      startTime: "2026-08-18T12:28:51Z"
+  resourceVersion: "8465"
+  state: Completed
+flow: completed
+kartaFile: docs/catalog/kubeflow-org-pytorchjob-v1.yaml
+kartaName: kubeflow-org-pytorchjob-v1
+operator: kubeflow
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Completed

--- a/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-pytorchjob-v1/failed.yaml
+++ b/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-pytorchjob-v1/failed.yaml
@@ -1,0 +1,158 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:29:08Z"
+      generation: 1
+      name: karta-e2e-pytorch-failed
+      namespace: test-8m4bc
+      uid: d5f1f1e6-7b0d-446e-945f-c60b6def2722
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 15; exit 1
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:29:08Z"
+        lastUpdateTime: "2026-08-18T12:29:08Z"
+        message: PyTorchJob karta-e2e-pytorch-failed is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      replicaStatuses:
+        Master:
+          selector: training.kubeflow.org/job-name=karta-e2e-pytorch-failed,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=master
+      startTime: "2026-08-18T12:29:08Z"
+  resourceVersion: "8485"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:29:08Z"
+      generation: 1
+      name: karta-e2e-pytorch-failed
+      namespace: test-8m4bc
+      uid: d5f1f1e6-7b0d-446e-945f-c60b6def2722
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 15; exit 1
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:29:08Z"
+        lastUpdateTime: "2026-08-18T12:29:08Z"
+        message: PyTorchJob karta-e2e-pytorch-failed is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:29:09Z"
+        lastUpdateTime: "2026-08-18T12:29:09Z"
+        message: PyTorchJob karta-e2e-pytorch-failed is running.
+        reason: PyTorchJobRunning
+        status: "True"
+        type: Running
+      replicaStatuses:
+        Master:
+          active: 1
+          selector: training.kubeflow.org/job-name=karta-e2e-pytorch-failed,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=master
+      startTime: "2026-08-18T12:29:08Z"
+  resourceVersion: "8498"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:29:08Z"
+      generation: 1
+      name: karta-e2e-pytorch-failed
+      namespace: test-8m4bc
+      uid: d5f1f1e6-7b0d-446e-945f-c60b6def2722
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 15; exit 1
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+    status:
+      completionTime: "2026-08-18T12:29:25Z"
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:29:08Z"
+        lastUpdateTime: "2026-08-18T12:29:08Z"
+        message: PyTorchJob karta-e2e-pytorch-failed is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:29:09Z"
+        lastUpdateTime: "2026-08-18T12:29:09Z"
+        message: PyTorchJob karta-e2e-pytorch-failed is running.
+        reason: PyTorchJobRunning
+        status: "False"
+        type: Running
+      - lastTransitionTime: "2026-08-18T12:29:25Z"
+        lastUpdateTime: "2026-08-18T12:29:25Z"
+        message: PyTorchJob karta-e2e-pytorch-failed is failed because 1 Master replica(s)
+          failed.
+        reason: PyTorchJobFailed
+        status: "True"
+        type: Failed
+      replicaStatuses:
+        Master:
+          failed: 1
+          selector: training.kubeflow.org/job-name=karta-e2e-pytorch-failed,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=master
+      startTime: "2026-08-18T12:29:08Z"
+  resourceVersion: "8637"
+  state: Failed
+flow: failed
+kartaFile: docs/catalog/kubeflow-org-pytorchjob-v1.yaml
+kartaName: kubeflow-org-pytorchjob-v1
+operator: kubeflow
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Failed

--- a/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-pytorchjob-v1/resumed.yaml
+++ b/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-pytorchjob-v1/resumed.yaml
@@ -1,0 +1,219 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:29:25Z"
+      generation: 1
+      name: karta-e2e-pytorch-resumed
+      namespace: test-8m4bc
+      uid: 90902c32-4091-4fbd-9249-d81eac7d604a
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep infinity
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runPolicy:
+        suspend: true
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:29:25Z"
+        lastUpdateTime: "2026-08-18T12:29:25Z"
+        message: PyTorchJob karta-e2e-pytorch-resumed is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:29:25Z"
+        lastUpdateTime: "2026-08-18T12:29:25Z"
+        message: PyTorchJob karta-e2e-pytorch-resumed is suspended.
+        reason: PyTorchJobSuspended
+        status: "True"
+        type: Suspended
+  resourceVersion: "8654"
+  state: Suspended
+- action:
+    name: Resume
+    operation:
+      patchType: application/merge-patch+json
+      payload:
+        spec:
+          runPolicy:
+            suspend: false
+      verb: PATCH
+  kind: ACTION
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:29:25Z"
+      generation: 2
+      name: karta-e2e-pytorch-resumed
+      namespace: test-8m4bc
+      uid: 90902c32-4091-4fbd-9249-d81eac7d604a
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep infinity
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runPolicy:
+        suspend: false
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:29:25Z"
+        lastUpdateTime: "2026-08-18T12:29:25Z"
+        message: PyTorchJob karta-e2e-pytorch-resumed is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:29:25Z"
+        lastUpdateTime: "2026-08-18T12:29:25Z"
+        message: PyTorchJob karta-e2e-pytorch-resumed is suspended.
+        reason: PyTorchJobSuspended
+        status: "True"
+        type: Suspended
+  resourceVersion: "8656"
+  state: Suspended
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:29:25Z"
+      generation: 2
+      name: karta-e2e-pytorch-resumed
+      namespace: test-8m4bc
+      uid: 90902c32-4091-4fbd-9249-d81eac7d604a
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep infinity
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runPolicy:
+        suspend: false
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:29:25Z"
+        lastUpdateTime: "2026-08-18T12:29:25Z"
+        message: PyTorchJob karta-e2e-pytorch-resumed is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:29:25Z"
+        lastUpdateTime: "2026-08-18T12:29:25Z"
+        message: PyTorchJob karta-e2e-pytorch-resumed is resumed.
+        reason: PyTorchJobResumed
+        status: "False"
+        type: Suspended
+      replicaStatuses:
+        Master:
+          selector: training.kubeflow.org/job-name=karta-e2e-pytorch-resumed,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=master
+      startTime: "2026-08-18T12:29:25Z"
+  resourceVersion: "8666"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:29:25Z"
+      generation: 2
+      name: karta-e2e-pytorch-resumed
+      namespace: test-8m4bc
+      uid: 90902c32-4091-4fbd-9249-d81eac7d604a
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep infinity
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runPolicy:
+        suspend: false
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:29:25Z"
+        lastUpdateTime: "2026-08-18T12:29:25Z"
+        message: PyTorchJob karta-e2e-pytorch-resumed is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:29:25Z"
+        lastUpdateTime: "2026-08-18T12:29:25Z"
+        message: PyTorchJob karta-e2e-pytorch-resumed is resumed.
+        reason: PyTorchJobResumed
+        status: "False"
+        type: Suspended
+      - lastTransitionTime: "2026-08-18T12:29:26Z"
+        lastUpdateTime: "2026-08-18T12:29:26Z"
+        message: PyTorchJob karta-e2e-pytorch-resumed is running.
+        reason: PyTorchJobRunning
+        status: "True"
+        type: Running
+      replicaStatuses:
+        Master:
+          active: 1
+          selector: training.kubeflow.org/job-name=karta-e2e-pytorch-resumed,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=master
+      startTime: "2026-08-18T12:29:25Z"
+  resourceVersion: "8682"
+  state: Running
+flow: resumed
+kartaFile: docs/catalog/kubeflow-org-pytorchjob-v1.yaml
+kartaName: kubeflow-org-pytorchjob-v1
+operator: kubeflow
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Running

--- a/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-pytorchjob-v1/running.yaml
+++ b/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-pytorchjob-v1/running.yaml
@@ -1,0 +1,133 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:28:51Z"
+      generation: 1
+      name: karta-e2e-pytorch
+      namespace: test-8m4bc
+      uid: b3e9e72f-a735-41e4-af36-a263afece952
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:28:51Z"
+        lastUpdateTime: "2026-08-18T12:28:51Z"
+        message: PyTorchJob karta-e2e-pytorch is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      replicaStatuses:
+        Master:
+          selector: training.kubeflow.org/job-name=karta-e2e-pytorch,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=master
+        Worker:
+          selector: training.kubeflow.org/job-name=karta-e2e-pytorch,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=worker
+      startTime: "2026-08-18T12:28:51Z"
+  resourceVersion: "8282"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:28:51Z"
+      generation: 1
+      name: karta-e2e-pytorch
+      namespace: test-8m4bc
+      uid: b3e9e72f-a735-41e4-af36-a263afece952
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:28:51Z"
+        lastUpdateTime: "2026-08-18T12:28:51Z"
+        message: PyTorchJob karta-e2e-pytorch is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:28:51Z"
+        lastUpdateTime: "2026-08-18T12:28:51Z"
+        message: PyTorchJob karta-e2e-pytorch is running.
+        reason: PyTorchJobRunning
+        status: "True"
+        type: Running
+      replicaStatuses:
+        Master:
+          active: 1
+          selector: training.kubeflow.org/job-name=karta-e2e-pytorch,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=master
+        Worker:
+          selector: training.kubeflow.org/job-name=karta-e2e-pytorch,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=worker
+      startTime: "2026-08-18T12:28:51Z"
+  resourceVersion: "8295"
+  state: Running
+flow: running
+kartaFile: docs/catalog/kubeflow-org-pytorchjob-v1.yaml
+kartaName: kubeflow-org-pytorchjob-v1
+operator: kubeflow
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Running

--- a/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-pytorchjob-v1/suspended.yaml
+++ b/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-pytorchjob-v1/suspended.yaml
@@ -1,0 +1,56 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:29:25Z"
+      generation: 1
+      name: karta-e2e-pytorch-suspended
+      namespace: test-8m4bc
+      uid: 9d5f034f-0ae1-42a8-ae67-dc9d5dea2d9d
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep infinity
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runPolicy:
+        suspend: true
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:29:25Z"
+        lastUpdateTime: "2026-08-18T12:29:25Z"
+        message: PyTorchJob karta-e2e-pytorch-suspended is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-08-18T12:29:25Z"
+        lastUpdateTime: "2026-08-18T12:29:25Z"
+        message: PyTorchJob karta-e2e-pytorch-suspended is suspended.
+        reason: PyTorchJobSuspended
+        status: "True"
+        type: Suspended
+  resourceVersion: "8648"
+  state: Suspended
+flow: suspended
+kartaFile: docs/catalog/kubeflow-org-pytorchjob-v1.yaml
+kartaName: kubeflow-org-pytorchjob-v1
+operator: kubeflow
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Suspended

--- a/test/e2e/recorded_data/kuberay/v1.34.0/ray-io-rayjob-v1/completed.yaml
+++ b/test/e2e/recorded_data/kuberay/v1.34.0/ray-io-rayjob-v1/completed.yaml
@@ -1,0 +1,929 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:33:05Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 2
+      name: karta-e2e-rayjob
+      namespace: test-8m4bc
+      uid: d39621ce-328b-48de-b075-134e930b15da
+    spec:
+      backoffLimit: 12
+      entrypoint: python -c "print('karta e2e ok')"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      submissionMode: K8sJobMode
+      ttlSecondsAfterFinished: 0
+  resourceVersion: "11308"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:33:05Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 2
+      name: karta-e2e-rayjob
+      namespace: test-8m4bc
+      uid: d39621ce-328b-48de-b075-134e930b15da
+    spec:
+      backoffLimit: 12
+      entrypoint: python -c "print('karta e2e ok')"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      submissionMode: K8sJobMode
+      ttlSecondsAfterFinished: 0
+    status:
+      failed: 0
+      jobDeploymentStatus: Initializing
+      jobId: karta-e2e-rayjob-n4w8l
+      rayClusterName: karta-e2e-rayjob-6zjw9
+      rayClusterStatus:
+        desiredCPU: "0"
+        desiredGPU: "0"
+        desiredMemory: "0"
+        desiredTPU: "0"
+        head: {}
+      rayJobInfo: {}
+      startTime: "2026-08-18T12:33:05Z"
+      succeeded: 0
+  resourceVersion: "11315"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:33:05Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 2
+      name: karta-e2e-rayjob
+      namespace: test-8m4bc
+      uid: d39621ce-328b-48de-b075-134e930b15da
+    spec:
+      backoffLimit: 12
+      entrypoint: python -c "print('karta e2e ok')"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      submissionMode: K8sJobMode
+      ttlSecondsAfterFinished: 0
+    status:
+      failed: 0
+      jobDeploymentStatus: Initializing
+      jobId: karta-e2e-rayjob-n4w8l
+      rayClusterName: karta-e2e-rayjob-6zjw9
+      rayClusterStatus:
+        conditions:
+        - lastTransitionTime: "2026-08-18T12:33:05Z"
+          message: Head Pod not found
+          reason: HeadPodNotFound
+          status: "False"
+          type: HeadPodReady
+        - lastTransitionTime: "2026-08-18T12:33:05Z"
+          message: RayCluster Pods are being provisioned for first time
+          reason: RayClusterPodsProvisioning
+          status: "False"
+          type: RayClusterProvisioned
+        - lastTransitionTime: "2026-08-18T12:33:05Z"
+          message: ""
+          reason: RayClusterSuspended
+          status: "False"
+          type: RayClusterSuspended
+        - lastTransitionTime: "2026-08-18T12:33:05Z"
+          message: ""
+          reason: RayClusterSuspending
+          status: "False"
+          type: RayClusterSuspending
+        desiredCPU: 500m
+        desiredGPU: "0"
+        desiredMemory: 2Gi
+        desiredTPU: "0"
+        endpoints:
+          client: "10001"
+          dashboard: "8265"
+          gcs-server: "6379"
+          metrics: "8080"
+          serve: "8000"
+        head:
+          serviceName: karta-e2e-rayjob-6zjw9-head-svc
+        lastUpdateTime: "2026-08-18T12:33:05Z"
+        observedGeneration: 1
+      rayJobInfo: {}
+      startTime: "2026-08-18T12:33:05Z"
+      succeeded: 0
+  resourceVersion: "11333"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:33:05Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 2
+      name: karta-e2e-rayjob
+      namespace: test-8m4bc
+      uid: d39621ce-328b-48de-b075-134e930b15da
+    spec:
+      backoffLimit: 12
+      entrypoint: python -c "print('karta e2e ok')"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      submissionMode: K8sJobMode
+      ttlSecondsAfterFinished: 0
+    status:
+      failed: 0
+      jobDeploymentStatus: Initializing
+      jobId: karta-e2e-rayjob-n4w8l
+      rayClusterName: karta-e2e-rayjob-6zjw9
+      rayClusterStatus:
+        conditions:
+        - lastTransitionTime: "2026-08-18T12:33:05Z"
+          message: ""
+          reason: Unknown
+          status: "False"
+          type: HeadPodReady
+        - lastTransitionTime: "2026-08-18T12:33:05Z"
+          message: RayCluster Pods are being provisioned for first time
+          reason: RayClusterPodsProvisioning
+          status: "False"
+          type: RayClusterProvisioned
+        - lastTransitionTime: "2026-08-18T12:33:05Z"
+          message: ""
+          reason: RayClusterSuspended
+          status: "False"
+          type: RayClusterSuspended
+        - lastTransitionTime: "2026-08-18T12:33:05Z"
+          message: ""
+          reason: RayClusterSuspending
+          status: "False"
+          type: RayClusterSuspending
+        desiredCPU: 500m
+        desiredGPU: "0"
+        desiredMemory: 2Gi
+        desiredTPU: "0"
+        endpoints:
+          client: "10001"
+          dashboard: "8265"
+          gcs-server: "6379"
+          metrics: "8080"
+          serve: "8000"
+        head:
+          podName: karta-e2e-rayjob-6zjw9-head-cl54v
+          serviceName: karta-e2e-rayjob-6zjw9-head-svc
+        lastUpdateTime: "2026-08-18T12:33:05Z"
+        observedGeneration: 1
+      rayJobInfo: {}
+      startTime: "2026-08-18T12:33:05Z"
+      succeeded: 0
+  resourceVersion: "11336"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:33:05Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 2
+      name: karta-e2e-rayjob
+      namespace: test-8m4bc
+      uid: d39621ce-328b-48de-b075-134e930b15da
+    spec:
+      backoffLimit: 12
+      entrypoint: python -c "print('karta e2e ok')"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      submissionMode: K8sJobMode
+      ttlSecondsAfterFinished: 0
+    status:
+      failed: 0
+      jobDeploymentStatus: Initializing
+      jobId: karta-e2e-rayjob-n4w8l
+      rayClusterName: karta-e2e-rayjob-6zjw9
+      rayClusterStatus:
+        conditions:
+        - lastTransitionTime: "2026-08-18T12:33:05Z"
+          message: 'containers with unready status: [ray-head]; ray-head: '
+          reason: ContainerCreating
+          status: "False"
+          type: HeadPodReady
+        - lastTransitionTime: "2026-08-18T12:33:05Z"
+          message: RayCluster Pods are being provisioned for first time
+          reason: RayClusterPodsProvisioning
+          status: "False"
+          type: RayClusterProvisioned
+        - lastTransitionTime: "2026-08-18T12:33:05Z"
+          message: ""
+          reason: RayClusterSuspended
+          status: "False"
+          type: RayClusterSuspended
+        - lastTransitionTime: "2026-08-18T12:33:05Z"
+          message: ""
+          reason: RayClusterSuspending
+          status: "False"
+          type: RayClusterSuspending
+        desiredCPU: 500m
+        desiredGPU: "0"
+        desiredMemory: 2Gi
+        desiredTPU: "0"
+        endpoints:
+          client: "10001"
+          dashboard: "8265"
+          gcs-server: "6379"
+          metrics: "8080"
+          serve: "8000"
+        head:
+          podName: karta-e2e-rayjob-6zjw9-head-cl54v
+          serviceName: karta-e2e-rayjob-6zjw9-head-svc
+        lastUpdateTime: "2026-08-18T12:33:05Z"
+        observedGeneration: 1
+      rayJobInfo: {}
+      startTime: "2026-08-18T12:33:05Z"
+      succeeded: 0
+  resourceVersion: "11343"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:33:05Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 2
+      name: karta-e2e-rayjob
+      namespace: test-8m4bc
+      uid: d39621ce-328b-48de-b075-134e930b15da
+    spec:
+      backoffLimit: 12
+      entrypoint: python -c "print('karta e2e ok')"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      submissionMode: K8sJobMode
+      ttlSecondsAfterFinished: 0
+    status:
+      failed: 0
+      jobDeploymentStatus: Initializing
+      jobId: karta-e2e-rayjob-n4w8l
+      rayClusterName: karta-e2e-rayjob-6zjw9
+      rayClusterStatus:
+        conditions:
+        - lastTransitionTime: "2026-08-18T12:33:05Z"
+          message: 'containers with unready status: [ray-head]'
+          reason: ContainersNotReady
+          status: "False"
+          type: HeadPodReady
+        - lastTransitionTime: "2026-08-18T12:33:05Z"
+          message: RayCluster Pods are being provisioned for first time
+          reason: RayClusterPodsProvisioning
+          status: "False"
+          type: RayClusterProvisioned
+        - lastTransitionTime: "2026-08-18T12:33:05Z"
+          message: ""
+          reason: RayClusterSuspended
+          status: "False"
+          type: RayClusterSuspended
+        - lastTransitionTime: "2026-08-18T12:33:05Z"
+          message: ""
+          reason: RayClusterSuspending
+          status: "False"
+          type: RayClusterSuspending
+        desiredCPU: 500m
+        desiredGPU: "0"
+        desiredMemory: 2Gi
+        desiredTPU: "0"
+        endpoints:
+          client: "10001"
+          dashboard: "8265"
+          gcs-server: "6379"
+          metrics: "8080"
+          serve: "8000"
+        head:
+          podIP: 10.244.2.46
+          podName: karta-e2e-rayjob-6zjw9-head-cl54v
+          serviceIP: 10.244.2.46
+          serviceName: karta-e2e-rayjob-6zjw9-head-svc
+        lastUpdateTime: "2026-08-18T12:33:06Z"
+        observedGeneration: 1
+      rayJobInfo: {}
+      startTime: "2026-08-18T12:33:05Z"
+      succeeded: 0
+  resourceVersion: "11360"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:33:05Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 2
+      name: karta-e2e-rayjob
+      namespace: test-8m4bc
+      uid: d39621ce-328b-48de-b075-134e930b15da
+    spec:
+      backoffLimit: 12
+      entrypoint: python -c "print('karta e2e ok')"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      submissionMode: K8sJobMode
+      ttlSecondsAfterFinished: 0
+    status:
+      dashboardURL: karta-e2e-rayjob-6zjw9-head-svc.test-8m4bc.svc.cluster.local:8265
+      failed: 0
+      jobDeploymentStatus: Running
+      jobId: karta-e2e-rayjob-n4w8l
+      rayClusterName: karta-e2e-rayjob-6zjw9
+      rayClusterStatus:
+        conditions:
+        - lastTransitionTime: "2026-08-18T12:33:05Z"
+          message: 'containers with unready status: [ray-head]'
+          reason: ContainersNotReady
+          status: "False"
+          type: HeadPodReady
+        - lastTransitionTime: "2026-08-18T12:33:05Z"
+          message: RayCluster Pods are being provisioned for first time
+          reason: RayClusterPodsProvisioning
+          status: "False"
+          type: RayClusterProvisioned
+        - lastTransitionTime: "2026-08-18T12:33:05Z"
+          message: ""
+          reason: RayClusterSuspended
+          status: "False"
+          type: RayClusterSuspended
+        - lastTransitionTime: "2026-08-18T12:33:05Z"
+          message: ""
+          reason: RayClusterSuspending
+          status: "False"
+          type: RayClusterSuspending
+        desiredCPU: 500m
+        desiredGPU: "0"
+        desiredMemory: 2Gi
+        desiredTPU: "0"
+        endpoints:
+          client: "10001"
+          dashboard: "8265"
+          gcs-server: "6379"
+          metrics: "8080"
+          serve: "8000"
+        head:
+          podIP: 10.244.2.46
+          podName: karta-e2e-rayjob-6zjw9-head-cl54v
+          serviceIP: 10.244.2.46
+          serviceName: karta-e2e-rayjob-6zjw9-head-svc
+        lastUpdateTime: "2026-08-18T12:33:06Z"
+        observedGeneration: 1
+      rayJobInfo: {}
+      startTime: "2026-08-18T12:33:05Z"
+      succeeded: 0
+  resourceVersion: "11496"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:33:05Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 2
+      name: karta-e2e-rayjob
+      namespace: test-8m4bc
+      uid: d39621ce-328b-48de-b075-134e930b15da
+    spec:
+      backoffLimit: 12
+      entrypoint: python -c "print('karta e2e ok')"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      submissionMode: K8sJobMode
+      ttlSecondsAfterFinished: 0
+    status:
+      dashboardURL: karta-e2e-rayjob-6zjw9-head-svc.test-8m4bc.svc.cluster.local:8265
+      failed: 0
+      jobDeploymentStatus: Running
+      jobId: karta-e2e-rayjob-n4w8l
+      jobStatus: PENDING
+      message: Job has not started yet.
+      rayClusterName: karta-e2e-rayjob-6zjw9
+      rayClusterStatus:
+        conditions:
+        - lastTransitionTime: "2026-08-18T12:33:22Z"
+          message: ""
+          reason: HeadPodRunningAndReady
+          status: "True"
+          type: HeadPodReady
+        - lastTransitionTime: "2026-08-18T12:33:22Z"
+          message: All Ray Pods are ready for the first time
+          reason: AllPodRunningAndReadyFirstTime
+          status: "True"
+          type: RayClusterProvisioned
+        - lastTransitionTime: "2026-08-18T12:33:05Z"
+          message: ""
+          reason: RayClusterSuspended
+          status: "False"
+          type: RayClusterSuspended
+        - lastTransitionTime: "2026-08-18T12:33:05Z"
+          message: ""
+          reason: RayClusterSuspending
+          status: "False"
+          type: RayClusterSuspending
+        desiredCPU: 500m
+        desiredGPU: "0"
+        desiredMemory: 2Gi
+        desiredTPU: "0"
+        endpoints:
+          client: "10001"
+          dashboard: "8265"
+          gcs-server: "6379"
+          metrics: "8080"
+          serve: "8000"
+        head:
+          podIP: 10.244.2.46
+          podName: karta-e2e-rayjob-6zjw9-head-cl54v
+          serviceIP: 10.244.2.46
+          serviceName: karta-e2e-rayjob-6zjw9-head-svc
+        lastUpdateTime: "2026-08-18T12:33:22Z"
+        observedGeneration: 1
+        state: ready
+        stateTransitionTimes:
+          ready: "2026-08-18T12:33:22Z"
+      rayJobInfo:
+        startTime: "2026-08-18T12:33:24Z"
+      startTime: "2026-08-18T12:33:05Z"
+      succeeded: 0
+  resourceVersion: "11537"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:33:05Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 2
+      name: karta-e2e-rayjob
+      namespace: test-8m4bc
+      uid: d39621ce-328b-48de-b075-134e930b15da
+    spec:
+      backoffLimit: 12
+      entrypoint: python -c "print('karta e2e ok')"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      submissionMode: K8sJobMode
+      ttlSecondsAfterFinished: 0
+    status:
+      dashboardURL: karta-e2e-rayjob-6zjw9-head-svc.test-8m4bc.svc.cluster.local:8265
+      failed: 0
+      jobDeploymentStatus: Running
+      jobId: karta-e2e-rayjob-n4w8l
+      jobStatus: SUCCEEDED
+      message: Job finished successfully.
+      rayClusterName: karta-e2e-rayjob-6zjw9
+      rayClusterStatus:
+        conditions:
+        - lastTransitionTime: "2026-08-18T12:33:22Z"
+          message: ""
+          reason: HeadPodRunningAndReady
+          status: "True"
+          type: HeadPodReady
+        - lastTransitionTime: "2026-08-18T12:33:22Z"
+          message: All Ray Pods are ready for the first time
+          reason: AllPodRunningAndReadyFirstTime
+          status: "True"
+          type: RayClusterProvisioned
+        - lastTransitionTime: "2026-08-18T12:33:05Z"
+          message: ""
+          reason: RayClusterSuspended
+          status: "False"
+          type: RayClusterSuspended
+        - lastTransitionTime: "2026-08-18T12:33:05Z"
+          message: ""
+          reason: RayClusterSuspending
+          status: "False"
+          type: RayClusterSuspending
+        desiredCPU: 500m
+        desiredGPU: "0"
+        desiredMemory: 2Gi
+        desiredTPU: "0"
+        endpoints:
+          client: "10001"
+          dashboard: "8265"
+          gcs-server: "6379"
+          metrics: "8080"
+          serve: "8000"
+        head:
+          podIP: 10.244.2.46
+          podName: karta-e2e-rayjob-6zjw9-head-cl54v
+          serviceIP: 10.244.2.46
+          serviceName: karta-e2e-rayjob-6zjw9-head-svc
+        lastUpdateTime: "2026-08-18T12:33:22Z"
+        observedGeneration: 1
+        state: ready
+        stateTransitionTimes:
+          ready: "2026-08-18T12:33:22Z"
+      rayJobInfo:
+        endTime: "2026-08-18T12:33:25Z"
+        startTime: "2026-08-18T12:33:24Z"
+      startTime: "2026-08-18T12:33:05Z"
+      succeeded: 0
+  resourceVersion: "11559"
+  state: Completed
+flow: completed
+kartaFile: docs/catalog/ray-io-rayjob-v1.yaml
+kartaName: ray-io-rayjob-v1
+operator: kuberay
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Completed

--- a/test/e2e/recorded_data/kuberay/v1.34.0/ray-io-rayjob-v1/failed.yaml
+++ b/test/e2e/recorded_data/kuberay/v1.34.0/ray-io-rayjob-v1/failed.yaml
@@ -1,0 +1,931 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:33:28Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 2
+      name: karta-e2e-rayjob-failed
+      namespace: test-8m4bc
+      uid: a91b3e61-1b61-488f-a6fb-68aa7348bf40
+    spec:
+      backoffLimit: 0
+      entrypoint: python -c "import sys; sys.exit(1)"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      submissionMode: K8sJobMode
+      ttlSecondsAfterFinished: 0
+  resourceVersion: "11573"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:33:28Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 2
+      name: karta-e2e-rayjob-failed
+      namespace: test-8m4bc
+      uid: a91b3e61-1b61-488f-a6fb-68aa7348bf40
+    spec:
+      backoffLimit: 0
+      entrypoint: python -c "import sys; sys.exit(1)"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      submissionMode: K8sJobMode
+      ttlSecondsAfterFinished: 0
+    status:
+      failed: 0
+      jobDeploymentStatus: Initializing
+      jobId: karta-e2e-rayjob-failed-4g265
+      rayClusterName: karta-e2e-rayjob-failed-wsmfg
+      rayClusterStatus:
+        desiredCPU: "0"
+        desiredGPU: "0"
+        desiredMemory: "0"
+        desiredTPU: "0"
+        head: {}
+      rayJobInfo: {}
+      startTime: "2026-08-18T12:33:28Z"
+      succeeded: 0
+  resourceVersion: "11578"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:33:28Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 2
+      name: karta-e2e-rayjob-failed
+      namespace: test-8m4bc
+      uid: a91b3e61-1b61-488f-a6fb-68aa7348bf40
+    spec:
+      backoffLimit: 0
+      entrypoint: python -c "import sys; sys.exit(1)"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      submissionMode: K8sJobMode
+      ttlSecondsAfterFinished: 0
+    status:
+      failed: 0
+      jobDeploymentStatus: Initializing
+      jobId: karta-e2e-rayjob-failed-4g265
+      rayClusterName: karta-e2e-rayjob-failed-wsmfg
+      rayClusterStatus:
+        conditions:
+        - lastTransitionTime: "2026-08-18T12:33:28Z"
+          message: Head Pod not found
+          reason: HeadPodNotFound
+          status: "False"
+          type: HeadPodReady
+        - lastTransitionTime: "2026-08-18T12:33:28Z"
+          message: RayCluster Pods are being provisioned for first time
+          reason: RayClusterPodsProvisioning
+          status: "False"
+          type: RayClusterProvisioned
+        - lastTransitionTime: "2026-08-18T12:33:28Z"
+          message: ""
+          reason: RayClusterSuspended
+          status: "False"
+          type: RayClusterSuspended
+        - lastTransitionTime: "2026-08-18T12:33:28Z"
+          message: ""
+          reason: RayClusterSuspending
+          status: "False"
+          type: RayClusterSuspending
+        desiredCPU: 500m
+        desiredGPU: "0"
+        desiredMemory: 2Gi
+        desiredTPU: "0"
+        endpoints:
+          client: "10001"
+          dashboard: "8265"
+          gcs-server: "6379"
+          metrics: "8080"
+          serve: "8000"
+        head:
+          serviceName: karta-e2e-rayjob-failed-wsmfg-head-svc
+        lastUpdateTime: "2026-08-18T12:33:28Z"
+        observedGeneration: 1
+      rayJobInfo: {}
+      startTime: "2026-08-18T12:33:28Z"
+      succeeded: 0
+  resourceVersion: "11592"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:33:28Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 2
+      name: karta-e2e-rayjob-failed
+      namespace: test-8m4bc
+      uid: a91b3e61-1b61-488f-a6fb-68aa7348bf40
+    spec:
+      backoffLimit: 0
+      entrypoint: python -c "import sys; sys.exit(1)"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      submissionMode: K8sJobMode
+      ttlSecondsAfterFinished: 0
+    status:
+      failed: 0
+      jobDeploymentStatus: Initializing
+      jobId: karta-e2e-rayjob-failed-4g265
+      rayClusterName: karta-e2e-rayjob-failed-wsmfg
+      rayClusterStatus:
+        conditions:
+        - lastTransitionTime: "2026-08-18T12:33:28Z"
+          message: ""
+          reason: Unknown
+          status: "False"
+          type: HeadPodReady
+        - lastTransitionTime: "2026-08-18T12:33:28Z"
+          message: RayCluster Pods are being provisioned for first time
+          reason: RayClusterPodsProvisioning
+          status: "False"
+          type: RayClusterProvisioned
+        - lastTransitionTime: "2026-08-18T12:33:28Z"
+          message: ""
+          reason: RayClusterSuspended
+          status: "False"
+          type: RayClusterSuspended
+        - lastTransitionTime: "2026-08-18T12:33:28Z"
+          message: ""
+          reason: RayClusterSuspending
+          status: "False"
+          type: RayClusterSuspending
+        desiredCPU: 500m
+        desiredGPU: "0"
+        desiredMemory: 2Gi
+        desiredTPU: "0"
+        endpoints:
+          client: "10001"
+          dashboard: "8265"
+          gcs-server: "6379"
+          metrics: "8080"
+          serve: "8000"
+        head:
+          podName: karta-e2e-rayjob-failed-wsmfg-head-rcdlk
+          serviceName: karta-e2e-rayjob-failed-wsmfg-head-svc
+        lastUpdateTime: "2026-08-18T12:33:28Z"
+        observedGeneration: 1
+      rayJobInfo: {}
+      startTime: "2026-08-18T12:33:28Z"
+      succeeded: 0
+  resourceVersion: "11595"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:33:28Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 2
+      name: karta-e2e-rayjob-failed
+      namespace: test-8m4bc
+      uid: a91b3e61-1b61-488f-a6fb-68aa7348bf40
+    spec:
+      backoffLimit: 0
+      entrypoint: python -c "import sys; sys.exit(1)"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      submissionMode: K8sJobMode
+      ttlSecondsAfterFinished: 0
+    status:
+      failed: 0
+      jobDeploymentStatus: Initializing
+      jobId: karta-e2e-rayjob-failed-4g265
+      rayClusterName: karta-e2e-rayjob-failed-wsmfg
+      rayClusterStatus:
+        conditions:
+        - lastTransitionTime: "2026-08-18T12:33:28Z"
+          message: 'containers with unready status: [ray-head]; ray-head: '
+          reason: ContainerCreating
+          status: "False"
+          type: HeadPodReady
+        - lastTransitionTime: "2026-08-18T12:33:28Z"
+          message: RayCluster Pods are being provisioned for first time
+          reason: RayClusterPodsProvisioning
+          status: "False"
+          type: RayClusterProvisioned
+        - lastTransitionTime: "2026-08-18T12:33:28Z"
+          message: ""
+          reason: RayClusterSuspended
+          status: "False"
+          type: RayClusterSuspended
+        - lastTransitionTime: "2026-08-18T12:33:28Z"
+          message: ""
+          reason: RayClusterSuspending
+          status: "False"
+          type: RayClusterSuspending
+        desiredCPU: 500m
+        desiredGPU: "0"
+        desiredMemory: 2Gi
+        desiredTPU: "0"
+        endpoints:
+          client: "10001"
+          dashboard: "8265"
+          gcs-server: "6379"
+          metrics: "8080"
+          serve: "8000"
+        head:
+          podName: karta-e2e-rayjob-failed-wsmfg-head-rcdlk
+          serviceName: karta-e2e-rayjob-failed-wsmfg-head-svc
+        lastUpdateTime: "2026-08-18T12:33:28Z"
+        observedGeneration: 1
+      rayJobInfo: {}
+      startTime: "2026-08-18T12:33:28Z"
+      succeeded: 0
+  resourceVersion: "11597"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:33:28Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 2
+      name: karta-e2e-rayjob-failed
+      namespace: test-8m4bc
+      uid: a91b3e61-1b61-488f-a6fb-68aa7348bf40
+    spec:
+      backoffLimit: 0
+      entrypoint: python -c "import sys; sys.exit(1)"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      submissionMode: K8sJobMode
+      ttlSecondsAfterFinished: 0
+    status:
+      failed: 0
+      jobDeploymentStatus: Initializing
+      jobId: karta-e2e-rayjob-failed-4g265
+      rayClusterName: karta-e2e-rayjob-failed-wsmfg
+      rayClusterStatus:
+        conditions:
+        - lastTransitionTime: "2026-08-18T12:33:28Z"
+          message: 'containers with unready status: [ray-head]'
+          reason: ContainersNotReady
+          status: "False"
+          type: HeadPodReady
+        - lastTransitionTime: "2026-08-18T12:33:28Z"
+          message: RayCluster Pods are being provisioned for first time
+          reason: RayClusterPodsProvisioning
+          status: "False"
+          type: RayClusterProvisioned
+        - lastTransitionTime: "2026-08-18T12:33:28Z"
+          message: ""
+          reason: RayClusterSuspended
+          status: "False"
+          type: RayClusterSuspended
+        - lastTransitionTime: "2026-08-18T12:33:28Z"
+          message: ""
+          reason: RayClusterSuspending
+          status: "False"
+          type: RayClusterSuspending
+        desiredCPU: 500m
+        desiredGPU: "0"
+        desiredMemory: 2Gi
+        desiredTPU: "0"
+        endpoints:
+          client: "10001"
+          dashboard: "8265"
+          gcs-server: "6379"
+          metrics: "8080"
+          serve: "8000"
+        head:
+          podIP: 10.244.1.52
+          podName: karta-e2e-rayjob-failed-wsmfg-head-rcdlk
+          serviceIP: 10.244.1.52
+          serviceName: karta-e2e-rayjob-failed-wsmfg-head-svc
+        lastUpdateTime: "2026-08-18T12:33:29Z"
+        observedGeneration: 1
+      rayJobInfo: {}
+      startTime: "2026-08-18T12:33:28Z"
+      succeeded: 0
+  resourceVersion: "11622"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:33:28Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 2
+      name: karta-e2e-rayjob-failed
+      namespace: test-8m4bc
+      uid: a91b3e61-1b61-488f-a6fb-68aa7348bf40
+    spec:
+      backoffLimit: 0
+      entrypoint: python -c "import sys; sys.exit(1)"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      submissionMode: K8sJobMode
+      ttlSecondsAfterFinished: 0
+    status:
+      dashboardURL: karta-e2e-rayjob-failed-wsmfg-head-svc.test-8m4bc.svc.cluster.local:8265
+      failed: 0
+      jobDeploymentStatus: Running
+      jobId: karta-e2e-rayjob-failed-4g265
+      rayClusterName: karta-e2e-rayjob-failed-wsmfg
+      rayClusterStatus:
+        conditions:
+        - lastTransitionTime: "2026-08-18T12:33:28Z"
+          message: 'containers with unready status: [ray-head]'
+          reason: ContainersNotReady
+          status: "False"
+          type: HeadPodReady
+        - lastTransitionTime: "2026-08-18T12:33:28Z"
+          message: RayCluster Pods are being provisioned for first time
+          reason: RayClusterPodsProvisioning
+          status: "False"
+          type: RayClusterProvisioned
+        - lastTransitionTime: "2026-08-18T12:33:28Z"
+          message: ""
+          reason: RayClusterSuspended
+          status: "False"
+          type: RayClusterSuspended
+        - lastTransitionTime: "2026-08-18T12:33:28Z"
+          message: ""
+          reason: RayClusterSuspending
+          status: "False"
+          type: RayClusterSuspending
+        desiredCPU: 500m
+        desiredGPU: "0"
+        desiredMemory: 2Gi
+        desiredTPU: "0"
+        endpoints:
+          client: "10001"
+          dashboard: "8265"
+          gcs-server: "6379"
+          metrics: "8080"
+          serve: "8000"
+        head:
+          podIP: 10.244.1.52
+          podName: karta-e2e-rayjob-failed-wsmfg-head-rcdlk
+          serviceIP: 10.244.1.52
+          serviceName: karta-e2e-rayjob-failed-wsmfg-head-svc
+        lastUpdateTime: "2026-08-18T12:33:29Z"
+        observedGeneration: 1
+      rayJobInfo: {}
+      startTime: "2026-08-18T12:33:28Z"
+      succeeded: 0
+  resourceVersion: "11755"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:33:28Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 2
+      name: karta-e2e-rayjob-failed
+      namespace: test-8m4bc
+      uid: a91b3e61-1b61-488f-a6fb-68aa7348bf40
+    spec:
+      backoffLimit: 0
+      entrypoint: python -c "import sys; sys.exit(1)"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      submissionMode: K8sJobMode
+      ttlSecondsAfterFinished: 0
+    status:
+      dashboardURL: karta-e2e-rayjob-failed-wsmfg-head-svc.test-8m4bc.svc.cluster.local:8265
+      failed: 0
+      jobDeploymentStatus: Running
+      jobId: karta-e2e-rayjob-failed-4g265
+      jobStatus: RUNNING
+      message: Job is currently running.
+      rayClusterName: karta-e2e-rayjob-failed-wsmfg
+      rayClusterStatus:
+        conditions:
+        - lastTransitionTime: "2026-08-18T12:33:45Z"
+          message: ""
+          reason: HeadPodRunningAndReady
+          status: "True"
+          type: HeadPodReady
+        - lastTransitionTime: "2026-08-18T12:33:45Z"
+          message: All Ray Pods are ready for the first time
+          reason: AllPodRunningAndReadyFirstTime
+          status: "True"
+          type: RayClusterProvisioned
+        - lastTransitionTime: "2026-08-18T12:33:28Z"
+          message: ""
+          reason: RayClusterSuspended
+          status: "False"
+          type: RayClusterSuspended
+        - lastTransitionTime: "2026-08-18T12:33:28Z"
+          message: ""
+          reason: RayClusterSuspending
+          status: "False"
+          type: RayClusterSuspending
+        desiredCPU: 500m
+        desiredGPU: "0"
+        desiredMemory: 2Gi
+        desiredTPU: "0"
+        endpoints:
+          client: "10001"
+          dashboard: "8265"
+          gcs-server: "6379"
+          metrics: "8080"
+          serve: "8000"
+        head:
+          podIP: 10.244.1.52
+          podName: karta-e2e-rayjob-failed-wsmfg-head-rcdlk
+          serviceIP: 10.244.1.52
+          serviceName: karta-e2e-rayjob-failed-wsmfg-head-svc
+        lastUpdateTime: "2026-08-18T12:33:45Z"
+        observedGeneration: 1
+        state: ready
+        stateTransitionTimes:
+          ready: "2026-08-18T12:33:45Z"
+      rayJobInfo:
+        startTime: "2026-08-18T12:33:47Z"
+      startTime: "2026-08-18T12:33:28Z"
+      succeeded: 0
+  resourceVersion: "11796"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:33:28Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 2
+      name: karta-e2e-rayjob-failed
+      namespace: test-8m4bc
+      uid: a91b3e61-1b61-488f-a6fb-68aa7348bf40
+    spec:
+      backoffLimit: 0
+      entrypoint: python -c "import sys; sys.exit(1)"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      submissionMode: K8sJobMode
+      ttlSecondsAfterFinished: 0
+    status:
+      dashboardURL: karta-e2e-rayjob-failed-wsmfg-head-svc.test-8m4bc.svc.cluster.local:8265
+      failed: 0
+      jobDeploymentStatus: Running
+      jobId: karta-e2e-rayjob-failed-4g265
+      jobStatus: FAILED
+      message: "Job entrypoint command failed with exit code 1, last available logs
+        (truncated to 20,000 chars):\n2026-08-18 05:33:47,919\tINFO job_manager.py:530
+        -- Runtime env is setting up.\n"
+      rayClusterName: karta-e2e-rayjob-failed-wsmfg
+      rayClusterStatus:
+        conditions:
+        - lastTransitionTime: "2026-08-18T12:33:45Z"
+          message: ""
+          reason: HeadPodRunningAndReady
+          status: "True"
+          type: HeadPodReady
+        - lastTransitionTime: "2026-08-18T12:33:45Z"
+          message: All Ray Pods are ready for the first time
+          reason: AllPodRunningAndReadyFirstTime
+          status: "True"
+          type: RayClusterProvisioned
+        - lastTransitionTime: "2026-08-18T12:33:28Z"
+          message: ""
+          reason: RayClusterSuspended
+          status: "False"
+          type: RayClusterSuspended
+        - lastTransitionTime: "2026-08-18T12:33:28Z"
+          message: ""
+          reason: RayClusterSuspending
+          status: "False"
+          type: RayClusterSuspending
+        desiredCPU: 500m
+        desiredGPU: "0"
+        desiredMemory: 2Gi
+        desiredTPU: "0"
+        endpoints:
+          client: "10001"
+          dashboard: "8265"
+          gcs-server: "6379"
+          metrics: "8080"
+          serve: "8000"
+        head:
+          podIP: 10.244.1.52
+          podName: karta-e2e-rayjob-failed-wsmfg-head-rcdlk
+          serviceIP: 10.244.1.52
+          serviceName: karta-e2e-rayjob-failed-wsmfg-head-svc
+        lastUpdateTime: "2026-08-18T12:33:45Z"
+        observedGeneration: 1
+        state: ready
+        stateTransitionTimes:
+          ready: "2026-08-18T12:33:45Z"
+      rayJobInfo:
+        endTime: "2026-08-18T12:33:50Z"
+        startTime: "2026-08-18T12:33:47Z"
+      startTime: "2026-08-18T12:33:28Z"
+      succeeded: 0
+  resourceVersion: "11817"
+  state: Failed
+flow: failed
+kartaFile: docs/catalog/ray-io-rayjob-v1.yaml
+kartaName: ray-io-rayjob-v1
+operator: kuberay
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Failed

--- a/test/e2e/recorded_data/kuberay/v1.34.0/ray-io-rayjob-v1/resumed.yaml
+++ b/test/e2e/recorded_data/kuberay/v1.34.0/ray-io-rayjob-v1/resumed.yaml
@@ -1,0 +1,1234 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:33:52Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 2
+      name: karta-e2e-rayjob-resumed
+      namespace: test-8m4bc
+      uid: f810edde-8b3a-40a6-a2ab-d8673dec5715
+    spec:
+      backoffLimit: 0
+      entrypoint: python -c "import time; time.sleep(300)"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      shutdownAfterJobFinishes: true
+      submissionMode: K8sJobMode
+      suspend: true
+      ttlSecondsAfterFinished: 0
+  resourceVersion: "11841"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:33:52Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 2
+      name: karta-e2e-rayjob-resumed
+      namespace: test-8m4bc
+      uid: f810edde-8b3a-40a6-a2ab-d8673dec5715
+    spec:
+      backoffLimit: 0
+      entrypoint: python -c "import time; time.sleep(300)"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      shutdownAfterJobFinishes: true
+      submissionMode: K8sJobMode
+      suspend: true
+      ttlSecondsAfterFinished: 0
+    status:
+      failed: 0
+      jobDeploymentStatus: Initializing
+      jobId: karta-e2e-rayjob-resumed-ctx9p
+      rayClusterName: karta-e2e-rayjob-resumed-l5n7h
+      rayClusterStatus:
+        desiredCPU: "0"
+        desiredGPU: "0"
+        desiredMemory: "0"
+        desiredTPU: "0"
+        head: {}
+      rayJobInfo: {}
+      startTime: "2026-08-18T12:33:52Z"
+      succeeded: 0
+  resourceVersion: "11842"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:33:52Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 2
+      name: karta-e2e-rayjob-resumed
+      namespace: test-8m4bc
+      uid: f810edde-8b3a-40a6-a2ab-d8673dec5715
+    spec:
+      backoffLimit: 0
+      entrypoint: python -c "import time; time.sleep(300)"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      shutdownAfterJobFinishes: true
+      submissionMode: K8sJobMode
+      suspend: true
+      ttlSecondsAfterFinished: 0
+    status:
+      failed: 0
+      jobDeploymentStatus: Suspending
+      jobId: karta-e2e-rayjob-resumed-ctx9p
+      rayClusterName: karta-e2e-rayjob-resumed-l5n7h
+      rayClusterStatus:
+        desiredCPU: "0"
+        desiredGPU: "0"
+        desiredMemory: "0"
+        desiredTPU: "0"
+        head: {}
+      rayJobInfo: {}
+      startTime: "2026-08-18T12:33:52Z"
+      succeeded: 0
+  resourceVersion: "11844"
+  state: Suspended
+- action:
+    name: Resume
+    operation:
+      patchType: application/merge-patch+json
+      payload:
+        spec:
+          suspend: false
+      verb: PATCH
+  kind: ACTION
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:33:52Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 2
+      name: karta-e2e-rayjob-resumed
+      namespace: test-8m4bc
+      uid: f810edde-8b3a-40a6-a2ab-d8673dec5715
+    spec:
+      backoffLimit: 0
+      entrypoint: python -c "import time; time.sleep(300)"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      shutdownAfterJobFinishes: true
+      submissionMode: K8sJobMode
+      suspend: true
+      ttlSecondsAfterFinished: 0
+    status:
+      failed: 0
+      jobDeploymentStatus: Suspended
+      rayClusterStatus:
+        desiredCPU: "0"
+        desiredGPU: "0"
+        desiredMemory: "0"
+        desiredTPU: "0"
+        head: {}
+      rayJobInfo: {}
+      startTime: "2026-08-18T12:33:52Z"
+      succeeded: 0
+  resourceVersion: "11845"
+  state: Suspended
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:33:52Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 3
+      name: karta-e2e-rayjob-resumed
+      namespace: test-8m4bc
+      uid: f810edde-8b3a-40a6-a2ab-d8673dec5715
+    spec:
+      backoffLimit: 0
+      entrypoint: python -c "import time; time.sleep(300)"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      shutdownAfterJobFinishes: true
+      submissionMode: K8sJobMode
+      suspend: false
+      ttlSecondsAfterFinished: 0
+    status:
+      failed: 0
+      jobDeploymentStatus: Suspended
+      rayClusterStatus:
+        desiredCPU: "0"
+        desiredGPU: "0"
+        desiredMemory: "0"
+        desiredTPU: "0"
+        head: {}
+      rayJobInfo: {}
+      startTime: "2026-08-18T12:33:52Z"
+      succeeded: 0
+  resourceVersion: "11846"
+  state: Suspended
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:33:52Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 3
+      name: karta-e2e-rayjob-resumed
+      namespace: test-8m4bc
+      uid: f810edde-8b3a-40a6-a2ab-d8673dec5715
+    spec:
+      backoffLimit: 0
+      entrypoint: python -c "import time; time.sleep(300)"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      shutdownAfterJobFinishes: true
+      submissionMode: K8sJobMode
+      suspend: false
+      ttlSecondsAfterFinished: 0
+    status:
+      failed: 0
+      rayClusterStatus:
+        desiredCPU: "0"
+        desiredGPU: "0"
+        desiredMemory: "0"
+        desiredTPU: "0"
+        head: {}
+      rayJobInfo: {}
+      startTime: "2026-08-18T12:33:52Z"
+      succeeded: 0
+  resourceVersion: "11847"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:33:52Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 3
+      name: karta-e2e-rayjob-resumed
+      namespace: test-8m4bc
+      uid: f810edde-8b3a-40a6-a2ab-d8673dec5715
+    spec:
+      backoffLimit: 0
+      entrypoint: python -c "import time; time.sleep(300)"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      shutdownAfterJobFinishes: true
+      submissionMode: K8sJobMode
+      suspend: false
+      ttlSecondsAfterFinished: 0
+    status:
+      failed: 0
+      jobDeploymentStatus: Initializing
+      jobId: karta-e2e-rayjob-resumed-x6cvl
+      rayClusterName: karta-e2e-rayjob-resumed-jqdqr
+      rayClusterStatus:
+        desiredCPU: "0"
+        desiredGPU: "0"
+        desiredMemory: "0"
+        desiredTPU: "0"
+        head: {}
+      rayJobInfo: {}
+      startTime: "2026-08-18T12:33:52Z"
+      succeeded: 0
+  resourceVersion: "11848"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:33:52Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 3
+      name: karta-e2e-rayjob-resumed
+      namespace: test-8m4bc
+      uid: f810edde-8b3a-40a6-a2ab-d8673dec5715
+    spec:
+      backoffLimit: 0
+      entrypoint: python -c "import time; time.sleep(300)"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      shutdownAfterJobFinishes: true
+      submissionMode: K8sJobMode
+      suspend: false
+      ttlSecondsAfterFinished: 0
+    status:
+      failed: 0
+      jobDeploymentStatus: Initializing
+      jobId: karta-e2e-rayjob-resumed-x6cvl
+      rayClusterName: karta-e2e-rayjob-resumed-jqdqr
+      rayClusterStatus:
+        conditions:
+        - lastTransitionTime: "2026-08-18T12:33:52Z"
+          message: ""
+          reason: Unknown
+          status: "False"
+          type: HeadPodReady
+        - lastTransitionTime: "2026-08-18T12:33:52Z"
+          message: RayCluster Pods are being provisioned for first time
+          reason: RayClusterPodsProvisioning
+          status: "False"
+          type: RayClusterProvisioned
+        - lastTransitionTime: "2026-08-18T12:33:52Z"
+          message: ""
+          reason: RayClusterSuspended
+          status: "False"
+          type: RayClusterSuspended
+        - lastTransitionTime: "2026-08-18T12:33:52Z"
+          message: ""
+          reason: RayClusterSuspending
+          status: "False"
+          type: RayClusterSuspending
+        desiredCPU: 500m
+        desiredGPU: "0"
+        desiredMemory: 2Gi
+        desiredTPU: "0"
+        endpoints:
+          client: "10001"
+          dashboard: "8265"
+          gcs-server: "6379"
+          metrics: "8080"
+          serve: "8000"
+        head:
+          podName: karta-e2e-rayjob-resumed-jqdqr-head-l8rjz
+          serviceName: karta-e2e-rayjob-resumed-jqdqr-head-svc
+        lastUpdateTime: "2026-08-18T12:33:52Z"
+        observedGeneration: 1
+      rayJobInfo: {}
+      startTime: "2026-08-18T12:33:52Z"
+      succeeded: 0
+  resourceVersion: "11860"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:33:52Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 3
+      name: karta-e2e-rayjob-resumed
+      namespace: test-8m4bc
+      uid: f810edde-8b3a-40a6-a2ab-d8673dec5715
+    spec:
+      backoffLimit: 0
+      entrypoint: python -c "import time; time.sleep(300)"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      shutdownAfterJobFinishes: true
+      submissionMode: K8sJobMode
+      suspend: false
+      ttlSecondsAfterFinished: 0
+    status:
+      failed: 0
+      jobDeploymentStatus: Initializing
+      jobId: karta-e2e-rayjob-resumed-x6cvl
+      rayClusterName: karta-e2e-rayjob-resumed-jqdqr
+      rayClusterStatus:
+        conditions:
+        - lastTransitionTime: "2026-08-18T12:33:52Z"
+          message: 'containers with unready status: [ray-head]; ray-head: '
+          reason: ContainerCreating
+          status: "False"
+          type: HeadPodReady
+        - lastTransitionTime: "2026-08-18T12:33:52Z"
+          message: RayCluster Pods are being provisioned for first time
+          reason: RayClusterPodsProvisioning
+          status: "False"
+          type: RayClusterProvisioned
+        - lastTransitionTime: "2026-08-18T12:33:52Z"
+          message: ""
+          reason: RayClusterSuspended
+          status: "False"
+          type: RayClusterSuspended
+        - lastTransitionTime: "2026-08-18T12:33:52Z"
+          message: ""
+          reason: RayClusterSuspending
+          status: "False"
+          type: RayClusterSuspending
+        desiredCPU: 500m
+        desiredGPU: "0"
+        desiredMemory: 2Gi
+        desiredTPU: "0"
+        endpoints:
+          client: "10001"
+          dashboard: "8265"
+          gcs-server: "6379"
+          metrics: "8080"
+          serve: "8000"
+        head:
+          podName: karta-e2e-rayjob-resumed-jqdqr-head-l8rjz
+          serviceName: karta-e2e-rayjob-resumed-jqdqr-head-svc
+        lastUpdateTime: "2026-08-18T12:33:52Z"
+        observedGeneration: 1
+      rayJobInfo: {}
+      startTime: "2026-08-18T12:33:52Z"
+      succeeded: 0
+  resourceVersion: "11863"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:33:52Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 3
+      name: karta-e2e-rayjob-resumed
+      namespace: test-8m4bc
+      uid: f810edde-8b3a-40a6-a2ab-d8673dec5715
+    spec:
+      backoffLimit: 0
+      entrypoint: python -c "import time; time.sleep(300)"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      shutdownAfterJobFinishes: true
+      submissionMode: K8sJobMode
+      suspend: false
+      ttlSecondsAfterFinished: 0
+    status:
+      failed: 0
+      jobDeploymentStatus: Initializing
+      jobId: karta-e2e-rayjob-resumed-x6cvl
+      rayClusterName: karta-e2e-rayjob-resumed-jqdqr
+      rayClusterStatus:
+        conditions:
+        - lastTransitionTime: "2026-08-18T12:33:52Z"
+          message: 'containers with unready status: [ray-head]'
+          reason: ContainersNotReady
+          status: "False"
+          type: HeadPodReady
+        - lastTransitionTime: "2026-08-18T12:33:52Z"
+          message: RayCluster Pods are being provisioned for first time
+          reason: RayClusterPodsProvisioning
+          status: "False"
+          type: RayClusterProvisioned
+        - lastTransitionTime: "2026-08-18T12:33:52Z"
+          message: ""
+          reason: RayClusterSuspended
+          status: "False"
+          type: RayClusterSuspended
+        - lastTransitionTime: "2026-08-18T12:33:52Z"
+          message: ""
+          reason: RayClusterSuspending
+          status: "False"
+          type: RayClusterSuspending
+        desiredCPU: 500m
+        desiredGPU: "0"
+        desiredMemory: 2Gi
+        desiredTPU: "0"
+        endpoints:
+          client: "10001"
+          dashboard: "8265"
+          gcs-server: "6379"
+          metrics: "8080"
+          serve: "8000"
+        head:
+          podIP: 10.244.2.48
+          podName: karta-e2e-rayjob-resumed-jqdqr-head-l8rjz
+          serviceIP: 10.244.2.48
+          serviceName: karta-e2e-rayjob-resumed-jqdqr-head-svc
+        lastUpdateTime: "2026-08-18T12:33:53Z"
+        observedGeneration: 1
+      rayJobInfo: {}
+      startTime: "2026-08-18T12:33:52Z"
+      succeeded: 0
+  resourceVersion: "11881"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:33:52Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 3
+      name: karta-e2e-rayjob-resumed
+      namespace: test-8m4bc
+      uid: f810edde-8b3a-40a6-a2ab-d8673dec5715
+    spec:
+      backoffLimit: 0
+      entrypoint: python -c "import time; time.sleep(300)"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      shutdownAfterJobFinishes: true
+      submissionMode: K8sJobMode
+      suspend: false
+      ttlSecondsAfterFinished: 0
+    status:
+      dashboardURL: karta-e2e-rayjob-resumed-jqdqr-head-svc.test-8m4bc.svc.cluster.local:8265
+      failed: 0
+      jobDeploymentStatus: Running
+      jobId: karta-e2e-rayjob-resumed-x6cvl
+      rayClusterName: karta-e2e-rayjob-resumed-jqdqr
+      rayClusterStatus:
+        conditions:
+        - lastTransitionTime: "2026-08-18T12:33:52Z"
+          message: 'containers with unready status: [ray-head]'
+          reason: ContainersNotReady
+          status: "False"
+          type: HeadPodReady
+        - lastTransitionTime: "2026-08-18T12:33:52Z"
+          message: RayCluster Pods are being provisioned for first time
+          reason: RayClusterPodsProvisioning
+          status: "False"
+          type: RayClusterProvisioned
+        - lastTransitionTime: "2026-08-18T12:33:52Z"
+          message: ""
+          reason: RayClusterSuspended
+          status: "False"
+          type: RayClusterSuspended
+        - lastTransitionTime: "2026-08-18T12:33:52Z"
+          message: ""
+          reason: RayClusterSuspending
+          status: "False"
+          type: RayClusterSuspending
+        desiredCPU: 500m
+        desiredGPU: "0"
+        desiredMemory: 2Gi
+        desiredTPU: "0"
+        endpoints:
+          client: "10001"
+          dashboard: "8265"
+          gcs-server: "6379"
+          metrics: "8080"
+          serve: "8000"
+        head:
+          podIP: 10.244.2.48
+          podName: karta-e2e-rayjob-resumed-jqdqr-head-l8rjz
+          serviceIP: 10.244.2.48
+          serviceName: karta-e2e-rayjob-resumed-jqdqr-head-svc
+        lastUpdateTime: "2026-08-18T12:33:53Z"
+        observedGeneration: 1
+      rayJobInfo: {}
+      startTime: "2026-08-18T12:33:52Z"
+      succeeded: 0
+  resourceVersion: "12018"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:33:52Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 3
+      name: karta-e2e-rayjob-resumed
+      namespace: test-8m4bc
+      uid: f810edde-8b3a-40a6-a2ab-d8673dec5715
+    spec:
+      backoffLimit: 0
+      entrypoint: python -c "import time; time.sleep(300)"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      shutdownAfterJobFinishes: true
+      submissionMode: K8sJobMode
+      suspend: false
+      ttlSecondsAfterFinished: 0
+    status:
+      dashboardURL: karta-e2e-rayjob-resumed-jqdqr-head-svc.test-8m4bc.svc.cluster.local:8265
+      failed: 0
+      jobDeploymentStatus: Running
+      jobId: karta-e2e-rayjob-resumed-x6cvl
+      jobStatus: PENDING
+      message: Job has not started yet.
+      rayClusterName: karta-e2e-rayjob-resumed-jqdqr
+      rayClusterStatus:
+        conditions:
+        - lastTransitionTime: "2026-08-18T12:34:09Z"
+          message: ""
+          reason: HeadPodRunningAndReady
+          status: "True"
+          type: HeadPodReady
+        - lastTransitionTime: "2026-08-18T12:34:09Z"
+          message: All Ray Pods are ready for the first time
+          reason: AllPodRunningAndReadyFirstTime
+          status: "True"
+          type: RayClusterProvisioned
+        - lastTransitionTime: "2026-08-18T12:33:52Z"
+          message: ""
+          reason: RayClusterSuspended
+          status: "False"
+          type: RayClusterSuspended
+        - lastTransitionTime: "2026-08-18T12:33:52Z"
+          message: ""
+          reason: RayClusterSuspending
+          status: "False"
+          type: RayClusterSuspending
+        desiredCPU: 500m
+        desiredGPU: "0"
+        desiredMemory: 2Gi
+        desiredTPU: "0"
+        endpoints:
+          client: "10001"
+          dashboard: "8265"
+          gcs-server: "6379"
+          metrics: "8080"
+          serve: "8000"
+        head:
+          podIP: 10.244.2.48
+          podName: karta-e2e-rayjob-resumed-jqdqr-head-l8rjz
+          serviceIP: 10.244.2.48
+          serviceName: karta-e2e-rayjob-resumed-jqdqr-head-svc
+        lastUpdateTime: "2026-08-18T12:34:09Z"
+        observedGeneration: 1
+        state: ready
+        stateTransitionTimes:
+          ready: "2026-08-18T12:34:09Z"
+      rayJobInfo:
+        startTime: "2026-08-18T12:34:11Z"
+      startTime: "2026-08-18T12:33:52Z"
+      succeeded: 0
+  resourceVersion: "12049"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:33:52Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 3
+      name: karta-e2e-rayjob-resumed
+      namespace: test-8m4bc
+      uid: f810edde-8b3a-40a6-a2ab-d8673dec5715
+    spec:
+      backoffLimit: 0
+      entrypoint: python -c "import time; time.sleep(300)"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      shutdownAfterJobFinishes: true
+      submissionMode: K8sJobMode
+      suspend: false
+      ttlSecondsAfterFinished: 0
+    status:
+      dashboardURL: karta-e2e-rayjob-resumed-jqdqr-head-svc.test-8m4bc.svc.cluster.local:8265
+      failed: 0
+      jobDeploymentStatus: Running
+      jobId: karta-e2e-rayjob-resumed-x6cvl
+      jobStatus: RUNNING
+      message: Job is currently running.
+      rayClusterName: karta-e2e-rayjob-resumed-jqdqr
+      rayClusterStatus:
+        conditions:
+        - lastTransitionTime: "2026-08-18T12:34:09Z"
+          message: ""
+          reason: HeadPodRunningAndReady
+          status: "True"
+          type: HeadPodReady
+        - lastTransitionTime: "2026-08-18T12:34:09Z"
+          message: All Ray Pods are ready for the first time
+          reason: AllPodRunningAndReadyFirstTime
+          status: "True"
+          type: RayClusterProvisioned
+        - lastTransitionTime: "2026-08-18T12:33:52Z"
+          message: ""
+          reason: RayClusterSuspended
+          status: "False"
+          type: RayClusterSuspended
+        - lastTransitionTime: "2026-08-18T12:33:52Z"
+          message: ""
+          reason: RayClusterSuspending
+          status: "False"
+          type: RayClusterSuspending
+        desiredCPU: 500m
+        desiredGPU: "0"
+        desiredMemory: 2Gi
+        desiredTPU: "0"
+        endpoints:
+          client: "10001"
+          dashboard: "8265"
+          gcs-server: "6379"
+          metrics: "8080"
+          serve: "8000"
+        head:
+          podIP: 10.244.2.48
+          podName: karta-e2e-rayjob-resumed-jqdqr-head-l8rjz
+          serviceIP: 10.244.2.48
+          serviceName: karta-e2e-rayjob-resumed-jqdqr-head-svc
+        lastUpdateTime: "2026-08-18T12:34:09Z"
+        observedGeneration: 1
+        state: ready
+        stateTransitionTimes:
+          ready: "2026-08-18T12:34:09Z"
+      rayJobInfo:
+        startTime: "2026-08-18T12:34:11Z"
+      startTime: "2026-08-18T12:33:52Z"
+      succeeded: 0
+  resourceVersion: "12076"
+  state: Running
+flow: resumed
+kartaFile: docs/catalog/ray-io-rayjob-v1.yaml
+kartaName: ray-io-rayjob-v1
+operator: kuberay
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Running

--- a/test/e2e/recorded_data/kuberay/v1.34.0/ray-io-rayjob-v1/running.yaml
+++ b/test/e2e/recorded_data/kuberay/v1.34.0/ray-io-rayjob-v1/running.yaml
@@ -1,0 +1,821 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:32:41Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 2
+      name: karta-e2e-rayjob-running
+      namespace: test-8m4bc
+      uid: 2756bccc-e76f-4f81-b073-37ec330b4f8f
+    spec:
+      backoffLimit: 0
+      entrypoint: python -c "import time; time.sleep(300)"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      submissionMode: K8sJobMode
+      ttlSecondsAfterFinished: 0
+  resourceVersion: "11064"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:32:41Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 2
+      name: karta-e2e-rayjob-running
+      namespace: test-8m4bc
+      uid: 2756bccc-e76f-4f81-b073-37ec330b4f8f
+    spec:
+      backoffLimit: 0
+      entrypoint: python -c "import time; time.sleep(300)"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      submissionMode: K8sJobMode
+      ttlSecondsAfterFinished: 0
+    status:
+      failed: 0
+      jobDeploymentStatus: Initializing
+      jobId: karta-e2e-rayjob-running-x2qvr
+      rayClusterName: karta-e2e-rayjob-running-bzcwv
+      rayClusterStatus:
+        desiredCPU: "0"
+        desiredGPU: "0"
+        desiredMemory: "0"
+        desiredTPU: "0"
+        head: {}
+      rayJobInfo: {}
+      startTime: "2026-08-18T12:32:41Z"
+      succeeded: 0
+  resourceVersion: "11065"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:32:41Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 2
+      name: karta-e2e-rayjob-running
+      namespace: test-8m4bc
+      uid: 2756bccc-e76f-4f81-b073-37ec330b4f8f
+    spec:
+      backoffLimit: 0
+      entrypoint: python -c "import time; time.sleep(300)"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      submissionMode: K8sJobMode
+      ttlSecondsAfterFinished: 0
+    status:
+      failed: 0
+      jobDeploymentStatus: Initializing
+      jobId: karta-e2e-rayjob-running-x2qvr
+      rayClusterName: karta-e2e-rayjob-running-bzcwv
+      rayClusterStatus:
+        conditions:
+        - lastTransitionTime: "2026-08-18T12:32:41Z"
+          message: ""
+          reason: Unknown
+          status: "False"
+          type: HeadPodReady
+        - lastTransitionTime: "2026-08-18T12:32:41Z"
+          message: RayCluster Pods are being provisioned for first time
+          reason: RayClusterPodsProvisioning
+          status: "False"
+          type: RayClusterProvisioned
+        - lastTransitionTime: "2026-08-18T12:32:41Z"
+          message: ""
+          reason: RayClusterSuspended
+          status: "False"
+          type: RayClusterSuspended
+        - lastTransitionTime: "2026-08-18T12:32:41Z"
+          message: ""
+          reason: RayClusterSuspending
+          status: "False"
+          type: RayClusterSuspending
+        desiredCPU: 500m
+        desiredGPU: "0"
+        desiredMemory: 2Gi
+        desiredTPU: "0"
+        endpoints:
+          client: "10001"
+          dashboard: "8265"
+          gcs-server: "6379"
+          metrics: "8080"
+          serve: "8000"
+        head:
+          podName: karta-e2e-rayjob-running-bzcwv-head-2b978
+          serviceName: karta-e2e-rayjob-running-bzcwv-head-svc
+        lastUpdateTime: "2026-08-18T12:32:41Z"
+        observedGeneration: 1
+      rayJobInfo: {}
+      startTime: "2026-08-18T12:32:41Z"
+      succeeded: 0
+  resourceVersion: "11078"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:32:41Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 2
+      name: karta-e2e-rayjob-running
+      namespace: test-8m4bc
+      uid: 2756bccc-e76f-4f81-b073-37ec330b4f8f
+    spec:
+      backoffLimit: 0
+      entrypoint: python -c "import time; time.sleep(300)"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      submissionMode: K8sJobMode
+      ttlSecondsAfterFinished: 0
+    status:
+      failed: 0
+      jobDeploymentStatus: Initializing
+      jobId: karta-e2e-rayjob-running-x2qvr
+      rayClusterName: karta-e2e-rayjob-running-bzcwv
+      rayClusterStatus:
+        conditions:
+        - lastTransitionTime: "2026-08-18T12:32:41Z"
+          message: 'containers with unready status: [ray-head]; ray-head: '
+          reason: ContainerCreating
+          status: "False"
+          type: HeadPodReady
+        - lastTransitionTime: "2026-08-18T12:32:41Z"
+          message: RayCluster Pods are being provisioned for first time
+          reason: RayClusterPodsProvisioning
+          status: "False"
+          type: RayClusterProvisioned
+        - lastTransitionTime: "2026-08-18T12:32:41Z"
+          message: ""
+          reason: RayClusterSuspended
+          status: "False"
+          type: RayClusterSuspended
+        - lastTransitionTime: "2026-08-18T12:32:41Z"
+          message: ""
+          reason: RayClusterSuspending
+          status: "False"
+          type: RayClusterSuspending
+        desiredCPU: 500m
+        desiredGPU: "0"
+        desiredMemory: 2Gi
+        desiredTPU: "0"
+        endpoints:
+          client: "10001"
+          dashboard: "8265"
+          gcs-server: "6379"
+          metrics: "8080"
+          serve: "8000"
+        head:
+          podName: karta-e2e-rayjob-running-bzcwv-head-2b978
+          serviceName: karta-e2e-rayjob-running-bzcwv-head-svc
+        lastUpdateTime: "2026-08-18T12:32:41Z"
+        observedGeneration: 1
+      rayJobInfo: {}
+      startTime: "2026-08-18T12:32:41Z"
+      succeeded: 0
+  resourceVersion: "11081"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:32:41Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 2
+      name: karta-e2e-rayjob-running
+      namespace: test-8m4bc
+      uid: 2756bccc-e76f-4f81-b073-37ec330b4f8f
+    spec:
+      backoffLimit: 0
+      entrypoint: python -c "import time; time.sleep(300)"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      submissionMode: K8sJobMode
+      ttlSecondsAfterFinished: 0
+    status:
+      failed: 0
+      jobDeploymentStatus: Initializing
+      jobId: karta-e2e-rayjob-running-x2qvr
+      rayClusterName: karta-e2e-rayjob-running-bzcwv
+      rayClusterStatus:
+        conditions:
+        - lastTransitionTime: "2026-08-18T12:32:41Z"
+          message: 'containers with unready status: [ray-head]'
+          reason: ContainersNotReady
+          status: "False"
+          type: HeadPodReady
+        - lastTransitionTime: "2026-08-18T12:32:41Z"
+          message: RayCluster Pods are being provisioned for first time
+          reason: RayClusterPodsProvisioning
+          status: "False"
+          type: RayClusterProvisioned
+        - lastTransitionTime: "2026-08-18T12:32:41Z"
+          message: ""
+          reason: RayClusterSuspended
+          status: "False"
+          type: RayClusterSuspended
+        - lastTransitionTime: "2026-08-18T12:32:41Z"
+          message: ""
+          reason: RayClusterSuspending
+          status: "False"
+          type: RayClusterSuspending
+        desiredCPU: 500m
+        desiredGPU: "0"
+        desiredMemory: 2Gi
+        desiredTPU: "0"
+        endpoints:
+          client: "10001"
+          dashboard: "8265"
+          gcs-server: "6379"
+          metrics: "8080"
+          serve: "8000"
+        head:
+          podIP: 10.244.1.50
+          podName: karta-e2e-rayjob-running-bzcwv-head-2b978
+          serviceIP: 10.244.1.50
+          serviceName: karta-e2e-rayjob-running-bzcwv-head-svc
+        lastUpdateTime: "2026-08-18T12:32:42Z"
+        observedGeneration: 1
+      rayJobInfo: {}
+      startTime: "2026-08-18T12:32:41Z"
+      succeeded: 0
+  resourceVersion: "11094"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:32:41Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 2
+      name: karta-e2e-rayjob-running
+      namespace: test-8m4bc
+      uid: 2756bccc-e76f-4f81-b073-37ec330b4f8f
+    spec:
+      backoffLimit: 0
+      entrypoint: python -c "import time; time.sleep(300)"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      submissionMode: K8sJobMode
+      ttlSecondsAfterFinished: 0
+    status:
+      dashboardURL: karta-e2e-rayjob-running-bzcwv-head-svc.test-8m4bc.svc.cluster.local:8265
+      failed: 0
+      jobDeploymentStatus: Running
+      jobId: karta-e2e-rayjob-running-x2qvr
+      rayClusterName: karta-e2e-rayjob-running-bzcwv
+      rayClusterStatus:
+        conditions:
+        - lastTransitionTime: "2026-08-18T12:32:41Z"
+          message: 'containers with unready status: [ray-head]'
+          reason: ContainersNotReady
+          status: "False"
+          type: HeadPodReady
+        - lastTransitionTime: "2026-08-18T12:32:41Z"
+          message: RayCluster Pods are being provisioned for first time
+          reason: RayClusterPodsProvisioning
+          status: "False"
+          type: RayClusterProvisioned
+        - lastTransitionTime: "2026-08-18T12:32:41Z"
+          message: ""
+          reason: RayClusterSuspended
+          status: "False"
+          type: RayClusterSuspended
+        - lastTransitionTime: "2026-08-18T12:32:41Z"
+          message: ""
+          reason: RayClusterSuspending
+          status: "False"
+          type: RayClusterSuspending
+        desiredCPU: 500m
+        desiredGPU: "0"
+        desiredMemory: 2Gi
+        desiredTPU: "0"
+        endpoints:
+          client: "10001"
+          dashboard: "8265"
+          gcs-server: "6379"
+          metrics: "8080"
+          serve: "8000"
+        head:
+          podIP: 10.244.1.50
+          podName: karta-e2e-rayjob-running-bzcwv-head-2b978
+          serviceIP: 10.244.1.50
+          serviceName: karta-e2e-rayjob-running-bzcwv-head-svc
+        lastUpdateTime: "2026-08-18T12:32:42Z"
+        observedGeneration: 1
+      rayJobInfo: {}
+      startTime: "2026-08-18T12:32:41Z"
+      succeeded: 0
+  resourceVersion: "11228"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:32:41Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 2
+      name: karta-e2e-rayjob-running
+      namespace: test-8m4bc
+      uid: 2756bccc-e76f-4f81-b073-37ec330b4f8f
+    spec:
+      backoffLimit: 0
+      entrypoint: python -c "import time; time.sleep(300)"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      submissionMode: K8sJobMode
+      ttlSecondsAfterFinished: 0
+    status:
+      dashboardURL: karta-e2e-rayjob-running-bzcwv-head-svc.test-8m4bc.svc.cluster.local:8265
+      failed: 0
+      jobDeploymentStatus: Running
+      jobId: karta-e2e-rayjob-running-x2qvr
+      jobStatus: PENDING
+      message: Job has not started yet.
+      rayClusterName: karta-e2e-rayjob-running-bzcwv
+      rayClusterStatus:
+        conditions:
+        - lastTransitionTime: "2026-08-18T12:32:58Z"
+          message: ""
+          reason: HeadPodRunningAndReady
+          status: "True"
+          type: HeadPodReady
+        - lastTransitionTime: "2026-08-18T12:32:58Z"
+          message: All Ray Pods are ready for the first time
+          reason: AllPodRunningAndReadyFirstTime
+          status: "True"
+          type: RayClusterProvisioned
+        - lastTransitionTime: "2026-08-18T12:32:41Z"
+          message: ""
+          reason: RayClusterSuspended
+          status: "False"
+          type: RayClusterSuspended
+        - lastTransitionTime: "2026-08-18T12:32:41Z"
+          message: ""
+          reason: RayClusterSuspending
+          status: "False"
+          type: RayClusterSuspending
+        desiredCPU: 500m
+        desiredGPU: "0"
+        desiredMemory: 2Gi
+        desiredTPU: "0"
+        endpoints:
+          client: "10001"
+          dashboard: "8265"
+          gcs-server: "6379"
+          metrics: "8080"
+          serve: "8000"
+        head:
+          podIP: 10.244.1.50
+          podName: karta-e2e-rayjob-running-bzcwv-head-2b978
+          serviceIP: 10.244.1.50
+          serviceName: karta-e2e-rayjob-running-bzcwv-head-svc
+        lastUpdateTime: "2026-08-18T12:32:58Z"
+        observedGeneration: 1
+        state: ready
+        stateTransitionTimes:
+          ready: "2026-08-18T12:32:58Z"
+      rayJobInfo:
+        startTime: "2026-08-18T12:33:01Z"
+      startTime: "2026-08-18T12:32:41Z"
+      succeeded: 0
+  resourceVersion: "11270"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:32:41Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 2
+      name: karta-e2e-rayjob-running
+      namespace: test-8m4bc
+      uid: 2756bccc-e76f-4f81-b073-37ec330b4f8f
+    spec:
+      backoffLimit: 0
+      entrypoint: python -c "import time; time.sleep(300)"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                readinessProbe:
+                  failureThreshold: 90
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  tcpSocket:
+                    port: 8265
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 3Gi
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      submissionMode: K8sJobMode
+      ttlSecondsAfterFinished: 0
+    status:
+      dashboardURL: karta-e2e-rayjob-running-bzcwv-head-svc.test-8m4bc.svc.cluster.local:8265
+      failed: 0
+      jobDeploymentStatus: Running
+      jobId: karta-e2e-rayjob-running-x2qvr
+      jobStatus: RUNNING
+      message: Job is currently running.
+      rayClusterName: karta-e2e-rayjob-running-bzcwv
+      rayClusterStatus:
+        conditions:
+        - lastTransitionTime: "2026-08-18T12:32:58Z"
+          message: ""
+          reason: HeadPodRunningAndReady
+          status: "True"
+          type: HeadPodReady
+        - lastTransitionTime: "2026-08-18T12:32:58Z"
+          message: All Ray Pods are ready for the first time
+          reason: AllPodRunningAndReadyFirstTime
+          status: "True"
+          type: RayClusterProvisioned
+        - lastTransitionTime: "2026-08-18T12:32:41Z"
+          message: ""
+          reason: RayClusterSuspended
+          status: "False"
+          type: RayClusterSuspended
+        - lastTransitionTime: "2026-08-18T12:32:41Z"
+          message: ""
+          reason: RayClusterSuspending
+          status: "False"
+          type: RayClusterSuspending
+        desiredCPU: 500m
+        desiredGPU: "0"
+        desiredMemory: 2Gi
+        desiredTPU: "0"
+        endpoints:
+          client: "10001"
+          dashboard: "8265"
+          gcs-server: "6379"
+          metrics: "8080"
+          serve: "8000"
+        head:
+          podIP: 10.244.1.50
+          podName: karta-e2e-rayjob-running-bzcwv-head-2b978
+          serviceIP: 10.244.1.50
+          serviceName: karta-e2e-rayjob-running-bzcwv-head-svc
+        lastUpdateTime: "2026-08-18T12:32:58Z"
+        observedGeneration: 1
+        state: ready
+        stateTransitionTimes:
+          ready: "2026-08-18T12:32:58Z"
+      rayJobInfo:
+        startTime: "2026-08-18T12:33:01Z"
+      startTime: "2026-08-18T12:32:41Z"
+      succeeded: 0
+  resourceVersion: "11302"
+  state: Running
+flow: running
+kartaFile: docs/catalog/ray-io-rayjob-v1.yaml
+kartaName: ray-io-rayjob-v1
+operator: kuberay
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Running

--- a/test/e2e/recorded_data/kuberay/v1.34.0/ray-io-rayjob-v1/suspended.yaml
+++ b/test/e2e/recorded_data/kuberay/v1.34.0/ray-io-rayjob-v1/suspended.yaml
@@ -1,0 +1,206 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:33:52Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 2
+      name: karta-e2e-rayjob-suspended
+      namespace: test-8m4bc
+      uid: ba0fb506-d176-46e9-bb51-31cff3ef6c72
+    spec:
+      backoffLimit: 0
+      entrypoint: python -c "print(1)"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                resources:
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      shutdownAfterJobFinishes: true
+      submissionMode: K8sJobMode
+      suspend: true
+      ttlSecondsAfterFinished: 0
+  resourceVersion: "11827"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:33:52Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 2
+      name: karta-e2e-rayjob-suspended
+      namespace: test-8m4bc
+      uid: ba0fb506-d176-46e9-bb51-31cff3ef6c72
+    spec:
+      backoffLimit: 0
+      entrypoint: python -c "print(1)"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                resources:
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      shutdownAfterJobFinishes: true
+      submissionMode: K8sJobMode
+      suspend: true
+      ttlSecondsAfterFinished: 0
+    status:
+      failed: 0
+      jobDeploymentStatus: Initializing
+      jobId: karta-e2e-rayjob-suspended-npmjl
+      rayClusterName: karta-e2e-rayjob-suspended-vskpq
+      rayClusterStatus:
+        desiredCPU: "0"
+        desiredGPU: "0"
+        desiredMemory: "0"
+        desiredTPU: "0"
+        head: {}
+      rayJobInfo: {}
+      startTime: "2026-08-18T12:33:52Z"
+      succeeded: 0
+  resourceVersion: "11830"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayJob
+    metadata:
+      creationTimestamp: "2026-08-18T12:33:52Z"
+      finalizers:
+      - ray.io/rayjob-finalizer
+      generation: 2
+      name: karta-e2e-rayjob-suspended
+      namespace: test-8m4bc
+      uid: ba0fb506-d176-46e9-bb51-31cff3ef6c72
+    spec:
+      backoffLimit: 0
+      entrypoint: python -c "print(1)"
+      rayClusterSpec:
+        headGroupSpec:
+          rayStartParams:
+            num-cpus: "1"
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-head
+                resources:
+                  requests:
+                    cpu: 500m
+                    memory: 2Gi
+        rayVersion: 2.40.0
+        workerGroupSpecs:
+        - groupName: small
+          maxReplicas: 0
+          minReplicas: 0
+          numOfHosts: 1
+          rayStartParams: {}
+          replicas: 0
+          scaleStrategy: {}
+          template:
+            metadata: {}
+            spec:
+              containers:
+              - image: ray-e2e:local
+                imagePullPolicy: IfNotPresent
+                name: ray-worker
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+      shutdownAfterJobFinishes: true
+      submissionMode: K8sJobMode
+      suspend: true
+      ttlSecondsAfterFinished: 0
+    status:
+      failed: 0
+      jobDeploymentStatus: Suspending
+      jobId: karta-e2e-rayjob-suspended-npmjl
+      rayClusterName: karta-e2e-rayjob-suspended-vskpq
+      rayClusterStatus:
+        desiredCPU: "0"
+        desiredGPU: "0"
+        desiredMemory: "0"
+        desiredTPU: "0"
+        head: {}
+      rayJobInfo: {}
+      startTime: "2026-08-18T12:33:52Z"
+      succeeded: 0
+  resourceVersion: "11835"
+  state: Suspended
+flow: suspended
+kartaFile: docs/catalog/ray-io-rayjob-v1.yaml
+kartaName: ray-io-rayjob-v1
+operator: kuberay
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Suspended


### PR DESCRIPTION
Part of #139 - one workload type per PR, stacked. Adds the rayjob flow: its spec steps, the predicates it judges stable states with (from the workload's own fields), and its recorded fixtures. Replayed offline by the suite in #260; `make check` green at every layer.