### PR TITLE
test(e2e): add the raycluster flow and its recorded fixtures

### DIFF
--- a/test/e2e/flows/predicates.go
+++ b/test/e2e/flows/predicates.go
@@ -267,6 +267,18 @@ func JobsetInitializing() recorder.StateCheck {
 	}
 }
 
+// RaySuspended matches a RayCluster suspended at creation: spec.suspend is true and status.state is either
+// "suspended" or not yet set (the operator may not have written a state yet).
+func RaySuspended() recorder.StateCheck {
+	return func(u *unstructured.Unstructured) bool {
+		if suspend, _, _ := unstructured.NestedBool(u.Object, "spec", "suspend"); !suspend {
+			return false
+		}
+		state, found, _ := unstructured.NestedString(u.Object, "status", "state")
+		return !found || state == "" || state == "suspended"
+	}
+}
+
 // RayJobInitializing matches a RayJob before its job runs: jobStatus PENDING, or empty while the RayJob
 // brings up its cluster and it is not suspended (jobDeploymentStatus Initializing/Running, or empty).
 func RayJobInitializing() recorder.StateCheck {
@@ -280,5 +292,18 @@ func RayJobInitializing() recorder.StateCheck {
 		}
 		ds, _, _ := unstructured.NestedString(u.Object, "status", "jobDeploymentStatus")
 		return ds != "Suspended" && ds != "Suspending"
+	}
+}
+
+// RayInitializing matches a RayCluster converging toward ready: not suspended and status.state not yet
+// "ready" or "failed". Covers a fresh provision (state empty) and the resume window where suspend is
+// already false but state still lags at "suspended".
+func RayInitializing() recorder.StateCheck {
+	return func(u *unstructured.Unstructured) bool {
+		if suspend, _, _ := unstructured.NestedBool(u.Object, "spec", "suspend"); suspend {
+			return false
+		}
+		state, _, _ := unstructured.NestedString(u.Object, "status", "state")
+		return state != "ready" && state != "failed"
 	}
 }

--- a/test/e2e/flows/raycluster_test.go
+++ b/test/e2e/flows/raycluster_test.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package flows
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kartav1alpha1 "github.com/run-ai/karta/pkg/api/runai/v1alpha1"
+	"github.com/run-ai/karta/test/e2e/recorder"
+)
+
+var _ = Describe("RayCluster", Ordered, Label("kuberay", "raycluster"), func() {
+	var rec *recorder.Recorder
+	var fx recorder.Fixture
+
+	BeforeAll(func(ctx SpecContext) {
+		installKarta(ctx, "../../docs/catalog/ray-io-raycluster-v1.yaml", "ray-io-raycluster-v1")
+		fx = recorder.Fixture{Operator: "kuberay", Version: operatorVersion("kuberay"), KartaName: "ray-io-raycluster-v1", KartaFile: "docs/catalog/ray-io-raycluster-v1.yaml"}
+		rec = recorder.New(cfg).
+			SetTimeout(8*time.Minute).
+			AddState(kartav1alpha1.InitializingStatus, RayInitializing()).
+			AddState(kartav1alpha1.RunningStatus, PhaseEq("ready", "status", "state")).
+			AddState(kartav1alpha1.SuspendedStatus, RaySuspended())
+	})
+
+	It("running", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "running", "testdata/raycluster/running.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("suspended", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "suspended", "testdata/raycluster/suspended.yaml").Through(recorder.Reaches(kartav1alpha1.SuspendedStatus)).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("resumed", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "resumed", "testdata/raycluster/resumed.yaml").Through(
+			recorder.Reaches(kartav1alpha1.SuspendedStatus).Do(Resume()),
+			recorder.Reaches(kartav1alpha1.InitializingStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.RunningStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+})

--- a/test/e2e/flows/testdata/raycluster/resumed.yaml
+++ b/test/e2e/flows/testdata/raycluster/resumed.yaml
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A RayCluster created suspended, then resumed by the e2e action (clearing spec.suspend). KubeRay
+# brings the head up and sets status.state=ready. The resumed flow records Suspended -> Running, the
+# transition an operator will not make on its own. Head-only (workers 0) so it comes up on kind.
+apiVersion: ray.io/v1
+kind: RayCluster
+metadata:
+  name: karta-e2e-ray-resumed
+  namespace: default
+spec:
+  suspend: true
+  rayVersion: "2.40.0"
+  headGroupSpec:
+    rayStartParams: {}
+    template:
+      spec:
+        containers:
+          - name: ray-head
+            image: ray-e2e:local
+            imagePullPolicy: IfNotPresent
+            resources:
+              requests: {cpu: 250m, memory: 1Gi}
+              limits: {cpu: "1", memory: 2Gi}
+            readinessProbe:
+              tcpSocket: {port: 6379}
+              initialDelaySeconds: 10
+              periodSeconds: 5
+              failureThreshold: 30
+            livenessProbe:
+              tcpSocket: {port: 6379}
+              initialDelaySeconds: 30
+              periodSeconds: 10
+              failureThreshold: 30
+  workerGroupSpecs:
+    - groupName: small
+      replicas: 0
+      minReplicas: 0
+      maxReplicas: 1
+      rayStartParams: {}
+      template:
+        spec:
+          containers:
+            - name: ray-worker
+              image: ray-e2e:local
+              imagePullPolicy: IfNotPresent
+              resources:
+                requests: {cpu: 250m, memory: 512Mi}

--- a/test/e2e/flows/testdata/raycluster/running.yaml
+++ b/test/e2e/flows/testdata/raycluster/running.yaml
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A minimal head-only RayCluster. The head/liveness probes are overridden with a
+# permissive tcpSocket check on the GCS port because KubeRay's default probes do
+# not pass reliably on a small CPU-only kind node; with this override the head
+# becomes Ready and KubeRay sets .status.state=ready. Workers are 0 to keep it
+# light (the worker component is still extracted from the spec). The Ray image is
+# pre-loaded into kind as ray-e2e:local (arch-native) by hack/e2e/up.sh.
+apiVersion: ray.io/v1
+kind: RayCluster
+metadata:
+  name: karta-e2e-ray
+  namespace: default
+spec:
+  rayVersion: "2.40.0"
+  headGroupSpec:
+    rayStartParams: {}
+    template:
+      spec:
+        containers:
+          - name: ray-head
+            image: ray-e2e:local
+            imagePullPolicy: IfNotPresent
+            resources:
+              requests: {cpu: 250m, memory: 1Gi}
+              limits: {cpu: "1", memory: 2Gi}
+            readinessProbe:
+              tcpSocket: {port: 6379}
+              initialDelaySeconds: 10
+              periodSeconds: 5
+              failureThreshold: 30
+            livenessProbe:
+              tcpSocket: {port: 6379}
+              initialDelaySeconds: 30
+              periodSeconds: 10
+              failureThreshold: 30
+  workerGroupSpecs:
+    - groupName: small
+      replicas: 0
+      minReplicas: 0
+      maxReplicas: 1
+      rayStartParams: {}
+      template:
+        spec:
+          containers:
+            - name: ray-worker
+              image: ray-e2e:local
+              imagePullPolicy: IfNotPresent
+              resources:
+                requests: {cpu: 250m, memory: 512Mi}

--- a/test/e2e/flows/testdata/raycluster/suspended.yaml
+++ b/test/e2e/flows/testdata/raycluster/suspended.yaml
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A RayCluster created suspended (spec.suspend true). KubeRay brings up no pods and
+# leaves status.state empty or "suspended", which the definition reads as Suspended.
+# The head and worker templates are still extracted from the spec. Same head-only shape
+# as running.yaml so the recorded extraction matches, only suspended.
+apiVersion: ray.io/v1
+kind: RayCluster
+metadata:
+  name: karta-e2e-ray-suspended
+  namespace: default
+spec:
+  suspend: true
+  rayVersion: "2.40.0"
+  headGroupSpec:
+    rayStartParams: {}
+    template:
+      spec:
+        containers:
+          - name: ray-head
+            image: ray-e2e:local
+            imagePullPolicy: IfNotPresent
+            resources:
+              requests: {cpu: 250m, memory: 1Gi}
+              limits: {cpu: "1", memory: 2Gi}
+            readinessProbe:
+              tcpSocket: {port: 6379}
+              initialDelaySeconds: 10
+              periodSeconds: 5
+              failureThreshold: 30
+            livenessProbe:
+              tcpSocket: {port: 6379}
+              initialDelaySeconds: 30
+              periodSeconds: 10
+              failureThreshold: 30
+  workerGroupSpecs:
+    - groupName: small
+      replicas: 0
+      minReplicas: 0
+      maxReplicas: 1
+      rayStartParams: {}
+      template:
+        spec:
+          containers:
+            - name: ray-worker
+              image: ray-e2e:local
+              imagePullPolicy: IfNotPresent
+              resources:
+                requests: {cpu: 250m, memory: 512Mi}

--- a/test/e2e/recorded_data/kuberay/v1.34.0/ray-io-raycluster-v1/resumed.yaml
+++ b/test/e2e/recorded_data/kuberay/v1.34.0/ray-io-raycluster-v1/resumed.yaml
@@ -1,0 +1,920 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayCluster
+    metadata:
+      creationTimestamp: "2026-08-18T12:40:57Z"
+      generation: 1
+      name: karta-e2e-ray-resumed
+      namespace: test-8m4bc
+      uid: c0bd5b90-057d-4886-9f67-44df11c61d30
+    spec:
+      headGroupSpec:
+        rayStartParams: {}
+        template:
+          spec:
+            containers:
+            - image: ray-e2e:local
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                failureThreshold: 30
+                initialDelaySeconds: 30
+                periodSeconds: 10
+                tcpSocket:
+                  port: 6379
+              name: ray-head
+              readinessProbe:
+                failureThreshold: 30
+                initialDelaySeconds: 10
+                periodSeconds: 5
+                tcpSocket:
+                  port: 6379
+              resources:
+                limits:
+                  cpu: "1"
+                  memory: 2Gi
+                requests:
+                  cpu: 250m
+                  memory: 1Gi
+      rayVersion: 2.40.0
+      suspend: true
+      workerGroupSpecs:
+      - groupName: small
+        maxReplicas: 1
+        minReplicas: 0
+        numOfHosts: 1
+        rayStartParams: {}
+        replicas: 0
+        template:
+          spec:
+            containers:
+            - image: ray-e2e:local
+              imagePullPolicy: IfNotPresent
+              name: ray-worker
+              resources:
+                requests:
+                  cpu: 250m
+                  memory: 512Mi
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:40:57Z"
+        message: Head Pod not found
+        reason: HeadPodNotFound
+        status: "False"
+        type: HeadPodReady
+      - lastTransitionTime: "2026-08-18T12:40:57Z"
+        message: RayCluster Pods are being provisioned for first time
+        reason: RayClusterPodsProvisioning
+        status: "False"
+        type: RayClusterProvisioned
+      - lastTransitionTime: "2026-08-18T12:40:57Z"
+        message: ""
+        reason: RayClusterSuspended
+        status: "False"
+        type: RayClusterSuspended
+      - lastTransitionTime: "2026-08-18T12:40:57Z"
+        message: ""
+        reason: RayClusterSuspending
+        status: "True"
+        type: RayClusterSuspending
+      desiredCPU: 250m
+      desiredGPU: "0"
+      desiredMemory: 1Gi
+      desiredTPU: "0"
+      endpoints:
+        client: "10001"
+        dashboard: "8265"
+        gcs-server: "6379"
+        metrics: "8080"
+        serve: "8000"
+      head:
+        serviceName: karta-e2e-ray-resumed-head-svc
+      lastUpdateTime: "2026-08-18T12:40:57Z"
+      maxWorkerReplicas: 1
+      observedGeneration: 1
+      state: suspended
+      stateTransitionTimes:
+        suspended: "2026-08-18T12:40:57Z"
+  resourceVersion: "16407"
+  state: Suspended
+- action:
+    name: Resume
+    operation:
+      patchType: application/merge-patch+json
+      payload:
+        spec:
+          suspend: false
+      verb: PATCH
+  kind: ACTION
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayCluster
+    metadata:
+      creationTimestamp: "2026-08-18T12:40:57Z"
+      generation: 2
+      name: karta-e2e-ray-resumed
+      namespace: test-8m4bc
+      uid: c0bd5b90-057d-4886-9f67-44df11c61d30
+    spec:
+      headGroupSpec:
+        rayStartParams: {}
+        template:
+          spec:
+            containers:
+            - image: ray-e2e:local
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                failureThreshold: 30
+                initialDelaySeconds: 30
+                periodSeconds: 10
+                tcpSocket:
+                  port: 6379
+              name: ray-head
+              readinessProbe:
+                failureThreshold: 30
+                initialDelaySeconds: 10
+                periodSeconds: 5
+                tcpSocket:
+                  port: 6379
+              resources:
+                limits:
+                  cpu: "1"
+                  memory: 2Gi
+                requests:
+                  cpu: 250m
+                  memory: 1Gi
+      rayVersion: 2.40.0
+      suspend: false
+      workerGroupSpecs:
+      - groupName: small
+        maxReplicas: 1
+        minReplicas: 0
+        numOfHosts: 1
+        rayStartParams: {}
+        replicas: 0
+        template:
+          spec:
+            containers:
+            - image: ray-e2e:local
+              imagePullPolicy: IfNotPresent
+              name: ray-worker
+              resources:
+                requests:
+                  cpu: 250m
+                  memory: 512Mi
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:40:57Z"
+        message: Head Pod not found
+        reason: HeadPodNotFound
+        status: "False"
+        type: HeadPodReady
+      - lastTransitionTime: "2026-08-18T12:40:57Z"
+        message: RayCluster Pods are being provisioned for first time
+        reason: RayClusterPodsProvisioning
+        status: "False"
+        type: RayClusterProvisioned
+      - lastTransitionTime: "2026-08-18T12:40:57Z"
+        message: ""
+        reason: RayClusterSuspended
+        status: "False"
+        type: RayClusterSuspended
+      - lastTransitionTime: "2026-08-18T12:40:57Z"
+        message: ""
+        reason: RayClusterSuspending
+        status: "True"
+        type: RayClusterSuspending
+      desiredCPU: 250m
+      desiredGPU: "0"
+      desiredMemory: 1Gi
+      desiredTPU: "0"
+      endpoints:
+        client: "10001"
+        dashboard: "8265"
+        gcs-server: "6379"
+        metrics: "8080"
+        serve: "8000"
+      head:
+        serviceName: karta-e2e-ray-resumed-head-svc
+      lastUpdateTime: "2026-08-18T12:40:57Z"
+      maxWorkerReplicas: 1
+      observedGeneration: 1
+      state: suspended
+      stateTransitionTimes:
+        suspended: "2026-08-18T12:40:57Z"
+  resourceVersion: "16408"
+  staleObservedGeneration: true
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayCluster
+    metadata:
+      creationTimestamp: "2026-08-18T12:40:57Z"
+      generation: 2
+      name: karta-e2e-ray-resumed
+      namespace: test-8m4bc
+      uid: c0bd5b90-057d-4886-9f67-44df11c61d30
+    spec:
+      headGroupSpec:
+        rayStartParams: {}
+        template:
+          spec:
+            containers:
+            - image: ray-e2e:local
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                failureThreshold: 30
+                initialDelaySeconds: 30
+                periodSeconds: 10
+                tcpSocket:
+                  port: 6379
+              name: ray-head
+              readinessProbe:
+                failureThreshold: 30
+                initialDelaySeconds: 10
+                periodSeconds: 5
+                tcpSocket:
+                  port: 6379
+              resources:
+                limits:
+                  cpu: "1"
+                  memory: 2Gi
+                requests:
+                  cpu: 250m
+                  memory: 1Gi
+      rayVersion: 2.40.0
+      suspend: false
+      workerGroupSpecs:
+      - groupName: small
+        maxReplicas: 1
+        minReplicas: 0
+        numOfHosts: 1
+        rayStartParams: {}
+        replicas: 0
+        template:
+          spec:
+            containers:
+            - image: ray-e2e:local
+              imagePullPolicy: IfNotPresent
+              name: ray-worker
+              resources:
+                requests:
+                  cpu: 250m
+                  memory: 512Mi
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:40:57Z"
+        message: Head Pod not found
+        reason: HeadPodNotFound
+        status: "False"
+        type: HeadPodReady
+      - lastTransitionTime: "2026-08-18T12:40:57Z"
+        message: RayCluster has been suspended
+        reason: RayClusterPodsProvisioning
+        status: "False"
+        type: RayClusterProvisioned
+      - lastTransitionTime: "2026-08-18T12:40:57Z"
+        message: ""
+        reason: RayClusterSuspended
+        status: "True"
+        type: RayClusterSuspended
+      - lastTransitionTime: "2026-08-18T12:40:57Z"
+        message: ""
+        reason: RayClusterSuspending
+        status: "False"
+        type: RayClusterSuspending
+      desiredCPU: 250m
+      desiredGPU: "0"
+      desiredMemory: 1Gi
+      desiredTPU: "0"
+      endpoints:
+        client: "10001"
+        dashboard: "8265"
+        gcs-server: "6379"
+        metrics: "8080"
+        serve: "8000"
+      head:
+        serviceName: karta-e2e-ray-resumed-head-svc
+      lastUpdateTime: "2026-08-18T12:40:57Z"
+      maxWorkerReplicas: 1
+      observedGeneration: 2
+      state: suspended
+      stateTransitionTimes:
+        suspended: "2026-08-18T12:40:57Z"
+  resourceVersion: "16410"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayCluster
+    metadata:
+      creationTimestamp: "2026-08-18T12:40:57Z"
+      generation: 2
+      name: karta-e2e-ray-resumed
+      namespace: test-8m4bc
+      uid: c0bd5b90-057d-4886-9f67-44df11c61d30
+    spec:
+      headGroupSpec:
+        rayStartParams: {}
+        template:
+          spec:
+            containers:
+            - image: ray-e2e:local
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                failureThreshold: 30
+                initialDelaySeconds: 30
+                periodSeconds: 10
+                tcpSocket:
+                  port: 6379
+              name: ray-head
+              readinessProbe:
+                failureThreshold: 30
+                initialDelaySeconds: 10
+                periodSeconds: 5
+                tcpSocket:
+                  port: 6379
+              resources:
+                limits:
+                  cpu: "1"
+                  memory: 2Gi
+                requests:
+                  cpu: 250m
+                  memory: 1Gi
+      rayVersion: 2.40.0
+      suspend: false
+      workerGroupSpecs:
+      - groupName: small
+        maxReplicas: 1
+        minReplicas: 0
+        numOfHosts: 1
+        rayStartParams: {}
+        replicas: 0
+        template:
+          spec:
+            containers:
+            - image: ray-e2e:local
+              imagePullPolicy: IfNotPresent
+              name: ray-worker
+              resources:
+                requests:
+                  cpu: 250m
+                  memory: 512Mi
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:40:57Z"
+        message: Head Pod not found
+        reason: HeadPodNotFound
+        status: "False"
+        type: HeadPodReady
+      - lastTransitionTime: "2026-08-18T12:40:57Z"
+        message: RayCluster has been suspended
+        reason: RayClusterPodsProvisioning
+        status: "False"
+        type: RayClusterProvisioned
+      - lastTransitionTime: "2026-08-18T12:40:57Z"
+        message: ""
+        reason: RayClusterSuspended
+        status: "False"
+        type: RayClusterSuspended
+      - lastTransitionTime: "2026-08-18T12:40:57Z"
+        message: ""
+        reason: RayClusterSuspending
+        status: "False"
+        type: RayClusterSuspending
+      desiredCPU: 250m
+      desiredGPU: "0"
+      desiredMemory: 1Gi
+      desiredTPU: "0"
+      endpoints:
+        client: "10001"
+        dashboard: "8265"
+        gcs-server: "6379"
+        metrics: "8080"
+        serve: "8000"
+      head:
+        serviceName: karta-e2e-ray-resumed-head-svc
+      lastUpdateTime: "2026-08-18T12:40:57Z"
+      maxWorkerReplicas: 1
+      observedGeneration: 2
+      state: suspended
+      stateTransitionTimes:
+        suspended: "2026-08-18T12:40:57Z"
+  resourceVersion: "16412"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayCluster
+    metadata:
+      creationTimestamp: "2026-08-18T12:40:57Z"
+      generation: 2
+      name: karta-e2e-ray-resumed
+      namespace: test-8m4bc
+      uid: c0bd5b90-057d-4886-9f67-44df11c61d30
+    spec:
+      headGroupSpec:
+        rayStartParams: {}
+        template:
+          spec:
+            containers:
+            - image: ray-e2e:local
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                failureThreshold: 30
+                initialDelaySeconds: 30
+                periodSeconds: 10
+                tcpSocket:
+                  port: 6379
+              name: ray-head
+              readinessProbe:
+                failureThreshold: 30
+                initialDelaySeconds: 10
+                periodSeconds: 5
+                tcpSocket:
+                  port: 6379
+              resources:
+                limits:
+                  cpu: "1"
+                  memory: 2Gi
+                requests:
+                  cpu: 250m
+                  memory: 1Gi
+      rayVersion: 2.40.0
+      suspend: false
+      workerGroupSpecs:
+      - groupName: small
+        maxReplicas: 1
+        minReplicas: 0
+        numOfHosts: 1
+        rayStartParams: {}
+        replicas: 0
+        template:
+          spec:
+            containers:
+            - image: ray-e2e:local
+              imagePullPolicy: IfNotPresent
+              name: ray-worker
+              resources:
+                requests:
+                  cpu: 250m
+                  memory: 512Mi
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:40:57Z"
+        message: Head Pod not found
+        reason: HeadPodNotFound
+        status: "False"
+        type: HeadPodReady
+      - lastTransitionTime: "2026-08-18T12:40:57Z"
+        message: RayCluster Pods are being provisioned for first time
+        reason: RayClusterPodsProvisioning
+        status: "False"
+        type: RayClusterProvisioned
+      - lastTransitionTime: "2026-08-18T12:40:57Z"
+        message: ""
+        reason: RayClusterSuspended
+        status: "False"
+        type: RayClusterSuspended
+      - lastTransitionTime: "2026-08-18T12:40:57Z"
+        message: ""
+        reason: RayClusterSuspending
+        status: "False"
+        type: RayClusterSuspending
+      desiredCPU: 250m
+      desiredGPU: "0"
+      desiredMemory: 1Gi
+      desiredTPU: "0"
+      endpoints:
+        client: "10001"
+        dashboard: "8265"
+        gcs-server: "6379"
+        metrics: "8080"
+        serve: "8000"
+      head:
+        serviceName: karta-e2e-ray-resumed-head-svc
+      lastUpdateTime: "2026-08-18T12:40:59Z"
+      maxWorkerReplicas: 1
+      observedGeneration: 2
+      state: suspended
+      stateTransitionTimes:
+        suspended: "2026-08-18T12:40:57Z"
+  resourceVersion: "16435"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayCluster
+    metadata:
+      creationTimestamp: "2026-08-18T12:40:57Z"
+      generation: 2
+      name: karta-e2e-ray-resumed
+      namespace: test-8m4bc
+      uid: c0bd5b90-057d-4886-9f67-44df11c61d30
+    spec:
+      headGroupSpec:
+        rayStartParams: {}
+        template:
+          spec:
+            containers:
+            - image: ray-e2e:local
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                failureThreshold: 30
+                initialDelaySeconds: 30
+                periodSeconds: 10
+                tcpSocket:
+                  port: 6379
+              name: ray-head
+              readinessProbe:
+                failureThreshold: 30
+                initialDelaySeconds: 10
+                periodSeconds: 5
+                tcpSocket:
+                  port: 6379
+              resources:
+                limits:
+                  cpu: "1"
+                  memory: 2Gi
+                requests:
+                  cpu: 250m
+                  memory: 1Gi
+      rayVersion: 2.40.0
+      suspend: false
+      workerGroupSpecs:
+      - groupName: small
+        maxReplicas: 1
+        minReplicas: 0
+        numOfHosts: 1
+        rayStartParams: {}
+        replicas: 0
+        template:
+          spec:
+            containers:
+            - image: ray-e2e:local
+              imagePullPolicy: IfNotPresent
+              name: ray-worker
+              resources:
+                requests:
+                  cpu: 250m
+                  memory: 512Mi
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:40:57Z"
+        message: ""
+        reason: Unknown
+        status: "False"
+        type: HeadPodReady
+      - lastTransitionTime: "2026-08-18T12:40:57Z"
+        message: RayCluster Pods are being provisioned for first time
+        reason: RayClusterPodsProvisioning
+        status: "False"
+        type: RayClusterProvisioned
+      - lastTransitionTime: "2026-08-18T12:40:57Z"
+        message: ""
+        reason: RayClusterSuspended
+        status: "False"
+        type: RayClusterSuspended
+      - lastTransitionTime: "2026-08-18T12:40:57Z"
+        message: ""
+        reason: RayClusterSuspending
+        status: "False"
+        type: RayClusterSuspending
+      desiredCPU: 250m
+      desiredGPU: "0"
+      desiredMemory: 1Gi
+      desiredTPU: "0"
+      endpoints:
+        client: "10001"
+        dashboard: "8265"
+        gcs-server: "6379"
+        metrics: "8080"
+        serve: "8000"
+      head:
+        podName: karta-e2e-ray-resumed-head-hj5v5
+        serviceName: karta-e2e-ray-resumed-head-svc
+      lastUpdateTime: "2026-08-18T12:40:59Z"
+      maxWorkerReplicas: 1
+      observedGeneration: 2
+      state: suspended
+      stateTransitionTimes:
+        suspended: "2026-08-18T12:40:57Z"
+  resourceVersion: "16437"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayCluster
+    metadata:
+      creationTimestamp: "2026-08-18T12:40:57Z"
+      generation: 2
+      name: karta-e2e-ray-resumed
+      namespace: test-8m4bc
+      uid: c0bd5b90-057d-4886-9f67-44df11c61d30
+    spec:
+      headGroupSpec:
+        rayStartParams: {}
+        template:
+          spec:
+            containers:
+            - image: ray-e2e:local
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                failureThreshold: 30
+                initialDelaySeconds: 30
+                periodSeconds: 10
+                tcpSocket:
+                  port: 6379
+              name: ray-head
+              readinessProbe:
+                failureThreshold: 30
+                initialDelaySeconds: 10
+                periodSeconds: 5
+                tcpSocket:
+                  port: 6379
+              resources:
+                limits:
+                  cpu: "1"
+                  memory: 2Gi
+                requests:
+                  cpu: 250m
+                  memory: 1Gi
+      rayVersion: 2.40.0
+      suspend: false
+      workerGroupSpecs:
+      - groupName: small
+        maxReplicas: 1
+        minReplicas: 0
+        numOfHosts: 1
+        rayStartParams: {}
+        replicas: 0
+        template:
+          spec:
+            containers:
+            - image: ray-e2e:local
+              imagePullPolicy: IfNotPresent
+              name: ray-worker
+              resources:
+                requests:
+                  cpu: 250m
+                  memory: 512Mi
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:40:57Z"
+        message: 'containers with unready status: [ray-head]; ray-head: '
+        reason: ContainerCreating
+        status: "False"
+        type: HeadPodReady
+      - lastTransitionTime: "2026-08-18T12:40:57Z"
+        message: RayCluster Pods are being provisioned for first time
+        reason: RayClusterPodsProvisioning
+        status: "False"
+        type: RayClusterProvisioned
+      - lastTransitionTime: "2026-08-18T12:40:57Z"
+        message: ""
+        reason: RayClusterSuspended
+        status: "False"
+        type: RayClusterSuspended
+      - lastTransitionTime: "2026-08-18T12:40:57Z"
+        message: ""
+        reason: RayClusterSuspending
+        status: "False"
+        type: RayClusterSuspending
+      desiredCPU: 250m
+      desiredGPU: "0"
+      desiredMemory: 1Gi
+      desiredTPU: "0"
+      endpoints:
+        client: "10001"
+        dashboard: "8265"
+        gcs-server: "6379"
+        metrics: "8080"
+        serve: "8000"
+      head:
+        podName: karta-e2e-ray-resumed-head-hj5v5
+        serviceName: karta-e2e-ray-resumed-head-svc
+      lastUpdateTime: "2026-08-18T12:40:59Z"
+      maxWorkerReplicas: 1
+      observedGeneration: 2
+      state: suspended
+      stateTransitionTimes:
+        suspended: "2026-08-18T12:40:57Z"
+  resourceVersion: "16439"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayCluster
+    metadata:
+      creationTimestamp: "2026-08-18T12:40:57Z"
+      generation: 2
+      name: karta-e2e-ray-resumed
+      namespace: test-8m4bc
+      uid: c0bd5b90-057d-4886-9f67-44df11c61d30
+    spec:
+      headGroupSpec:
+        rayStartParams: {}
+        template:
+          spec:
+            containers:
+            - image: ray-e2e:local
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                failureThreshold: 30
+                initialDelaySeconds: 30
+                periodSeconds: 10
+                tcpSocket:
+                  port: 6379
+              name: ray-head
+              readinessProbe:
+                failureThreshold: 30
+                initialDelaySeconds: 10
+                periodSeconds: 5
+                tcpSocket:
+                  port: 6379
+              resources:
+                limits:
+                  cpu: "1"
+                  memory: 2Gi
+                requests:
+                  cpu: 250m
+                  memory: 1Gi
+      rayVersion: 2.40.0
+      suspend: false
+      workerGroupSpecs:
+      - groupName: small
+        maxReplicas: 1
+        minReplicas: 0
+        numOfHosts: 1
+        rayStartParams: {}
+        replicas: 0
+        template:
+          spec:
+            containers:
+            - image: ray-e2e:local
+              imagePullPolicy: IfNotPresent
+              name: ray-worker
+              resources:
+                requests:
+                  cpu: 250m
+                  memory: 512Mi
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:40:57Z"
+        message: 'containers with unready status: [ray-head]'
+        reason: ContainersNotReady
+        status: "False"
+        type: HeadPodReady
+      - lastTransitionTime: "2026-08-18T12:40:57Z"
+        message: RayCluster Pods are being provisioned for first time
+        reason: RayClusterPodsProvisioning
+        status: "False"
+        type: RayClusterProvisioned
+      - lastTransitionTime: "2026-08-18T12:40:57Z"
+        message: ""
+        reason: RayClusterSuspended
+        status: "False"
+        type: RayClusterSuspended
+      - lastTransitionTime: "2026-08-18T12:40:57Z"
+        message: ""
+        reason: RayClusterSuspending
+        status: "False"
+        type: RayClusterSuspending
+      desiredCPU: 250m
+      desiredGPU: "0"
+      desiredMemory: 1Gi
+      desiredTPU: "0"
+      endpoints:
+        client: "10001"
+        dashboard: "8265"
+        gcs-server: "6379"
+        metrics: "8080"
+        serve: "8000"
+      head:
+        podIP: 10.244.2.70
+        podName: karta-e2e-ray-resumed-head-hj5v5
+        serviceIP: 10.244.2.70
+        serviceName: karta-e2e-ray-resumed-head-svc
+      lastUpdateTime: "2026-08-18T12:41:00Z"
+      maxWorkerReplicas: 1
+      observedGeneration: 2
+      state: suspended
+      stateTransitionTimes:
+        suspended: "2026-08-18T12:40:57Z"
+  resourceVersion: "16453"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayCluster
+    metadata:
+      creationTimestamp: "2026-08-18T12:40:57Z"
+      generation: 2
+      name: karta-e2e-ray-resumed
+      namespace: test-8m4bc
+      uid: c0bd5b90-057d-4886-9f67-44df11c61d30
+    spec:
+      headGroupSpec:
+        rayStartParams: {}
+        template:
+          spec:
+            containers:
+            - image: ray-e2e:local
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                failureThreshold: 30
+                initialDelaySeconds: 30
+                periodSeconds: 10
+                tcpSocket:
+                  port: 6379
+              name: ray-head
+              readinessProbe:
+                failureThreshold: 30
+                initialDelaySeconds: 10
+                periodSeconds: 5
+                tcpSocket:
+                  port: 6379
+              resources:
+                limits:
+                  cpu: "1"
+                  memory: 2Gi
+                requests:
+                  cpu: 250m
+                  memory: 1Gi
+      rayVersion: 2.40.0
+      suspend: false
+      workerGroupSpecs:
+      - groupName: small
+        maxReplicas: 1
+        minReplicas: 0
+        numOfHosts: 1
+        rayStartParams: {}
+        replicas: 0
+        template:
+          spec:
+            containers:
+            - image: ray-e2e:local
+              imagePullPolicy: IfNotPresent
+              name: ray-worker
+              resources:
+                requests:
+                  cpu: 250m
+                  memory: 512Mi
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:41:11Z"
+        message: ""
+        reason: HeadPodRunningAndReady
+        status: "True"
+        type: HeadPodReady
+      - lastTransitionTime: "2026-08-18T12:41:11Z"
+        message: All Ray Pods are ready for the first time
+        reason: AllPodRunningAndReadyFirstTime
+        status: "True"
+        type: RayClusterProvisioned
+      - lastTransitionTime: "2026-08-18T12:40:57Z"
+        message: ""
+        reason: RayClusterSuspended
+        status: "False"
+        type: RayClusterSuspended
+      - lastTransitionTime: "2026-08-18T12:40:57Z"
+        message: ""
+        reason: RayClusterSuspending
+        status: "False"
+        type: RayClusterSuspending
+      desiredCPU: 250m
+      desiredGPU: "0"
+      desiredMemory: 1Gi
+      desiredTPU: "0"
+      endpoints:
+        client: "10001"
+        dashboard: "8265"
+        gcs-server: "6379"
+        metrics: "8080"
+        serve: "8000"
+      head:
+        podIP: 10.244.2.70
+        podName: karta-e2e-ray-resumed-head-hj5v5
+        serviceIP: 10.244.2.70
+        serviceName: karta-e2e-ray-resumed-head-svc
+      lastUpdateTime: "2026-08-18T12:41:11Z"
+      maxWorkerReplicas: 1
+      observedGeneration: 2
+      state: ready
+      stateTransitionTimes:
+        ready: "2026-08-18T12:41:11Z"
+        suspended: "2026-08-18T12:40:57Z"
+  resourceVersion: "16537"
+  state: Running
+flow: resumed
+kartaFile: docs/catalog/ray-io-raycluster-v1.yaml
+kartaName: ray-io-raycluster-v1
+operator: kuberay
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Running

--- a/test/e2e/recorded_data/kuberay/v1.34.0/ray-io-raycluster-v1/running.yaml
+++ b/test/e2e/recorded_data/kuberay/v1.34.0/ray-io-raycluster-v1/running.yaml
@@ -1,0 +1,401 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayCluster
+    metadata:
+      creationTimestamp: "2026-08-18T12:40:45Z"
+      generation: 1
+      name: karta-e2e-ray
+      namespace: test-8m4bc
+      uid: 851d69e4-cf4d-44b5-a5b1-aadbf3835537
+    spec:
+      headGroupSpec:
+        rayStartParams: {}
+        template:
+          spec:
+            containers:
+            - image: ray-e2e:local
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                failureThreshold: 30
+                initialDelaySeconds: 30
+                periodSeconds: 10
+                tcpSocket:
+                  port: 6379
+              name: ray-head
+              readinessProbe:
+                failureThreshold: 30
+                initialDelaySeconds: 10
+                periodSeconds: 5
+                tcpSocket:
+                  port: 6379
+              resources:
+                limits:
+                  cpu: "1"
+                  memory: 2Gi
+                requests:
+                  cpu: 250m
+                  memory: 1Gi
+      rayVersion: 2.40.0
+      workerGroupSpecs:
+      - groupName: small
+        maxReplicas: 1
+        minReplicas: 0
+        numOfHosts: 1
+        rayStartParams: {}
+        replicas: 0
+        template:
+          spec:
+            containers:
+            - image: ray-e2e:local
+              imagePullPolicy: IfNotPresent
+              name: ray-worker
+              resources:
+                requests:
+                  cpu: 250m
+                  memory: 512Mi
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:40:45Z"
+        message: ""
+        reason: Unknown
+        status: "False"
+        type: HeadPodReady
+      - lastTransitionTime: "2026-08-18T12:40:45Z"
+        message: RayCluster Pods are being provisioned for first time
+        reason: RayClusterPodsProvisioning
+        status: "False"
+        type: RayClusterProvisioned
+      - lastTransitionTime: "2026-08-18T12:40:45Z"
+        message: ""
+        reason: RayClusterSuspended
+        status: "False"
+        type: RayClusterSuspended
+      - lastTransitionTime: "2026-08-18T12:40:45Z"
+        message: ""
+        reason: RayClusterSuspending
+        status: "False"
+        type: RayClusterSuspending
+      desiredCPU: 250m
+      desiredGPU: "0"
+      desiredMemory: 1Gi
+      desiredTPU: "0"
+      endpoints:
+        client: "10001"
+        dashboard: "8265"
+        gcs-server: "6379"
+        metrics: "8080"
+        serve: "8000"
+      head:
+        podName: karta-e2e-ray-head-f2cmd
+        serviceName: karta-e2e-ray-head-svc
+      lastUpdateTime: "2026-08-18T12:40:45Z"
+      maxWorkerReplicas: 1
+      observedGeneration: 1
+  resourceVersion: "16279"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayCluster
+    metadata:
+      creationTimestamp: "2026-08-18T12:40:45Z"
+      generation: 1
+      name: karta-e2e-ray
+      namespace: test-8m4bc
+      uid: 851d69e4-cf4d-44b5-a5b1-aadbf3835537
+    spec:
+      headGroupSpec:
+        rayStartParams: {}
+        template:
+          spec:
+            containers:
+            - image: ray-e2e:local
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                failureThreshold: 30
+                initialDelaySeconds: 30
+                periodSeconds: 10
+                tcpSocket:
+                  port: 6379
+              name: ray-head
+              readinessProbe:
+                failureThreshold: 30
+                initialDelaySeconds: 10
+                periodSeconds: 5
+                tcpSocket:
+                  port: 6379
+              resources:
+                limits:
+                  cpu: "1"
+                  memory: 2Gi
+                requests:
+                  cpu: 250m
+                  memory: 1Gi
+      rayVersion: 2.40.0
+      workerGroupSpecs:
+      - groupName: small
+        maxReplicas: 1
+        minReplicas: 0
+        numOfHosts: 1
+        rayStartParams: {}
+        replicas: 0
+        template:
+          spec:
+            containers:
+            - image: ray-e2e:local
+              imagePullPolicy: IfNotPresent
+              name: ray-worker
+              resources:
+                requests:
+                  cpu: 250m
+                  memory: 512Mi
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:40:45Z"
+        message: 'containers with unready status: [ray-head]; ray-head: '
+        reason: ContainerCreating
+        status: "False"
+        type: HeadPodReady
+      - lastTransitionTime: "2026-08-18T12:40:45Z"
+        message: RayCluster Pods are being provisioned for first time
+        reason: RayClusterPodsProvisioning
+        status: "False"
+        type: RayClusterProvisioned
+      - lastTransitionTime: "2026-08-18T12:40:45Z"
+        message: ""
+        reason: RayClusterSuspended
+        status: "False"
+        type: RayClusterSuspended
+      - lastTransitionTime: "2026-08-18T12:40:45Z"
+        message: ""
+        reason: RayClusterSuspending
+        status: "False"
+        type: RayClusterSuspending
+      desiredCPU: 250m
+      desiredGPU: "0"
+      desiredMemory: 1Gi
+      desiredTPU: "0"
+      endpoints:
+        client: "10001"
+        dashboard: "8265"
+        gcs-server: "6379"
+        metrics: "8080"
+        serve: "8000"
+      head:
+        podName: karta-e2e-ray-head-f2cmd
+        serviceName: karta-e2e-ray-head-svc
+      lastUpdateTime: "2026-08-18T12:40:45Z"
+      maxWorkerReplicas: 1
+      observedGeneration: 1
+  resourceVersion: "16282"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayCluster
+    metadata:
+      creationTimestamp: "2026-08-18T12:40:45Z"
+      generation: 1
+      name: karta-e2e-ray
+      namespace: test-8m4bc
+      uid: 851d69e4-cf4d-44b5-a5b1-aadbf3835537
+    spec:
+      headGroupSpec:
+        rayStartParams: {}
+        template:
+          spec:
+            containers:
+            - image: ray-e2e:local
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                failureThreshold: 30
+                initialDelaySeconds: 30
+                periodSeconds: 10
+                tcpSocket:
+                  port: 6379
+              name: ray-head
+              readinessProbe:
+                failureThreshold: 30
+                initialDelaySeconds: 10
+                periodSeconds: 5
+                tcpSocket:
+                  port: 6379
+              resources:
+                limits:
+                  cpu: "1"
+                  memory: 2Gi
+                requests:
+                  cpu: 250m
+                  memory: 1Gi
+      rayVersion: 2.40.0
+      workerGroupSpecs:
+      - groupName: small
+        maxReplicas: 1
+        minReplicas: 0
+        numOfHosts: 1
+        rayStartParams: {}
+        replicas: 0
+        template:
+          spec:
+            containers:
+            - image: ray-e2e:local
+              imagePullPolicy: IfNotPresent
+              name: ray-worker
+              resources:
+                requests:
+                  cpu: 250m
+                  memory: 512Mi
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:40:45Z"
+        message: 'containers with unready status: [ray-head]'
+        reason: ContainersNotReady
+        status: "False"
+        type: HeadPodReady
+      - lastTransitionTime: "2026-08-18T12:40:45Z"
+        message: RayCluster Pods are being provisioned for first time
+        reason: RayClusterPodsProvisioning
+        status: "False"
+        type: RayClusterProvisioned
+      - lastTransitionTime: "2026-08-18T12:40:45Z"
+        message: ""
+        reason: RayClusterSuspended
+        status: "False"
+        type: RayClusterSuspended
+      - lastTransitionTime: "2026-08-18T12:40:45Z"
+        message: ""
+        reason: RayClusterSuspending
+        status: "False"
+        type: RayClusterSuspending
+      desiredCPU: 250m
+      desiredGPU: "0"
+      desiredMemory: 1Gi
+      desiredTPU: "0"
+      endpoints:
+        client: "10001"
+        dashboard: "8265"
+        gcs-server: "6379"
+        metrics: "8080"
+        serve: "8000"
+      head:
+        podIP: 10.244.2.69
+        podName: karta-e2e-ray-head-f2cmd
+        serviceIP: 10.244.2.69
+        serviceName: karta-e2e-ray-head-svc
+      lastUpdateTime: "2026-08-18T12:40:46Z"
+      maxWorkerReplicas: 1
+      observedGeneration: 1
+  resourceVersion: "16298"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayCluster
+    metadata:
+      creationTimestamp: "2026-08-18T12:40:45Z"
+      generation: 1
+      name: karta-e2e-ray
+      namespace: test-8m4bc
+      uid: 851d69e4-cf4d-44b5-a5b1-aadbf3835537
+    spec:
+      headGroupSpec:
+        rayStartParams: {}
+        template:
+          spec:
+            containers:
+            - image: ray-e2e:local
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                failureThreshold: 30
+                initialDelaySeconds: 30
+                periodSeconds: 10
+                tcpSocket:
+                  port: 6379
+              name: ray-head
+              readinessProbe:
+                failureThreshold: 30
+                initialDelaySeconds: 10
+                periodSeconds: 5
+                tcpSocket:
+                  port: 6379
+              resources:
+                limits:
+                  cpu: "1"
+                  memory: 2Gi
+                requests:
+                  cpu: 250m
+                  memory: 1Gi
+      rayVersion: 2.40.0
+      workerGroupSpecs:
+      - groupName: small
+        maxReplicas: 1
+        minReplicas: 0
+        numOfHosts: 1
+        rayStartParams: {}
+        replicas: 0
+        template:
+          spec:
+            containers:
+            - image: ray-e2e:local
+              imagePullPolicy: IfNotPresent
+              name: ray-worker
+              resources:
+                requests:
+                  cpu: 250m
+                  memory: 512Mi
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:40:57Z"
+        message: ""
+        reason: HeadPodRunningAndReady
+        status: "True"
+        type: HeadPodReady
+      - lastTransitionTime: "2026-08-18T12:40:57Z"
+        message: All Ray Pods are ready for the first time
+        reason: AllPodRunningAndReadyFirstTime
+        status: "True"
+        type: RayClusterProvisioned
+      - lastTransitionTime: "2026-08-18T12:40:45Z"
+        message: ""
+        reason: RayClusterSuspended
+        status: "False"
+        type: RayClusterSuspended
+      - lastTransitionTime: "2026-08-18T12:40:45Z"
+        message: ""
+        reason: RayClusterSuspending
+        status: "False"
+        type: RayClusterSuspending
+      desiredCPU: 250m
+      desiredGPU: "0"
+      desiredMemory: 1Gi
+      desiredTPU: "0"
+      endpoints:
+        client: "10001"
+        dashboard: "8265"
+        gcs-server: "6379"
+        metrics: "8080"
+        serve: "8000"
+      head:
+        podIP: 10.244.2.69
+        podName: karta-e2e-ray-head-f2cmd
+        serviceIP: 10.244.2.69
+        serviceName: karta-e2e-ray-head-svc
+      lastUpdateTime: "2026-08-18T12:40:57Z"
+      maxWorkerReplicas: 1
+      observedGeneration: 1
+      state: ready
+      stateTransitionTimes:
+        ready: "2026-08-18T12:40:57Z"
+  resourceVersion: "16385"
+  state: Running
+flow: running
+kartaFile: docs/catalog/ray-io-raycluster-v1.yaml
+kartaName: ray-io-raycluster-v1
+operator: kuberay
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Running

--- a/test/e2e/recorded_data/kuberay/v1.34.0/ray-io-raycluster-v1/suspended.yaml
+++ b/test/e2e/recorded_data/kuberay/v1.34.0/ray-io-raycluster-v1/suspended.yaml
@@ -1,0 +1,69 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: ray.io/v1
+    kind: RayCluster
+    metadata:
+      creationTimestamp: "2026-08-18T12:40:57Z"
+      generation: 1
+      name: karta-e2e-ray-suspended
+      namespace: test-8m4bc
+      uid: 0be1270f-70b1-4875-baac-2cdfc3682af9
+    spec:
+      headGroupSpec:
+        rayStartParams: {}
+        template:
+          spec:
+            containers:
+            - image: ray-e2e:local
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                failureThreshold: 30
+                initialDelaySeconds: 30
+                periodSeconds: 10
+                tcpSocket:
+                  port: 6379
+              name: ray-head
+              readinessProbe:
+                failureThreshold: 30
+                initialDelaySeconds: 10
+                periodSeconds: 5
+                tcpSocket:
+                  port: 6379
+              resources:
+                limits:
+                  cpu: "1"
+                  memory: 2Gi
+                requests:
+                  cpu: 250m
+                  memory: 1Gi
+      rayVersion: 2.40.0
+      suspend: true
+      workerGroupSpecs:
+      - groupName: small
+        maxReplicas: 1
+        minReplicas: 0
+        numOfHosts: 1
+        rayStartParams: {}
+        replicas: 0
+        template:
+          spec:
+            containers:
+            - image: ray-e2e:local
+              imagePullPolicy: IfNotPresent
+              name: ray-worker
+              resources:
+                requests:
+                  cpu: 250m
+                  memory: 512Mi
+  resourceVersion: "16389"
+  state: Suspended
+flow: suspended
+kartaFile: docs/catalog/ray-io-raycluster-v1.yaml
+kartaName: ray-io-raycluster-v1
+operator: kuberay
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Suspended


### PR DESCRIPTION
Part of #139 - one workload type per PR, stacked. Adds the raycluster flow: its spec steps, the predicates it judges stable states with (from the workload's own fields), and its recorded fixtures. Replayed offline by the suite in #260; `make check` green at every layer.