### PR TITLE
test(e2e): add the kserve flow and its recorded fixtures

### DIFF
--- a/test/e2e/flows/kserve_test.go
+++ b/test/e2e/flows/kserve_test.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package flows
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kartav1alpha1 "github.com/run-ai/karta/pkg/api/runai/v1alpha1"
+	"github.com/run-ai/karta/test/e2e/recorder"
+)
+
+var _ = Describe("KServe InferenceService", Ordered, Label("kserve"), func() {
+	var rec *recorder.Recorder
+	var fx recorder.Fixture
+
+	BeforeAll(func(ctx SpecContext) {
+		installKarta(ctx, "../../docs/catalog/serving-kserve-io-inferenceservice-v1beta1.yaml", "serving-kserve-io-inferenceservice-v1beta1")
+		fx = recorder.Fixture{Operator: "kserve", Version: operatorVersion("kserve"), KartaName: "serving-kserve-io-inferenceservice-v1beta1", KartaFile: "docs/catalog/serving-kserve-io-inferenceservice-v1beta1.yaml"}
+		rec = recorder.New(cfg).
+			SetTimeout(6*time.Minute).
+			AddState(kartav1alpha1.InitializingStatus, CondPending("Ready")).
+			AddState(kartav1alpha1.RunningStatus, CondTrue("Ready")).
+			AddState(kartav1alpha1.FailedStatus, CondsFalse("PredictorReady", "PredictorConfigurationReady", "RoutesReady"))
+	})
+
+	It("running", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "running", "testdata/kserve/running.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	// Custom predictor with a nonexistent-registry image: PredictorReady/PredictorConfigurationReady/
+	// RoutesReady all False -> Failed.
+	It("failed", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "failed", "testdata/kserve/failed.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.FailedStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+})

--- a/test/e2e/flows/predicates.go
+++ b/test/e2e/flows/predicates.go
@@ -71,6 +71,21 @@ func CondStatus(condType, status string) recorder.StateCheck {
 	}
 }
 
+// CondPending matches when condType is not yet decided: absent, or present with a status other than True
+// or False (typically Unknown while the workload reconciles). Separates "still deploying" from ready or
+// failed, including the early window before the condition is written at all.
+func CondPending(condType string) recorder.StateCheck {
+	return func(u *unstructured.Unstructured) bool {
+		conds, _, _ := unstructured.NestedSlice(u.Object, "status", "conditions")
+		for _, c := range conds {
+			if m, ok := c.(map[string]any); ok && m["type"] == condType {
+				return m["status"] != "True" && m["status"] != "False"
+			}
+		}
+		return true // absent = pending
+	}
+}
+
 // CondNotTrue matches when no condition of condType is present with status True (absent or non-True). A
 // just-created Deployment is Progressing with no Available condition yet, still initializing.
 func CondNotTrue(condType string) recorder.StateCheck {
@@ -96,6 +111,27 @@ func CondReason(condType, reason string) recorder.StateCheck {
 			}
 		}
 		return false
+	}
+}
+
+// CondsFalse matches when every listed status condition is present and False (the KServe failed mapping:
+// PredictorReady, PredictorConfigurationReady, and RoutesReady all False).
+func CondsFalse(types ...string) recorder.StateCheck {
+	return func(u *unstructured.Unstructured) bool {
+		conds, _, _ := unstructured.NestedSlice(u.Object, "status", "conditions")
+		for _, want := range types {
+			ok := false
+			for _, c := range conds {
+				if m, is := c.(map[string]any); is && m["type"] == want && m["status"] == "False" {
+					ok = true
+					break
+				}
+			}
+			if !ok {
+				return false
+			}
+		}
+		return len(types) > 0
 	}
 }
 

--- a/test/e2e/flows/testdata/kserve/failed.yaml
+++ b/test/e2e/flows/testdata/kserve/failed.yaml
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# An InferenceService with a custom predictor container whose image does not exist, so
+# the Knative Configuration fails to create a Revision (RevisionFailed). That drives
+# PredictorConfigurationReady, PredictorReady, and RoutesReady all to False, which the
+# Karta library reads as Failed. (A bad model storageUri only fails the pod and leaves
+# the conditions Unknown, not False, so it does not match the sample's failed mapping.)
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: karta-e2e-kserve-failed
+  namespace: default
+spec:
+  predictor:
+    containers:
+      - name: kserve-container
+        image: karta-e2e-no-such-registry.invalid/nope:latest
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi

--- a/test/e2e/flows/testdata/kserve/running.yaml
+++ b/test/e2e/flows/testdata/kserve/running.yaml
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A real KServe InferenceService driven by the KServe controller in Serverless
+# mode (on the Knative Serving + Kourier stack installed by hack/e2e/up.sh). The
+# sklearn ServingRuntime serves a small public CPU model; the controller marks
+# the service Ready once the predictor's Knative Service is ready and its routes
+# are admitted. No GPU and no credentials (the model is a public bucket).
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: karta-e2e-kserve
+  namespace: default
+spec:
+  predictor:
+    model:
+      modelFormat:
+        name: sklearn
+      storageUri: gs://kfserving-examples/models/sklearn/1.0/model
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi

--- a/test/e2e/recorded_data/kserve/v1.34.0/serving-kserve-io-inferenceservice-v1beta1/failed.yaml
+++ b/test/e2e/recorded_data/kserve/v1.34.0/serving-kserve-io-inferenceservice-v1beta1/failed.yaml
@@ -1,0 +1,157 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: serving.kserve.io/v1beta1
+    kind: InferenceService
+    metadata:
+      creationTimestamp: "2026-08-18T12:43:59Z"
+      finalizers:
+      - inferenceservice.finalizers
+      generation: 1
+      name: karta-e2e-kserve-failed
+      namespace: test-rb5mt
+      uid: 785989f6-fc31-40fb-b34a-93de2274dea5
+    spec:
+      predictor:
+        containers:
+        - image: karta-e2e-no-such-registry.invalid/nope:latest
+          name: kserve-container
+          resources:
+            limits:
+              cpu: "1"
+              memory: 2Gi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+  resourceVersion: "18859"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: serving.kserve.io/v1beta1
+    kind: InferenceService
+    metadata:
+      creationTimestamp: "2026-08-18T12:43:59Z"
+      finalizers:
+      - inferenceservice.finalizers
+      generation: 1
+      name: karta-e2e-kserve-failed
+      namespace: test-rb5mt
+      uid: 785989f6-fc31-40fb-b34a-93de2274dea5
+    spec:
+      predictor:
+        containers:
+        - image: karta-e2e-no-such-registry.invalid/nope:latest
+          name: kserve-container
+          resources:
+            limits:
+              cpu: "1"
+              memory: 2Gi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+    status:
+      components:
+        predictor: {}
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:43:59Z"
+        reason: PredictorConfigurationReady not ready
+        severity: Info
+        status: Unknown
+        type: LatestDeploymentReady
+      - lastTransitionTime: "2026-08-18T12:43:59Z"
+        reason: PredictorRouteReady not ready
+        severity: Info
+        status: Unknown
+        type: RoutesReady
+      modelStatus:
+        states:
+          activeModelState: ""
+          targetModelState: Pending
+        transitionStatus: InProgress
+  resourceVersion: "18861"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: serving.kserve.io/v1beta1
+    kind: InferenceService
+    metadata:
+      creationTimestamp: "2026-08-18T12:43:59Z"
+      finalizers:
+      - inferenceservice.finalizers
+      generation: 1
+      name: karta-e2e-kserve-failed
+      namespace: test-rb5mt
+      uid: 785989f6-fc31-40fb-b34a-93de2274dea5
+    spec:
+      predictor:
+        containers:
+        - image: karta-e2e-no-such-registry.invalid/nope:latest
+          name: kserve-container
+          resources:
+            limits:
+              cpu: "1"
+              memory: 2Gi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+    status:
+      components:
+        predictor:
+          latestCreatedRevision: karta-e2e-kserve-failed-predictor-00001
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:43:59Z"
+        reason: PredictorConfigurationReady not ready
+        severity: Info
+        status: "False"
+        type: LatestDeploymentReady
+      - lastTransitionTime: "2026-08-18T12:43:59Z"
+        message: 'Revision "karta-e2e-kserve-failed-predictor-00001" failed with message:
+          Unable to fetch image "karta-e2e-no-such-registry.invalid/nope:latest":
+          failed to resolve image to digest: Get "https://karta-e2e-no-such-registry.invalid/v2/":
+          dial tcp: lookup karta-e2e-no-such-registry.invalid on 10.96.0.10:53: no
+          such host.'
+        reason: RevisionFailed
+        severity: Info
+        status: "False"
+        type: PredictorConfigurationReady
+      - lastTransitionTime: "2026-08-18T12:43:59Z"
+        message: Configuration "karta-e2e-kserve-failed-predictor" does not have any
+          ready Revision.
+        reason: RevisionMissing
+        status: "False"
+        type: PredictorReady
+      - lastTransitionTime: "2026-08-18T12:43:59Z"
+        message: Configuration "karta-e2e-kserve-failed-predictor" does not have any
+          ready Revision.
+        reason: RevisionMissing
+        severity: Info
+        status: "False"
+        type: PredictorRouteReady
+      - lastTransitionTime: "2026-08-18T12:43:59Z"
+        message: Configuration "karta-e2e-kserve-failed-predictor" does not have any
+          ready Revision.
+        reason: RevisionMissing
+        status: "False"
+        type: Ready
+      - lastTransitionTime: "2026-08-18T12:43:59Z"
+        reason: PredictorRouteReady not ready
+        severity: Info
+        status: "False"
+        type: RoutesReady
+      modelStatus:
+        states:
+          activeModelState: ""
+          targetModelState: Pending
+        transitionStatus: InProgress
+      observedGeneration: 1
+  resourceVersion: "18884"
+  state: Failed
+flow: failed
+kartaFile: docs/catalog/serving-kserve-io-inferenceservice-v1beta1.yaml
+kartaName: serving-kserve-io-inferenceservice-v1beta1
+operator: kserve
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Failed

--- a/test/e2e/recorded_data/kserve/v1.34.0/serving-kserve-io-inferenceservice-v1beta1/running.yaml
+++ b/test/e2e/recorded_data/kserve/v1.34.0/serving-kserve-io-inferenceservice-v1beta1/running.yaml
@@ -1,0 +1,431 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: serving.kserve.io/v1beta1
+    kind: InferenceService
+    metadata:
+      creationTimestamp: "2026-08-18T12:37:02Z"
+      finalizers:
+      - inferenceservice.finalizers
+      generation: 1
+      name: karta-e2e-kserve
+      namespace: test-8m4bc
+      uid: 65ec226a-90f1-47b0-be93-16a846429735
+    spec:
+      predictor:
+        model:
+          modelFormat:
+            name: sklearn
+          name: ""
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          storageUri: gs://kfserving-examples/models/sklearn/1.0/model
+  resourceVersion: "13749"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: serving.kserve.io/v1beta1
+    kind: InferenceService
+    metadata:
+      creationTimestamp: "2026-08-18T12:37:02Z"
+      finalizers:
+      - inferenceservice.finalizers
+      generation: 1
+      name: karta-e2e-kserve
+      namespace: test-8m4bc
+      uid: 65ec226a-90f1-47b0-be93-16a846429735
+    spec:
+      predictor:
+        model:
+          modelFormat:
+            name: sklearn
+          name: ""
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          storageUri: gs://kfserving-examples/models/sklearn/1.0/model
+    status:
+      components:
+        predictor: {}
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:37:02Z"
+        reason: PredictorConfigurationReady not ready
+        severity: Info
+        status: Unknown
+        type: LatestDeploymentReady
+      - lastTransitionTime: "2026-08-18T12:37:02Z"
+        reason: PredictorRouteReady not ready
+        severity: Info
+        status: Unknown
+        type: RoutesReady
+      modelStatus:
+        states:
+          activeModelState: ""
+          targetModelState: Pending
+        transitionStatus: InProgress
+  resourceVersion: "13756"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: serving.kserve.io/v1beta1
+    kind: InferenceService
+    metadata:
+      creationTimestamp: "2026-08-18T12:37:02Z"
+      finalizers:
+      - inferenceservice.finalizers
+      generation: 1
+      name: karta-e2e-kserve
+      namespace: test-8m4bc
+      uid: 65ec226a-90f1-47b0-be93-16a846429735
+    spec:
+      predictor:
+        model:
+          modelFormat:
+            name: sklearn
+          name: ""
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          storageUri: gs://kfserving-examples/models/sklearn/1.0/model
+    status:
+      components:
+        predictor: {}
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:37:02Z"
+        reason: PredictorConfigurationReady not ready
+        severity: Info
+        status: Unknown
+        type: LatestDeploymentReady
+      - lastTransitionTime: "2026-08-18T12:37:02Z"
+        message: The Configuration is still working to reflect the latest desired
+          specification.
+        reason: OutOfDate
+        severity: Info
+        status: Unknown
+        type: PredictorConfigurationReady
+      - lastTransitionTime: "2026-08-18T12:37:02Z"
+        message: The Route is still working to reflect the latest desired specification.
+        reason: OutOfDate
+        status: Unknown
+        type: PredictorReady
+      - lastTransitionTime: "2026-08-18T12:37:02Z"
+        message: The Route is still working to reflect the latest desired specification.
+        reason: OutOfDate
+        severity: Info
+        status: Unknown
+        type: PredictorRouteReady
+      - lastTransitionTime: "2026-08-18T12:37:02Z"
+        message: The Route is still working to reflect the latest desired specification.
+        reason: OutOfDate
+        status: Unknown
+        type: Ready
+      - lastTransitionTime: "2026-08-18T12:37:02Z"
+        reason: PredictorRouteReady not ready
+        severity: Info
+        status: Unknown
+        type: RoutesReady
+      modelStatus:
+        states:
+          activeModelState: ""
+          targetModelState: Pending
+        transitionStatus: InProgress
+      observedGeneration: 1
+  resourceVersion: "13765"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: serving.kserve.io/v1beta1
+    kind: InferenceService
+    metadata:
+      creationTimestamp: "2026-08-18T12:37:02Z"
+      finalizers:
+      - inferenceservice.finalizers
+      generation: 1
+      name: karta-e2e-kserve
+      namespace: test-8m4bc
+      uid: 65ec226a-90f1-47b0-be93-16a846429735
+    spec:
+      predictor:
+        model:
+          modelFormat:
+            name: sklearn
+          name: ""
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          storageUri: gs://kfserving-examples/models/sklearn/1.0/model
+    status:
+      components:
+        predictor:
+          latestCreatedRevision: karta-e2e-kserve-predictor-00001
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:37:02Z"
+        reason: PredictorConfigurationReady not ready
+        severity: Info
+        status: Unknown
+        type: LatestDeploymentReady
+      - lastTransitionTime: "2026-08-18T12:37:02Z"
+        severity: Info
+        status: Unknown
+        type: PredictorConfigurationReady
+      - lastTransitionTime: "2026-08-18T12:37:02Z"
+        message: Configuration "karta-e2e-kserve-predictor" is waiting for a Revision
+          to become ready.
+        reason: RevisionMissing
+        status: Unknown
+        type: PredictorReady
+      - lastTransitionTime: "2026-08-18T12:37:02Z"
+        message: Configuration "karta-e2e-kserve-predictor" is waiting for a Revision
+          to become ready.
+        reason: RevisionMissing
+        severity: Info
+        status: Unknown
+        type: PredictorRouteReady
+      - lastTransitionTime: "2026-08-18T12:37:02Z"
+        message: Configuration "karta-e2e-kserve-predictor" is waiting for a Revision
+          to become ready.
+        reason: RevisionMissing
+        status: Unknown
+        type: Ready
+      - lastTransitionTime: "2026-08-18T12:37:02Z"
+        reason: PredictorRouteReady not ready
+        severity: Info
+        status: Unknown
+        type: RoutesReady
+      modelStatus:
+        states:
+          activeModelState: ""
+          targetModelState: Pending
+        transitionStatus: InProgress
+      observedGeneration: 1
+  resourceVersion: "13768"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: serving.kserve.io/v1beta1
+    kind: InferenceService
+    metadata:
+      creationTimestamp: "2026-08-18T12:37:02Z"
+      finalizers:
+      - inferenceservice.finalizers
+      generation: 1
+      name: karta-e2e-kserve
+      namespace: test-8m4bc
+      uid: 65ec226a-90f1-47b0-be93-16a846429735
+    spec:
+      predictor:
+        model:
+          modelFormat:
+            name: sklearn
+          name: ""
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          storageUri: gs://kfserving-examples/models/sklearn/1.0/model
+    status:
+      components:
+        predictor:
+          latestCreatedRevision: karta-e2e-kserve-predictor-00001
+          latestReadyRevision: karta-e2e-kserve-predictor-00001
+          latestRolledoutRevision: karta-e2e-kserve-predictor-00001
+          traffic:
+          - latestRevision: true
+            percent: 100
+            revisionName: karta-e2e-kserve-predictor-00001
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:37:27Z"
+        severity: Info
+        status: "True"
+        type: LatestDeploymentReady
+      - lastTransitionTime: "2026-08-18T12:37:27Z"
+        severity: Info
+        status: "True"
+        type: PredictorConfigurationReady
+      - lastTransitionTime: "2026-08-18T12:37:27Z"
+        message: Ingress has not yet been reconciled.
+        reason: IngressNotConfigured
+        status: Unknown
+        type: PredictorReady
+      - lastTransitionTime: "2026-08-18T12:37:27Z"
+        message: Ingress has not yet been reconciled.
+        reason: IngressNotConfigured
+        severity: Info
+        status: Unknown
+        type: PredictorRouteReady
+      - lastTransitionTime: "2026-08-18T12:37:27Z"
+        message: Ingress has not yet been reconciled.
+        reason: IngressNotConfigured
+        status: Unknown
+        type: Ready
+      - lastTransitionTime: "2026-08-18T12:37:02Z"
+        reason: PredictorRouteReady not ready
+        severity: Info
+        status: Unknown
+        type: RoutesReady
+      modelStatus:
+        states:
+          activeModelState: ""
+          targetModelState: Pending
+        transitionStatus: InProgress
+      observedGeneration: 1
+  resourceVersion: "14039"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: serving.kserve.io/v1beta1
+    kind: InferenceService
+    metadata:
+      creationTimestamp: "2026-08-18T12:37:02Z"
+      finalizers:
+      - inferenceservice.finalizers
+      generation: 1
+      name: karta-e2e-kserve
+      namespace: test-8m4bc
+      uid: 65ec226a-90f1-47b0-be93-16a846429735
+    spec:
+      predictor:
+        model:
+          modelFormat:
+            name: sklearn
+          name: ""
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          storageUri: gs://kfserving-examples/models/sklearn/1.0/model
+    status:
+      components:
+        predictor:
+          latestCreatedRevision: karta-e2e-kserve-predictor-00001
+          latestReadyRevision: karta-e2e-kserve-predictor-00001
+          latestRolledoutRevision: karta-e2e-kserve-predictor-00001
+          traffic:
+          - latestRevision: true
+            percent: 100
+            revisionName: karta-e2e-kserve-predictor-00001
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:37:27Z"
+        severity: Info
+        status: "True"
+        type: LatestDeploymentReady
+      - lastTransitionTime: "2026-08-18T12:37:27Z"
+        severity: Info
+        status: "True"
+        type: PredictorConfigurationReady
+      - lastTransitionTime: "2026-08-18T12:37:27Z"
+        message: Waiting for load balancer to be ready
+        reason: Uninitialized
+        status: Unknown
+        type: PredictorReady
+      - lastTransitionTime: "2026-08-18T12:37:27Z"
+        message: Waiting for load balancer to be ready
+        reason: Uninitialized
+        severity: Info
+        status: Unknown
+        type: PredictorRouteReady
+      - lastTransitionTime: "2026-08-18T12:37:27Z"
+        message: Waiting for load balancer to be ready
+        reason: Uninitialized
+        status: Unknown
+        type: Ready
+      - lastTransitionTime: "2026-08-18T12:37:02Z"
+        reason: PredictorRouteReady not ready
+        severity: Info
+        status: Unknown
+        type: RoutesReady
+      modelStatus:
+        states:
+          activeModelState: ""
+          targetModelState: Pending
+        transitionStatus: InProgress
+      observedGeneration: 1
+  resourceVersion: "14043"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: serving.kserve.io/v1beta1
+    kind: InferenceService
+    metadata:
+      creationTimestamp: "2026-08-18T12:37:02Z"
+      finalizers:
+      - inferenceservice.finalizers
+      generation: 1
+      name: karta-e2e-kserve
+      namespace: test-8m4bc
+      uid: 65ec226a-90f1-47b0-be93-16a846429735
+    spec:
+      predictor:
+        model:
+          modelFormat:
+            name: sklearn
+          name: ""
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          storageUri: gs://kfserving-examples/models/sklearn/1.0/model
+    status:
+      address:
+        url: http://karta-e2e-kserve-predictor.test-8m4bc.svc.cluster.local
+      components:
+        predictor:
+          address:
+            url: http://karta-e2e-kserve-predictor.test-8m4bc.svc.cluster.local
+          latestCreatedRevision: karta-e2e-kserve-predictor-00001
+          latestReadyRevision: karta-e2e-kserve-predictor-00001
+          latestRolledoutRevision: karta-e2e-kserve-predictor-00001
+          traffic:
+          - latestRevision: true
+            percent: 100
+            revisionName: karta-e2e-kserve-predictor-00001
+          url: http://karta-e2e-kserve-predictor.test-8m4bc.127.0.0.1.sslip.io
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:37:27Z"
+        status: "True"
+        type: IngressReady
+      - lastTransitionTime: "2026-08-18T12:37:27Z"
+        severity: Info
+        status: "True"
+        type: LatestDeploymentReady
+      - lastTransitionTime: "2026-08-18T12:37:27Z"
+        severity: Info
+        status: "True"
+        type: PredictorConfigurationReady
+      - lastTransitionTime: "2026-08-18T12:37:27Z"
+        status: "True"
+        type: PredictorReady
+      - lastTransitionTime: "2026-08-18T12:37:27Z"
+        severity: Info
+        status: "True"
+        type: PredictorRouteReady
+      - lastTransitionTime: "2026-08-18T12:37:27Z"
+        status: "True"
+        type: Ready
+      - lastTransitionTime: "2026-08-18T12:37:27Z"
+        severity: Info
+        status: "True"
+        type: RoutesReady
+      modelStatus:
+        states:
+          activeModelState: ""
+          targetModelState: Pending
+        transitionStatus: InProgress
+      observedGeneration: 1
+      url: http://karta-e2e-kserve-predictor.test-8m4bc.127.0.0.1.sslip.io
+  resourceVersion: "14048"
+  state: Running
+flow: running
+kartaFile: docs/catalog/serving-kserve-io-inferenceservice-v1beta1.yaml
+kartaName: serving-kserve-io-inferenceservice-v1beta1
+operator: kserve
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Running


### PR DESCRIPTION
Part of #139 - one workload type per PR, stacked. Adds the kserve flow: its spec steps, the predicates it judges stable states with (from the workload's own fields), and its recorded fixtures. Replayed offline by the suite in #260; `make check` green at every layer.