### PR TITLE
test(e2e): add the knative flow and its recorded fixtures

### DIFF
--- a/test/e2e/flows/knative_test.go
+++ b/test/e2e/flows/knative_test.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package flows
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kartav1alpha1 "github.com/run-ai/karta/pkg/api/runai/v1alpha1"
+	"github.com/run-ai/karta/test/e2e/recorder"
+)
+
+var _ = Describe("KnativeService", Ordered, Label("knative"), func() {
+	var rec *recorder.Recorder
+	var fx recorder.Fixture
+
+	BeforeAll(func(ctx SpecContext) {
+		installKarta(ctx, "../../docs/catalog/serving-knative-dev-service-v1.yaml", "serving-knative-dev-service-v1")
+		fx = recorder.Fixture{Operator: "knative", Version: operatorVersion("knative"), KartaName: "serving-knative-dev-service-v1", KartaFile: "docs/catalog/serving-knative-dev-service-v1.yaml"}
+		rec = recorder.New(cfg).
+			SetTimeout(5*time.Minute).
+			AddState(kartav1alpha1.InitializingStatus, CondStatus("Ready", "Unknown")).
+			AddState(kartav1alpha1.RunningStatus, CondTrue("Ready"))
+	})
+
+	It("running", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "running", "testdata/knative/running.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+})

--- a/test/e2e/flows/predicates.go
+++ b/test/e2e/flows/predicates.go
@@ -57,6 +57,20 @@ func CondFalse(condType string) recorder.StateCheck {
 	}
 }
 
+// CondStatus matches when a condition of condType is present with the given status. Useful for the
+// "Unknown" status a workload reports while it is still reconciling (Knative Ready=Unknown while deploying).
+func CondStatus(condType, status string) recorder.StateCheck {
+	return func(u *unstructured.Unstructured) bool {
+		conds, _, _ := unstructured.NestedSlice(u.Object, "status", "conditions")
+		for _, c := range conds {
+			if m, ok := c.(map[string]any); ok && m["type"] == condType && m["status"] == status {
+				return true
+			}
+		}
+		return false
+	}
+}
+
 // CondNotTrue matches when no condition of condType is present with status True (absent or non-True). A
 // just-created Deployment is Progressing with no Available condition yet, still initializing.
 func CondNotTrue(condType string) recorder.StateCheck {

--- a/test/e2e/flows/testdata/knative/running.yaml
+++ b/test/e2e/flows/testdata/knative/running.yaml
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A real Knative Service driven by the Knative Serving controller (installed by
+# hack/e2e/up.sh together with the Kourier networking layer). The controller
+# creates a Revision and a Deployment and marks the Service Ready once the pod is
+# running and the route is admitted; the test waits for that real Ready condition.
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: karta-e2e-knative
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+        - image: ghcr.io/knative/helloworld-go:latest
+          ports:
+            - containerPort: 8080
+          env:
+            - name: TARGET
+              value: karta-e2e
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi

--- a/test/e2e/recorded_data/knative/v1.34.0/serving-knative-dev-service-v1/running.yaml
+++ b/test/e2e/recorded_data/knative/v1.34.0/serving-knative-dev-service-v1/running.yaml
@@ -1,0 +1,459 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: serving.knative.dev/v1
+    kind: Service
+    metadata:
+      annotations:
+        serving.knative.dev/creator: kubernetes-admin
+        serving.knative.dev/lastModifier: kubernetes-admin
+      creationTimestamp: "2026-08-18T12:39:29Z"
+      generation: 1
+      name: karta-e2e-knative
+      namespace: test-8m4bc
+      uid: a5ef0c59-af42-481c-8581-1594424d3f1b
+    spec:
+      template:
+        metadata:
+          creationTimestamp: null
+        spec:
+          containerConcurrency: 0
+          containers:
+          - env:
+            - name: TARGET
+              value: karta-e2e
+            image: ghcr.io/knative/helloworld-go:latest
+            name: user-container
+            ports:
+            - containerPort: 8080
+              protocol: TCP
+            readinessProbe:
+              successThreshold: 1
+              tcpSocket:
+                port: 0
+            resources:
+              requests:
+                cpu: 50m
+                memory: 64Mi
+          enableServiceLinks: false
+          timeoutSeconds: 300
+      traffic:
+      - latestRevision: true
+        percent: 100
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:39:29Z"
+        message: The Configuration is still working to reflect the latest desired
+          specification.
+        reason: OutOfDate
+        status: Unknown
+        type: ConfigurationsReady
+      - lastTransitionTime: "2026-08-18T12:39:29Z"
+        message: The Route is still working to reflect the latest desired specification.
+        reason: OutOfDate
+        status: Unknown
+        type: Ready
+      - lastTransitionTime: "2026-08-18T12:39:29Z"
+        message: The Route is still working to reflect the latest desired specification.
+        reason: OutOfDate
+        status: Unknown
+        type: RoutesReady
+      observedGeneration: 1
+  resourceVersion: "15356"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: serving.knative.dev/v1
+    kind: Service
+    metadata:
+      annotations:
+        serving.knative.dev/creator: kubernetes-admin
+        serving.knative.dev/lastModifier: kubernetes-admin
+      creationTimestamp: "2026-08-18T12:39:29Z"
+      generation: 1
+      name: karta-e2e-knative
+      namespace: test-8m4bc
+      uid: a5ef0c59-af42-481c-8581-1594424d3f1b
+    spec:
+      template:
+        metadata:
+          creationTimestamp: null
+        spec:
+          containerConcurrency: 0
+          containers:
+          - env:
+            - name: TARGET
+              value: karta-e2e
+            image: ghcr.io/knative/helloworld-go:latest
+            name: user-container
+            ports:
+            - containerPort: 8080
+              protocol: TCP
+            readinessProbe:
+              successThreshold: 1
+              tcpSocket:
+                port: 0
+            resources:
+              requests:
+                cpu: 50m
+                memory: 64Mi
+          enableServiceLinks: false
+          timeoutSeconds: 300
+      traffic:
+      - latestRevision: true
+        percent: 100
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:39:29Z"
+        status: Unknown
+        type: ConfigurationsReady
+      - lastTransitionTime: "2026-08-18T12:39:29Z"
+        message: The Route is still working to reflect the latest desired specification.
+        reason: OutOfDate
+        status: Unknown
+        type: Ready
+      - lastTransitionTime: "2026-08-18T12:39:29Z"
+        message: The Route is still working to reflect the latest desired specification.
+        reason: OutOfDate
+        status: Unknown
+        type: RoutesReady
+      latestCreatedRevisionName: karta-e2e-knative-00001
+      observedGeneration: 1
+  resourceVersion: "15361"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: serving.knative.dev/v1
+    kind: Service
+    metadata:
+      annotations:
+        serving.knative.dev/creator: kubernetes-admin
+        serving.knative.dev/lastModifier: kubernetes-admin
+      creationTimestamp: "2026-08-18T12:39:29Z"
+      generation: 1
+      name: karta-e2e-knative
+      namespace: test-8m4bc
+      uid: a5ef0c59-af42-481c-8581-1594424d3f1b
+    spec:
+      template:
+        metadata:
+          creationTimestamp: null
+        spec:
+          containerConcurrency: 0
+          containers:
+          - env:
+            - name: TARGET
+              value: karta-e2e
+            image: ghcr.io/knative/helloworld-go:latest
+            name: user-container
+            ports:
+            - containerPort: 8080
+              protocol: TCP
+            readinessProbe:
+              successThreshold: 1
+              tcpSocket:
+                port: 0
+            resources:
+              requests:
+                cpu: 50m
+                memory: 64Mi
+          enableServiceLinks: false
+          timeoutSeconds: 300
+      traffic:
+      - latestRevision: true
+        percent: 100
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:39:29Z"
+        status: Unknown
+        type: ConfigurationsReady
+      - lastTransitionTime: "2026-08-18T12:39:29Z"
+        message: Configuration "karta-e2e-knative" is waiting for a Revision to become
+          ready.
+        reason: RevisionMissing
+        status: Unknown
+        type: Ready
+      - lastTransitionTime: "2026-08-18T12:39:29Z"
+        message: Configuration "karta-e2e-knative" is waiting for a Revision to become
+          ready.
+        reason: RevisionMissing
+        status: Unknown
+        type: RoutesReady
+      latestCreatedRevisionName: karta-e2e-knative-00001
+      observedGeneration: 1
+      url: http://karta-e2e-knative.test-8m4bc.127.0.0.1.sslip.io
+  resourceVersion: "15363"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: serving.knative.dev/v1
+    kind: Service
+    metadata:
+      annotations:
+        serving.knative.dev/creator: kubernetes-admin
+        serving.knative.dev/lastModifier: kubernetes-admin
+      creationTimestamp: "2026-08-18T12:39:29Z"
+      generation: 1
+      name: karta-e2e-knative
+      namespace: test-8m4bc
+      uid: a5ef0c59-af42-481c-8581-1594424d3f1b
+    spec:
+      template:
+        metadata:
+          creationTimestamp: null
+        spec:
+          containerConcurrency: 0
+          containers:
+          - env:
+            - name: TARGET
+              value: karta-e2e
+            image: ghcr.io/knative/helloworld-go:latest
+            name: user-container
+            ports:
+            - containerPort: 8080
+              protocol: TCP
+            readinessProbe:
+              successThreshold: 1
+              tcpSocket:
+                port: 0
+            resources:
+              requests:
+                cpu: 50m
+                memory: 64Mi
+          enableServiceLinks: false
+          timeoutSeconds: 300
+      traffic:
+      - latestRevision: true
+        percent: 100
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:39:34Z"
+        status: "True"
+        type: ConfigurationsReady
+      - lastTransitionTime: "2026-08-18T12:39:29Z"
+        message: Configuration "karta-e2e-knative" is waiting for a Revision to become
+          ready.
+        reason: RevisionMissing
+        status: Unknown
+        type: Ready
+      - lastTransitionTime: "2026-08-18T12:39:29Z"
+        message: Configuration "karta-e2e-knative" is waiting for a Revision to become
+          ready.
+        reason: RevisionMissing
+        status: Unknown
+        type: RoutesReady
+      latestCreatedRevisionName: karta-e2e-knative-00001
+      latestReadyRevisionName: karta-e2e-knative-00001
+      observedGeneration: 1
+      url: http://karta-e2e-knative.test-8m4bc.127.0.0.1.sslip.io
+  resourceVersion: "15460"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: serving.knative.dev/v1
+    kind: Service
+    metadata:
+      annotations:
+        serving.knative.dev/creator: kubernetes-admin
+        serving.knative.dev/lastModifier: kubernetes-admin
+      creationTimestamp: "2026-08-18T12:39:29Z"
+      generation: 1
+      name: karta-e2e-knative
+      namespace: test-8m4bc
+      uid: a5ef0c59-af42-481c-8581-1594424d3f1b
+    spec:
+      template:
+        metadata:
+          creationTimestamp: null
+        spec:
+          containerConcurrency: 0
+          containers:
+          - env:
+            - name: TARGET
+              value: karta-e2e
+            image: ghcr.io/knative/helloworld-go:latest
+            name: user-container
+            ports:
+            - containerPort: 8080
+              protocol: TCP
+            readinessProbe:
+              successThreshold: 1
+              tcpSocket:
+                port: 0
+            resources:
+              requests:
+                cpu: 50m
+                memory: 64Mi
+          enableServiceLinks: false
+          timeoutSeconds: 300
+      traffic:
+      - latestRevision: true
+        percent: 100
+    status:
+      address:
+        url: http://karta-e2e-knative.test-8m4bc.svc.cluster.local
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:39:34Z"
+        status: "True"
+        type: ConfigurationsReady
+      - lastTransitionTime: "2026-08-18T12:39:34Z"
+        message: Ingress has not yet been reconciled.
+        reason: IngressNotConfigured
+        status: Unknown
+        type: Ready
+      - lastTransitionTime: "2026-08-18T12:39:34Z"
+        message: Ingress has not yet been reconciled.
+        reason: IngressNotConfigured
+        status: Unknown
+        type: RoutesReady
+      latestCreatedRevisionName: karta-e2e-knative-00001
+      latestReadyRevisionName: karta-e2e-knative-00001
+      observedGeneration: 1
+      traffic:
+      - latestRevision: true
+        percent: 100
+        revisionName: karta-e2e-knative-00001
+      url: http://karta-e2e-knative.test-8m4bc.127.0.0.1.sslip.io
+  resourceVersion: "15469"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: serving.knative.dev/v1
+    kind: Service
+    metadata:
+      annotations:
+        serving.knative.dev/creator: kubernetes-admin
+        serving.knative.dev/lastModifier: kubernetes-admin
+      creationTimestamp: "2026-08-18T12:39:29Z"
+      generation: 1
+      name: karta-e2e-knative
+      namespace: test-8m4bc
+      uid: a5ef0c59-af42-481c-8581-1594424d3f1b
+    spec:
+      template:
+        metadata:
+          creationTimestamp: null
+        spec:
+          containerConcurrency: 0
+          containers:
+          - env:
+            - name: TARGET
+              value: karta-e2e
+            image: ghcr.io/knative/helloworld-go:latest
+            name: user-container
+            ports:
+            - containerPort: 8080
+              protocol: TCP
+            readinessProbe:
+              successThreshold: 1
+              tcpSocket:
+                port: 0
+            resources:
+              requests:
+                cpu: 50m
+                memory: 64Mi
+          enableServiceLinks: false
+          timeoutSeconds: 300
+      traffic:
+      - latestRevision: true
+        percent: 100
+    status:
+      address:
+        url: http://karta-e2e-knative.test-8m4bc.svc.cluster.local
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:39:34Z"
+        status: "True"
+        type: ConfigurationsReady
+      - lastTransitionTime: "2026-08-18T12:39:34Z"
+        message: Waiting for load balancer to be ready
+        reason: Uninitialized
+        status: Unknown
+        type: Ready
+      - lastTransitionTime: "2026-08-18T12:39:34Z"
+        message: Waiting for load balancer to be ready
+        reason: Uninitialized
+        status: Unknown
+        type: RoutesReady
+      latestCreatedRevisionName: karta-e2e-knative-00001
+      latestReadyRevisionName: karta-e2e-knative-00001
+      observedGeneration: 1
+      traffic:
+      - latestRevision: true
+        percent: 100
+        revisionName: karta-e2e-knative-00001
+      url: http://karta-e2e-knative.test-8m4bc.127.0.0.1.sslip.io
+  resourceVersion: "15474"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: serving.knative.dev/v1
+    kind: Service
+    metadata:
+      annotations:
+        serving.knative.dev/creator: kubernetes-admin
+        serving.knative.dev/lastModifier: kubernetes-admin
+      creationTimestamp: "2026-08-18T12:39:29Z"
+      generation: 1
+      name: karta-e2e-knative
+      namespace: test-8m4bc
+      uid: a5ef0c59-af42-481c-8581-1594424d3f1b
+    spec:
+      template:
+        metadata:
+          creationTimestamp: null
+        spec:
+          containerConcurrency: 0
+          containers:
+          - env:
+            - name: TARGET
+              value: karta-e2e
+            image: ghcr.io/knative/helloworld-go:latest
+            name: user-container
+            ports:
+            - containerPort: 8080
+              protocol: TCP
+            readinessProbe:
+              successThreshold: 1
+              tcpSocket:
+                port: 0
+            resources:
+              requests:
+                cpu: 50m
+                memory: 64Mi
+          enableServiceLinks: false
+          timeoutSeconds: 300
+      traffic:
+      - latestRevision: true
+        percent: 100
+    status:
+      address:
+        url: http://karta-e2e-knative.test-8m4bc.svc.cluster.local
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:39:34Z"
+        status: "True"
+        type: ConfigurationsReady
+      - lastTransitionTime: "2026-08-18T12:39:34Z"
+        status: "True"
+        type: Ready
+      - lastTransitionTime: "2026-08-18T12:39:34Z"
+        status: "True"
+        type: RoutesReady
+      latestCreatedRevisionName: karta-e2e-knative-00001
+      latestReadyRevisionName: karta-e2e-knative-00001
+      observedGeneration: 1
+      traffic:
+      - latestRevision: true
+        percent: 100
+        revisionName: karta-e2e-knative-00001
+      url: http://karta-e2e-knative.test-8m4bc.127.0.0.1.sslip.io
+  resourceVersion: "15478"
+  state: Running
+flow: running
+kartaFile: docs/catalog/serving-knative-dev-service-v1.yaml
+kartaName: serving-knative-dev-service-v1
+operator: knative
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Running


### PR DESCRIPTION
Part of #139 - one workload type per PR, stacked. Adds the knative flow: its spec steps, the predicates it judges stable states with (from the workload's own fields), and its recorded fixtures. Replayed offline by the suite in #260; `make check` green at every layer.