### PR TITLE
test(e2e): add the nim flow and its recorded fixtures

### DIFF
--- a/test/e2e/flows/nim_test.go
+++ b/test/e2e/flows/nim_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package flows
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kartav1alpha1 "github.com/run-ai/karta/pkg/api/runai/v1alpha1"
+	"github.com/run-ai/karta/test/e2e/recorder"
+)
+
+var _ = Describe("NIMService", Ordered, Label("nim"), func() {
+	var rec *recorder.Recorder
+	var fx recorder.Fixture
+
+	BeforeAll(func(ctx SpecContext) {
+		installKarta(ctx, "../../docs/catalog/apps-nvidia-com-nimservice-v1alpha1.yaml", "apps-nvidia-com-nimservice-v1alpha1")
+		// The NIMService references authSecret ngc-secret; the operator reads it from the workload's own
+		// namespace, so seed it here (up.sh only creates it in default).
+		ensureSecret(ctx, "ngc-secret", map[string]string{"NGC_API_KEY": "dummy-not-a-real-token"})
+		fx = recorder.Fixture{Operator: "nim", Version: operatorVersion("nim"), KartaName: "apps-nvidia-com-nimservice-v1alpha1", KartaFile: "docs/catalog/apps-nvidia-com-nimservice-v1alpha1.yaml"}
+		rec = recorder.New(cfg).
+			SetTimeout(5*time.Minute).
+			AddState(kartav1alpha1.InitializingStatus, PhaseNot([]string{"Ready", "Failed"}, "status", "state")).
+			AddState(kartav1alpha1.RunningStatus, PhaseEq("Ready", "status", "state"))
+	})
+
+	It("running", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "running", "testdata/nim/running.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("initializing", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "initializing", "testdata/nim/initializing.yaml").Through(recorder.Reaches(kartav1alpha1.InitializingStatus)).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+})

--- a/test/e2e/flows/predicates.go
+++ b/test/e2e/flows/predicates.go
@@ -156,6 +156,21 @@ func PhaseAny(wants []string, path ...string) recorder.StateCheck {
 	}
 }
 
+// PhaseNot matches when the string at the path (empty if absent) is none of unwanted. Useful for a
+// catch-all Initializing that tolerates every intermediate operator phase, keying only off the terminal
+// ones (for example any NIMService state that is not Ready or Failed).
+func PhaseNot(unwanted []string, path ...string) recorder.StateCheck {
+	return func(u *unstructured.Unstructured) bool {
+		got, _, _ := unstructured.NestedString(u.Object, path...)
+		for _, w := range unwanted {
+			if got == w {
+				return false
+			}
+		}
+		return true
+	}
+}
+
 func IntAtLeast(n int64, path ...string) recorder.StateCheck {
 	return func(u *unstructured.Unstructured) bool {
 		got, found, err := unstructured.NestedInt64(u.Object, path...)

--- a/test/e2e/flows/setup_test.go
+++ b/test/e2e/flows/setup_test.go
@@ -10,9 +10,12 @@ import (
 	"strings"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/yaml"
 
@@ -61,4 +64,17 @@ func operatorVersion(op string) string {
 		}
 	}
 	return serverVersion
+}
+
+// ensureSecret creates an opaque Secret in the flow's namespace for a workload that references it. The
+// k8s-nim-operator reads a NIMService's authSecret from the NIMService's own namespace, but up.sh only
+// creates the dummy ngc-secret in default, so a flow recording in a throwaway namespace must seed its own.
+// Deleted after the spec tree that created it.
+func ensureSecret(ctx context.Context, name string, data map[string]string) {
+	sec := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
+		StringData: data,
+	}
+	Expect(k8sClient.Create(ctx, sec)).To(Succeed(), "create secret %s", name)
+	DeferCleanup(func(ctx SpecContext) { _ = k8sClient.Delete(ctx, sec) })
 }

--- a/test/e2e/flows/testdata/nim/initializing.yaml
+++ b/test/e2e/flows/testdata/nim/initializing.yaml
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A NIMService pointing at a nonexistent image, so the operator's Deployment pods stay in
+# ImagePullBackOff and the service never becomes ready. The k8s-nim-operator holds
+# status.state=NotReady, which the definition reads as Initializing - a service still coming
+# up (here, permanently). Karta must read it as Initializing, not Ready.
+apiVersion: apps.nvidia.com/v1alpha1
+kind: NIMService
+metadata:
+  name: karta-e2e-nim-initializing
+  namespace: default
+spec:
+  image:
+    repository: nonexistent-nim
+    tag: bad
+    pullPolicy: IfNotPresent
+  authSecret: ngc-secret
+  storage:
+    pvc:
+      create: true
+      size: 1Gi
+      volumeAccessMode: ReadWriteOnce
+  replicas: 1
+  expose:
+    service:
+      type: ClusterIP
+      port: 8000
+  env:
+    - name: NIM_REQUEST_LATENCY
+      value: "2"

--- a/test/e2e/flows/testdata/nim/running.yaml
+++ b/test/e2e/flows/testdata/nim/running.yaml
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A real, operator-driven NIMService using a fictive CPU NIM image (no GPU, no
+# real NGC token). The k8s-nim-operator creates a Deployment from this image;
+# the fake server answers /v1/health/ready so the operator marks it state=Ready.
+# Prereqs installed by hack/e2e/up.sh: the nim-cpu:e2e image, the k8s-nim-operator,
+# and a dummy "ngc-secret" Secret holding key NGC_API_KEY.
+apiVersion: apps.nvidia.com/v1alpha1
+kind: NIMService
+metadata:
+  name: karta-e2e-nim
+  namespace: default
+spec:
+  image:
+    repository: nim-cpu
+    tag: e2e
+    pullPolicy: IfNotPresent
+  authSecret: ngc-secret
+  storage:
+    pvc:
+      create: true
+      size: 1Gi
+      volumeAccessMode: ReadWriteOnce
+  replicas: 1
+  expose:
+    service:
+      type: ClusterIP
+      port: 8000
+  env:
+    - name: NIM_REQUEST_LATENCY
+      value: "2"

--- a/test/e2e/recorded_data/nim/v1.34.0/apps-nvidia-com-nimservice-v1alpha1/initializing.yaml
+++ b/test/e2e/recorded_data/nim/v1.34.0/apps-nvidia-com-nimservice-v1alpha1/initializing.yaml
@@ -1,0 +1,42 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: apps.nvidia.com/v1alpha1
+    kind: NIMService
+    metadata:
+      creationTimestamp: "2026-08-18T12:39:12Z"
+      generation: 1
+      name: karta-e2e-nim-initializing
+      namespace: test-8m4bc
+      uid: 29f41728-6685-4b9c-a511-8f7e083b4ae9
+    spec:
+      authSecret: ngc-secret
+      env:
+      - name: NIM_REQUEST_LATENCY
+        value: "2"
+      expose:
+        service:
+          port: 8000
+          type: ClusterIP
+      image:
+        pullPolicy: IfNotPresent
+        repository: nonexistent-nim
+        tag: bad
+      inferencePlatform: standalone
+      replicas: 1
+      storage:
+        pvc:
+          create: true
+          size: 1Gi
+          volumeAccessMode: ReadWriteOnce
+  resourceVersion: "15079"
+  state: Initializing
+flow: initializing
+kartaFile: docs/catalog/apps-nvidia-com-nimservice-v1alpha1.yaml
+kartaName: apps-nvidia-com-nimservice-v1alpha1
+operator: nim
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Initializing

--- a/test/e2e/recorded_data/nim/v1.34.0/apps-nvidia-com-nimservice-v1alpha1/running.yaml
+++ b/test/e2e/recorded_data/nim/v1.34.0/apps-nvidia-com-nimservice-v1alpha1/running.yaml
@@ -1,0 +1,296 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: apps.nvidia.com/v1alpha1
+    kind: NIMService
+    metadata:
+      creationTimestamp: "2026-08-18T12:38:23Z"
+      finalizers:
+      - finalizer.nimservice.apps.nvidia.com
+      generation: 2
+      name: karta-e2e-nim
+      namespace: test-8m4bc
+      uid: b0ac246a-0539-4707-af84-26c2617802ad
+    spec:
+      authSecret: ngc-secret
+      env:
+      - name: NIM_REQUEST_LATENCY
+        value: "2"
+      expose:
+        ingress:
+          spec: {}
+        service:
+          port: 8000
+          type: ClusterIP
+      image:
+        pullPolicy: IfNotPresent
+        repository: nim-cpu
+        tag: e2e
+      inferencePlatform: standalone
+      livenessProbe: {}
+      metrics:
+        serviceMonitor: {}
+      readinessProbe: {}
+      replicas: 1
+      scale:
+        hpa:
+          maxReplicas: 0
+          minReplicas: 1
+      startupProbe: {}
+      storage:
+        nimCache: {}
+        pvc:
+          create: true
+          size: 1Gi
+          volumeAccessMode: ReadWriteOnce
+  resourceVersion: "14624"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: apps.nvidia.com/v1alpha1
+    kind: NIMService
+    metadata:
+      creationTimestamp: "2026-08-18T12:38:23Z"
+      finalizers:
+      - finalizer.nimservice.apps.nvidia.com
+      generation: 2
+      name: karta-e2e-nim
+      namespace: test-8m4bc
+      uid: b0ac246a-0539-4707-af84-26c2617802ad
+    spec:
+      authSecret: ngc-secret
+      env:
+      - name: NIM_REQUEST_LATENCY
+        value: "2"
+      expose:
+        ingress:
+          spec: {}
+        service:
+          port: 8000
+          type: ClusterIP
+      image:
+        pullPolicy: IfNotPresent
+        repository: nim-cpu
+        tag: e2e
+      inferencePlatform: standalone
+      livenessProbe: {}
+      metrics:
+        serviceMonitor: {}
+      readinessProbe: {}
+      replicas: 1
+      scale:
+        hpa:
+          maxReplicas: 0
+          minReplicas: 1
+      startupProbe: {}
+      storage:
+        nimCache: {}
+        pvc:
+          create: true
+          size: 1Gi
+          volumeAccessMode: ReadWriteOnce
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:38:23Z"
+        message: The PVC has been created for storing NIM
+        reason: PVCCreated
+        status: "True"
+        type: NIM_CACHE_PVC_CREATED
+      state: PVC-Created
+  resourceVersion: "14634"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: apps.nvidia.com/v1alpha1
+    kind: NIMService
+    metadata:
+      creationTimestamp: "2026-08-18T12:38:23Z"
+      finalizers:
+      - finalizer.nimservice.apps.nvidia.com
+      generation: 2
+      name: karta-e2e-nim
+      namespace: test-8m4bc
+      uid: b0ac246a-0539-4707-af84-26c2617802ad
+    spec:
+      authSecret: ngc-secret
+      env:
+      - name: NIM_REQUEST_LATENCY
+        value: "2"
+      expose:
+        ingress:
+          spec: {}
+        service:
+          port: 8000
+          type: ClusterIP
+      image:
+        pullPolicy: IfNotPresent
+        repository: nim-cpu
+        tag: e2e
+      inferencePlatform: standalone
+      livenessProbe: {}
+      metrics:
+        serviceMonitor: {}
+      readinessProbe: {}
+      replicas: 1
+      scale:
+        hpa:
+          maxReplicas: 0
+          minReplicas: 1
+      startupProbe: {}
+      storage:
+        nimCache: {}
+        pvc:
+          create: true
+          size: 1Gi
+          volumeAccessMode: ReadWriteOnce
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:38:23Z"
+        message: |
+          Waiting for deployment "karta-e2e-nim" rollout to finish: 0 out of 1 new replicas have been updated...
+        reason: NotReady
+        status: "False"
+        type: Ready
+      - lastTransitionTime: "2026-08-18T12:38:23Z"
+        message: |
+          Waiting for deployment "karta-e2e-nim" rollout to finish: 0 out of 1 new replicas have been updated...
+        reason: Ready
+        status: "False"
+        type: Failed
+      state: NotReady
+  resourceVersion: "14637"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: apps.nvidia.com/v1alpha1
+    kind: NIMService
+    metadata:
+      creationTimestamp: "2026-08-18T12:38:23Z"
+      finalizers:
+      - finalizer.nimservice.apps.nvidia.com
+      generation: 2
+      name: karta-e2e-nim
+      namespace: test-8m4bc
+      uid: b0ac246a-0539-4707-af84-26c2617802ad
+    spec:
+      authSecret: ngc-secret
+      env:
+      - name: NIM_REQUEST_LATENCY
+        value: "2"
+      expose:
+        ingress:
+          spec: {}
+        service:
+          port: 8000
+          type: ClusterIP
+      image:
+        pullPolicy: IfNotPresent
+        repository: nim-cpu
+        tag: e2e
+      inferencePlatform: standalone
+      livenessProbe: {}
+      metrics:
+        serviceMonitor: {}
+      readinessProbe: {}
+      replicas: 1
+      scale:
+        hpa:
+          maxReplicas: 0
+          minReplicas: 1
+      startupProbe: {}
+      storage:
+        nimCache: {}
+        pvc:
+          create: true
+          size: 1Gi
+          volumeAccessMode: ReadWriteOnce
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:38:23Z"
+        message: |
+          Waiting for deployment "karta-e2e-nim" rollout to finish: 0 of 1 updated replicas are available...
+        reason: NotReady
+        status: "False"
+        type: Ready
+      - lastTransitionTime: "2026-08-18T12:38:23Z"
+        message: |
+          Waiting for deployment "karta-e2e-nim" rollout to finish: 0 of 1 updated replicas are available...
+        reason: Ready
+        status: "False"
+        type: Failed
+      state: NotReady
+  resourceVersion: "14655"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: apps.nvidia.com/v1alpha1
+    kind: NIMService
+    metadata:
+      creationTimestamp: "2026-08-18T12:38:23Z"
+      finalizers:
+      - finalizer.nimservice.apps.nvidia.com
+      generation: 2
+      name: karta-e2e-nim
+      namespace: test-8m4bc
+      uid: b0ac246a-0539-4707-af84-26c2617802ad
+    spec:
+      authSecret: ngc-secret
+      env:
+      - name: NIM_REQUEST_LATENCY
+        value: "2"
+      expose:
+        ingress:
+          spec: {}
+        service:
+          port: 8000
+          type: ClusterIP
+      image:
+        pullPolicy: IfNotPresent
+        repository: nim-cpu
+        tag: e2e
+      inferencePlatform: standalone
+      livenessProbe: {}
+      metrics:
+        serviceMonitor: {}
+      readinessProbe: {}
+      replicas: 1
+      scale:
+        hpa:
+          maxReplicas: 0
+          minReplicas: 1
+      startupProbe: {}
+      storage:
+        nimCache: {}
+        pvc:
+          create: true
+          size: 1Gi
+          volumeAccessMode: ReadWriteOnce
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:39:12Z"
+        message: |
+          deployment "karta-e2e-nim" successfully rolled out
+        reason: Ready
+        status: "True"
+        type: Ready
+      - lastTransitionTime: "2026-08-18T12:38:23Z"
+        message: ""
+        reason: Ready
+        status: "False"
+        type: Failed
+      model:
+        clusterEndpoint: 10.96.95.35:8000
+        externalEndpoint: ""
+        name: meta/llama-3.2-1b-instruct
+      state: Ready
+  resourceVersion: "15066"
+  state: Running
+flow: running
+kartaFile: docs/catalog/apps-nvidia-com-nimservice-v1alpha1.yaml
+kartaName: apps-nvidia-com-nimservice-v1alpha1
+operator: nim
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Running


### PR DESCRIPTION
Part of #139 - one workload type per PR, stacked. Adds the nim (plus the ensureSecret setup helper it needs) flow: its spec steps, the predicates it judges stable states with (from the workload's own fields), and its recorded fixtures. Replayed offline by the suite in #260; `make check` green at every layer.