### PR TITLE
test(e2e): add the dynamo flow and its recorded fixtures

### DIFF
--- a/test/e2e/flows/dynamo_test.go
+++ b/test/e2e/flows/dynamo_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package flows
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kartav1alpha1 "github.com/run-ai/karta/pkg/api/runai/v1alpha1"
+	"github.com/run-ai/karta/test/e2e/recorder"
+)
+
+var _ = Describe("DynamoGraphDeployment", Ordered, Label("dynamo"), func() {
+	var rec *recorder.Recorder
+	var fx recorder.Fixture
+
+	BeforeAll(func(ctx SpecContext) {
+		installKarta(ctx, "../../docs/catalog/nvidia-com-dynamographdeployment-v1alpha1.yaml", "nvidia-com-dynamographdeployment-v1alpha1")
+		// The decode worker pulls env from hf-token-secret; the operator reads it from the workload's own
+		// namespace, so seed it here (up.sh only creates it in default).
+		ensureSecret(ctx, "hf-token-secret", map[string]string{"HF_TOKEN": "dummy"})
+		fx = recorder.Fixture{Operator: "dynamo", Version: operatorVersion("dynamo"), KartaName: "nvidia-com-dynamographdeployment-v1alpha1", KartaFile: "docs/catalog/nvidia-com-dynamographdeployment-v1alpha1.yaml"}
+		rec = recorder.New(cfg).
+			SetTimeout(8*time.Minute).
+			AddState(kartav1alpha1.InitializingStatus, PhaseAny([]string{"initializing", "pending", ""}, "status", "state")).
+			AddState(kartav1alpha1.RunningStatus, PhaseEq("successful", "status", "state"))
+	})
+
+	It("running", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "running", "testdata/dynamo/running.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("initializing", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "initializing", "testdata/dynamo/initializing.yaml").Through(recorder.Reaches(kartav1alpha1.InitializingStatus)).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+})

--- a/test/e2e/flows/grove_test.go
+++ b/test/e2e/flows/grove_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package flows
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kartav1alpha1 "github.com/run-ai/karta/pkg/api/runai/v1alpha1"
+	"github.com/run-ai/karta/test/e2e/recorder"
+)
+
+var _ = Describe("Grove PodCliqueSet", Ordered, Label("grove"), func() {
+	var rec *recorder.Recorder
+	var fx recorder.Fixture
+
+	BeforeAll(func(ctx SpecContext) {
+		installKarta(ctx, "../../docs/catalog/grove-io-podcliqueset-v1alpha1.yaml", "grove-io-podcliqueset-v1alpha1")
+		fx = recorder.Fixture{Operator: "grove", Version: operatorVersion("grove"), KartaName: "grove-io-podcliqueset-v1alpha1", KartaFile: "docs/catalog/grove-io-podcliqueset-v1alpha1.yaml"}
+		rec = recorder.New(cfg).
+			SetTimeout(4*time.Minute).
+			AddState(kartav1alpha1.InitializingStatus, ReplicasComingUp()).
+			AddState(kartav1alpha1.RunningStatus, AllReplicasAvailable())
+	})
+
+	It("running", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "running", "testdata/grove/running.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("initializing", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "initializing", "testdata/grove/initializing.yaml").Through(recorder.Reaches(kartav1alpha1.InitializingStatus)).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("scaled", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "scaled", "testdata/grove/scaled.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.RunningStatus).With(IntEq(1, "status", "availableReplicas")).Do(ScaleReplicas(2)),
+			recorder.Reaches(kartav1alpha1.InitializingStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.RunningStatus).With(IntEq(2, "status", "availableReplicas")).Do(ScaleReplicas(1)),
+			recorder.Reaches(kartav1alpha1.InitializingStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.RunningStatus).With(IntEq(1, "status", "availableReplicas")),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+})

--- a/test/e2e/flows/predicates.go
+++ b/test/e2e/flows/predicates.go
@@ -258,6 +258,26 @@ func ReplicasInitializing() recorder.StateCheck {
 	}
 }
 
+// AllReplicasAvailable matches when every desired replica is available (status.availableReplicas >=
+// spec.replicas), Karta's Running for a Grove PodCliqueSet. Includes the vacuous spec.replicas == 0 case.
+func AllReplicasAvailable() recorder.StateCheck {
+	return func(u *unstructured.Unstructured) bool {
+		desired, _, _ := unstructured.NestedInt64(u.Object, "spec", "replicas")
+		avail, _, _ := unstructured.NestedInt64(u.Object, "status", "availableReplicas")
+		return avail >= desired
+	}
+}
+
+// ReplicasComingUp is the initializing counterpart of AllReplicasAvailable: spec.replicas > 0 and not every
+// desired replica is available yet (status.availableReplicas < spec.replicas).
+func ReplicasComingUp() recorder.StateCheck {
+	return func(u *unstructured.Unstructured) bool {
+		desired, _, _ := unstructured.NestedInt64(u.Object, "spec", "replicas")
+		avail, _, _ := unstructured.NestedInt64(u.Object, "status", "availableReplicas")
+		return desired > 0 && avail < desired
+	}
+}
+
 // CronjobFired matches a CronJob that has scheduled at least once (status.lastScheduleTime set). Karta reads
 // a fired, enabled CronJob as Running (suspended wins via the registry order).
 func CronjobFired() recorder.StateCheck {

--- a/test/e2e/flows/testdata/dynamo/initializing.yaml
+++ b/test/e2e/flows/testdata/dynamo/initializing.yaml
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A DynamoGraphDeployment whose containers reference a nonexistent image tag, so the pods
+# stay in ImagePullBackOff and never register. The dynamo-operator holds status.state=pending,
+# which the definition reads as Initializing - a graph still coming up (here, permanently).
+# Same Frontend + decode shape as running.yaml so the extraction matches; Karta must read it as
+# Initializing, not Running.
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: karta-e2e-dynamo-initializing
+  namespace: default
+spec:
+  services:
+    Frontend:
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: busybox:99.99.99
+          imagePullPolicy: IfNotPresent
+    decode:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      subComponentType: decode
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: busybox:99.99.99
+          imagePullPolicy: IfNotPresent
+          workingDir: /workspace
+          command: ["python3", "-m", "dynamo.mocker"]
+          args:
+            - --model-path
+            - nvidia/Llama-3.1-8B-Instruct-FP8
+            - --model-name
+            - nvidia/Llama-3.1-8B-Instruct-FP8

--- a/test/e2e/flows/testdata/dynamo/running.yaml
+++ b/test/e2e/flows/testdata/dynamo/running.yaml
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A real DynamoGraphDeployment driven by the dynamo-operator using Dynamo's
+# mocker backend (simulated inference, no GPU and no real model) so it runs
+# CPU-only on kind. A Frontend plus a decode worker running
+# `python3 -m dynamo.mocker`; the operator reports .status.state=successful once
+# both pods are ready and registered (via etcd + NATS). The dynamo-planner image
+# (which ships the mocker) and a dummy hf-token-secret are installed by
+# hack/e2e/up.sh.
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: karta-e2e-dynamo
+  namespace: default
+spec:
+  services:
+    Frontend:
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
+          imagePullPolicy: IfNotPresent
+    decode:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      subComponentType: decode
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
+          imagePullPolicy: IfNotPresent
+          workingDir: /workspace
+          command: ["python3", "-m", "dynamo.mocker"]
+          args:
+            - --model-path
+            - nvidia/Llama-3.1-8B-Instruct-FP8
+            - --model-name
+            - nvidia/Llama-3.1-8B-Instruct-FP8
+            - --speedup-ratio
+            - "1.0"
+            - --planner-profile-data
+            - /workspace/components/src/dynamo/planner/tests/data/profiling_results/H200_TP1P_TP1D

--- a/test/e2e/flows/testdata/grove/initializing.yaml
+++ b/test/e2e/flows/testdata/grove/initializing.yaml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A Grove PodCliqueSet whose clique references a nonexistent image tag, so its pods stay in
+# ImagePullBackOff and never become available. The operator keeps status.availableReplicas
+# below spec.replicas, which the definition reads as Initializing - a workload still coming
+# up (here, permanently). Karta must read it as Initializing, not Running.
+apiVersion: grove.io/v1alpha1
+kind: PodCliqueSet
+metadata:
+  name: karta-e2e-grove-initializing
+  namespace: default
+spec:
+  replicas: 1
+  template:
+    cliques:
+      - name: worker
+        spec:
+          roleName: worker
+          replicas: 2
+          podSpec:
+            containers:
+              - name: worker
+                image: busybox:99.99.99
+                command: ["/bin/sh", "-c", "echo karta-e2e-grove && sleep infinity"]
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi

--- a/test/e2e/flows/testdata/grove/running.yaml
+++ b/test/e2e/flows/testdata/grove/running.yaml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A real Grove PodCliqueSet driven by the Grove operator (installed by
+# hack/e2e/up.sh alongside kai-scheduler). The operator creates the clique's
+# pods and reports availableReplicas once they are running; the test waits for
+# that. Kept tiny (busybox sleeping) so it runs CPU-only on local kind.
+apiVersion: grove.io/v1alpha1
+kind: PodCliqueSet
+metadata:
+  name: karta-e2e-grove
+  namespace: default
+spec:
+  replicas: 1
+  template:
+    cliques:
+      - name: worker
+        spec:
+          roleName: worker
+          replicas: 2
+          podSpec:
+            containers:
+              - name: worker
+                image: busybox:1.36
+                command: ["/bin/sh", "-c", "echo karta-e2e-grove && sleep infinity"]
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi

--- a/test/e2e/flows/testdata/grove/scaled.yaml
+++ b/test/e2e/flows/testdata/grove/scaled.yaml
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A Grove PodCliqueSet the scaled flow drives 1 -> 2 -> 1 replicas (spec.replicas). Each replica is a
+# full worker clique; status.availableReplicas tracks how many are up. The definition reads Running
+# once availableReplicas >= spec.replicas. Karta reads Running at each settled count, extraction differs.
+apiVersion: grove.io/v1alpha1
+kind: PodCliqueSet
+metadata:
+  name: karta-e2e-grove-scaled
+  namespace: default
+spec:
+  replicas: 1
+  template:
+    cliques:
+      - name: worker
+        spec:
+          roleName: worker
+          replicas: 2
+          podSpec:
+            containers:
+              - name: worker
+                image: busybox:1.36
+                command: ["/bin/sh", "-c", "echo karta-e2e-grove && sleep infinity"]
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi

--- a/test/e2e/recorded_data/dynamo/v1.34.0/nvidia-com-dynamographdeployment-v1alpha1/initializing.yaml
+++ b/test/e2e/recorded_data/dynamo/v1.34.0/nvidia-com-dynamographdeployment-v1alpha1/initializing.yaml
@@ -1,0 +1,56 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: nvidia.com/v1alpha1
+    kind: DynamoGraphDeployment
+    metadata:
+      annotations:
+        nvidia.com/dynamo-operator-origin-version: 1.2.1
+      creationTimestamp: "2026-08-18T12:30:45Z"
+      generation: 1
+      name: karta-e2e-dynamo-initializing
+      namespace: test-8m4bc
+      uid: c0865f0b-eb17-49df-b5f6-c481c47843b5
+    spec:
+      services:
+        Frontend:
+          componentType: frontend
+          extraPodSpec:
+            mainContainer:
+              image: busybox:99.99.99
+              imagePullPolicy: IfNotPresent
+              name: ""
+              resources: {}
+          replicas: 1
+        decode:
+          componentType: worker
+          envFromSecret: hf-token-secret
+          extraPodSpec:
+            mainContainer:
+              args:
+              - --model-path
+              - nvidia/Llama-3.1-8B-Instruct-FP8
+              - --model-name
+              - nvidia/Llama-3.1-8B-Instruct-FP8
+              command:
+              - python3
+              - -m
+              - dynamo.mocker
+              image: busybox:99.99.99
+              imagePullPolicy: IfNotPresent
+              name: ""
+              resources: {}
+              workingDir: /workspace
+          replicas: 1
+          subComponentType: decode
+  resourceVersion: "9667"
+  state: Initializing
+flow: initializing
+kartaFile: docs/catalog/nvidia-com-dynamographdeployment-v1alpha1.yaml
+kartaName: nvidia-com-dynamographdeployment-v1alpha1
+operator: dynamo
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Initializing

--- a/test/e2e/recorded_data/dynamo/v1.34.0/nvidia-com-dynamographdeployment-v1alpha1/running.yaml
+++ b/test/e2e/recorded_data/dynamo/v1.34.0/nvidia-com-dynamographdeployment-v1alpha1/running.yaml
@@ -1,0 +1,584 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: nvidia.com/v1alpha1
+    kind: DynamoGraphDeployment
+    metadata:
+      annotations:
+        nvidia.com/dynamo-operator-origin-version: 1.2.1
+      creationTimestamp: "2026-08-18T12:30:25Z"
+      finalizers:
+      - nvidia.com/finalizer
+      generation: 1
+      name: karta-e2e-dynamo
+      namespace: test-8m4bc
+      uid: 3e7a3b40-2179-4cfd-8dfd-fa8e65ca46c1
+    spec:
+      services:
+        Frontend:
+          componentType: frontend
+          extraPodSpec:
+            mainContainer:
+              image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
+              imagePullPolicy: IfNotPresent
+              name: ""
+              resources: {}
+          replicas: 1
+        decode:
+          componentType: worker
+          envFromSecret: hf-token-secret
+          extraPodSpec:
+            mainContainer:
+              args:
+              - --model-path
+              - nvidia/Llama-3.1-8B-Instruct-FP8
+              - --model-name
+              - nvidia/Llama-3.1-8B-Instruct-FP8
+              - --speedup-ratio
+              - "1.0"
+              - --planner-profile-data
+              - /workspace/components/src/dynamo/planner/tests/data/profiling_results/H200_TP1P_TP1D
+              command:
+              - python3
+              - -m
+              - dynamo.mocker
+              image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
+              imagePullPolicy: IfNotPresent
+              name: ""
+              resources: {}
+              workingDir: /workspace
+          replicas: 1
+          subComponentType: decode
+    status:
+      state: ""
+  resourceVersion: "9334"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: nvidia.com/v1alpha1
+    kind: DynamoGraphDeployment
+    metadata:
+      annotations:
+        nvidia.com/current-worker-hash: a7fcd167
+        nvidia.com/current-worker-hash-v2: 534e74fa
+        nvidia.com/dynamo-operator-origin-version: 1.2.1
+      creationTimestamp: "2026-08-18T12:30:25Z"
+      finalizers:
+      - nvidia.com/finalizer
+      generation: 1
+      name: karta-e2e-dynamo
+      namespace: test-8m4bc
+      uid: 3e7a3b40-2179-4cfd-8dfd-fa8e65ca46c1
+    spec:
+      services:
+        Frontend:
+          componentType: frontend
+          extraPodSpec:
+            mainContainer:
+              image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
+              imagePullPolicy: IfNotPresent
+              name: ""
+              resources: {}
+          replicas: 1
+        decode:
+          componentType: worker
+          envFromSecret: hf-token-secret
+          extraPodSpec:
+            mainContainer:
+              args:
+              - --model-path
+              - nvidia/Llama-3.1-8B-Instruct-FP8
+              - --model-name
+              - nvidia/Llama-3.1-8B-Instruct-FP8
+              - --speedup-ratio
+              - "1.0"
+              - --planner-profile-data
+              - /workspace/components/src/dynamo/planner/tests/data/profiling_results/H200_TP1P_TP1D
+              command:
+              - python3
+              - -m
+              - dynamo.mocker
+              image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
+              imagePullPolicy: IfNotPresent
+              name: ""
+              resources: {}
+              workingDir: /workspace
+          replicas: 1
+          subComponentType: decode
+    status:
+      state: ""
+  resourceVersion: "9335"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: nvidia.com/v1alpha1
+    kind: DynamoGraphDeployment
+    metadata:
+      annotations:
+        nvidia.com/current-worker-hash: a7fcd167
+        nvidia.com/current-worker-hash-v2: 534e74fa
+        nvidia.com/dynamo-operator-origin-version: 1.2.1
+      creationTimestamp: "2026-08-18T12:30:25Z"
+      finalizers:
+      - nvidia.com/finalizer
+      generation: 1
+      name: karta-e2e-dynamo
+      namespace: test-8m4bc
+      uid: 3e7a3b40-2179-4cfd-8dfd-fa8e65ca46c1
+    spec:
+      services:
+        Frontend:
+          componentType: frontend
+          extraPodSpec:
+            mainContainer:
+              image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
+              imagePullPolicy: IfNotPresent
+              name: ""
+              resources: {}
+          replicas: 1
+        decode:
+          componentType: worker
+          envFromSecret: hf-token-secret
+          extraPodSpec:
+            mainContainer:
+              args:
+              - --model-path
+              - nvidia/Llama-3.1-8B-Instruct-FP8
+              - --model-name
+              - nvidia/Llama-3.1-8B-Instruct-FP8
+              - --speedup-ratio
+              - "1.0"
+              - --planner-profile-data
+              - /workspace/components/src/dynamo/planner/tests/data/profiling_results/H200_TP1P_TP1D
+              command:
+              - python3
+              - -m
+              - dynamo.mocker
+              image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
+              imagePullPolicy: IfNotPresent
+              name: ""
+              resources: {}
+              workingDir: /workspace
+          replicas: 1
+          subComponentType: decode
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:25Z"
+        message: 'Resources not ready: karta-e2e-dynamo-decode-a7fcd167: Component
+          deployment not ready - Available condition not true; karta-e2e-dynamo-frontend:
+          Component deployment not ready - Available condition not true'
+        reason: some_resources_are_not_ready
+        status: "False"
+        type: Ready
+      observedGeneration: 1
+      state: pending
+  resourceVersion: "9355"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: nvidia.com/v1alpha1
+    kind: DynamoGraphDeployment
+    metadata:
+      annotations:
+        nvidia.com/current-worker-hash: a7fcd167
+        nvidia.com/current-worker-hash-v2: 534e74fa
+        nvidia.com/dynamo-operator-origin-version: 1.2.1
+      creationTimestamp: "2026-08-18T12:30:25Z"
+      finalizers:
+      - nvidia.com/finalizer
+      generation: 1
+      name: karta-e2e-dynamo
+      namespace: test-8m4bc
+      uid: 3e7a3b40-2179-4cfd-8dfd-fa8e65ca46c1
+    spec:
+      services:
+        Frontend:
+          componentType: frontend
+          extraPodSpec:
+            mainContainer:
+              image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
+              imagePullPolicy: IfNotPresent
+              name: ""
+              resources: {}
+          replicas: 1
+        decode:
+          componentType: worker
+          envFromSecret: hf-token-secret
+          extraPodSpec:
+            mainContainer:
+              args:
+              - --model-path
+              - nvidia/Llama-3.1-8B-Instruct-FP8
+              - --model-name
+              - nvidia/Llama-3.1-8B-Instruct-FP8
+              - --speedup-ratio
+              - "1.0"
+              - --planner-profile-data
+              - /workspace/components/src/dynamo/planner/tests/data/profiling_results/H200_TP1P_TP1D
+              command:
+              - python3
+              - -m
+              - dynamo.mocker
+              image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
+              imagePullPolicy: IfNotPresent
+              name: ""
+              resources: {}
+              workingDir: /workspace
+          replicas: 1
+          subComponentType: decode
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:25Z"
+        message: 'Resources not ready: karta-e2e-dynamo-decode-a7fcd167: Component
+          deployment not ready - Available condition not true; karta-e2e-dynamo-frontend:
+          Component deployment not ready - Available condition not true'
+        reason: some_resources_are_not_ready
+        status: "False"
+        type: Ready
+      observedGeneration: 1
+      services:
+        Frontend:
+          availableReplicas: 0
+          componentKind: Deployment
+          componentName: karta-e2e-dynamo-frontend
+          componentNames:
+          - karta-e2e-dynamo-frontend
+          readyReplicas: 0
+          replicas: 0
+          updatedReplicas: 0
+      state: pending
+  resourceVersion: "9394"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: nvidia.com/v1alpha1
+    kind: DynamoGraphDeployment
+    metadata:
+      annotations:
+        nvidia.com/current-worker-hash: a7fcd167
+        nvidia.com/current-worker-hash-v2: 534e74fa
+        nvidia.com/dynamo-operator-origin-version: 1.2.1
+      creationTimestamp: "2026-08-18T12:30:25Z"
+      finalizers:
+      - nvidia.com/finalizer
+      generation: 1
+      name: karta-e2e-dynamo
+      namespace: test-8m4bc
+      uid: 3e7a3b40-2179-4cfd-8dfd-fa8e65ca46c1
+    spec:
+      services:
+        Frontend:
+          componentType: frontend
+          extraPodSpec:
+            mainContainer:
+              image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
+              imagePullPolicy: IfNotPresent
+              name: ""
+              resources: {}
+          replicas: 1
+        decode:
+          componentType: worker
+          envFromSecret: hf-token-secret
+          extraPodSpec:
+            mainContainer:
+              args:
+              - --model-path
+              - nvidia/Llama-3.1-8B-Instruct-FP8
+              - --model-name
+              - nvidia/Llama-3.1-8B-Instruct-FP8
+              - --speedup-ratio
+              - "1.0"
+              - --planner-profile-data
+              - /workspace/components/src/dynamo/planner/tests/data/profiling_results/H200_TP1P_TP1D
+              command:
+              - python3
+              - -m
+              - dynamo.mocker
+              image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
+              imagePullPolicy: IfNotPresent
+              name: ""
+              resources: {}
+              workingDir: /workspace
+          replicas: 1
+          subComponentType: decode
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:25Z"
+        message: 'Resources not ready: karta-e2e-dynamo-decode-a7fcd167: Component
+          deployment not ready - Available condition not true; karta-e2e-dynamo-frontend:
+          Component deployment not ready - Available condition not true'
+        reason: some_resources_are_not_ready
+        status: "False"
+        type: Ready
+      observedGeneration: 1
+      services:
+        Frontend:
+          availableReplicas: 0
+          componentKind: Deployment
+          componentName: karta-e2e-dynamo-frontend
+          componentNames:
+          - karta-e2e-dynamo-frontend
+          readyReplicas: 0
+          replicas: 1
+          updatedReplicas: 1
+      state: pending
+  resourceVersion: "9429"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: nvidia.com/v1alpha1
+    kind: DynamoGraphDeployment
+    metadata:
+      annotations:
+        nvidia.com/current-worker-hash: a7fcd167
+        nvidia.com/current-worker-hash-v2: 534e74fa
+        nvidia.com/dynamo-operator-origin-version: 1.2.1
+      creationTimestamp: "2026-08-18T12:30:25Z"
+      finalizers:
+      - nvidia.com/finalizer
+      generation: 1
+      name: karta-e2e-dynamo
+      namespace: test-8m4bc
+      uid: 3e7a3b40-2179-4cfd-8dfd-fa8e65ca46c1
+    spec:
+      services:
+        Frontend:
+          componentType: frontend
+          extraPodSpec:
+            mainContainer:
+              image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
+              imagePullPolicy: IfNotPresent
+              name: ""
+              resources: {}
+          replicas: 1
+        decode:
+          componentType: worker
+          envFromSecret: hf-token-secret
+          extraPodSpec:
+            mainContainer:
+              args:
+              - --model-path
+              - nvidia/Llama-3.1-8B-Instruct-FP8
+              - --model-name
+              - nvidia/Llama-3.1-8B-Instruct-FP8
+              - --speedup-ratio
+              - "1.0"
+              - --planner-profile-data
+              - /workspace/components/src/dynamo/planner/tests/data/profiling_results/H200_TP1P_TP1D
+              command:
+              - python3
+              - -m
+              - dynamo.mocker
+              image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
+              imagePullPolicy: IfNotPresent
+              name: ""
+              resources: {}
+              workingDir: /workspace
+          replicas: 1
+          subComponentType: decode
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:25Z"
+        message: 'Resources not ready: karta-e2e-dynamo-decode-a7fcd167: Component
+          deployment not ready - Available condition not true; karta-e2e-dynamo-frontend:
+          Component deployment not ready - Available condition not true'
+        reason: some_resources_are_not_ready
+        status: "False"
+        type: Ready
+      observedGeneration: 1
+      services:
+        Frontend:
+          availableReplicas: 0
+          componentKind: Deployment
+          componentName: karta-e2e-dynamo-frontend
+          componentNames:
+          - karta-e2e-dynamo-frontend
+          readyReplicas: 0
+          replicas: 1
+          updatedReplicas: 1
+        decode:
+          availableReplicas: 0
+          componentKind: Deployment
+          componentName: karta-e2e-dynamo-decode-a7fcd167
+          componentNames:
+          - karta-e2e-dynamo-decode-a7fcd167
+          readyReplicas: 0
+          replicas: 1
+          updatedReplicas: 1
+      state: pending
+  resourceVersion: "9444"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: nvidia.com/v1alpha1
+    kind: DynamoGraphDeployment
+    metadata:
+      annotations:
+        nvidia.com/current-worker-hash: a7fcd167
+        nvidia.com/current-worker-hash-v2: 534e74fa
+        nvidia.com/dynamo-operator-origin-version: 1.2.1
+      creationTimestamp: "2026-08-18T12:30:25Z"
+      finalizers:
+      - nvidia.com/finalizer
+      generation: 1
+      name: karta-e2e-dynamo
+      namespace: test-8m4bc
+      uid: 3e7a3b40-2179-4cfd-8dfd-fa8e65ca46c1
+    spec:
+      services:
+        Frontend:
+          componentType: frontend
+          extraPodSpec:
+            mainContainer:
+              image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
+              imagePullPolicy: IfNotPresent
+              name: ""
+              resources: {}
+          replicas: 1
+        decode:
+          componentType: worker
+          envFromSecret: hf-token-secret
+          extraPodSpec:
+            mainContainer:
+              args:
+              - --model-path
+              - nvidia/Llama-3.1-8B-Instruct-FP8
+              - --model-name
+              - nvidia/Llama-3.1-8B-Instruct-FP8
+              - --speedup-ratio
+              - "1.0"
+              - --planner-profile-data
+              - /workspace/components/src/dynamo/planner/tests/data/profiling_results/H200_TP1P_TP1D
+              command:
+              - python3
+              - -m
+              - dynamo.mocker
+              image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
+              imagePullPolicy: IfNotPresent
+              name: ""
+              resources: {}
+              workingDir: /workspace
+          replicas: 1
+          subComponentType: decode
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:25Z"
+        message: 'Resources not ready: karta-e2e-dynamo-decode-a7fcd167: Component
+          deployment not ready - Available condition not true'
+        reason: some_resources_are_not_ready
+        status: "False"
+        type: Ready
+      observedGeneration: 1
+      services:
+        Frontend:
+          availableReplicas: 1
+          componentKind: Deployment
+          componentName: karta-e2e-dynamo-frontend
+          componentNames:
+          - karta-e2e-dynamo-frontend
+          readyReplicas: 1
+          replicas: 1
+          updatedReplicas: 1
+        decode:
+          availableReplicas: 0
+          componentKind: Deployment
+          componentName: karta-e2e-dynamo-decode-a7fcd167
+          componentNames:
+          - karta-e2e-dynamo-decode-a7fcd167
+          readyReplicas: 0
+          replicas: 1
+          updatedReplicas: 1
+      state: pending
+  resourceVersion: "9578"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: nvidia.com/v1alpha1
+    kind: DynamoGraphDeployment
+    metadata:
+      annotations:
+        nvidia.com/current-worker-hash: a7fcd167
+        nvidia.com/current-worker-hash-v2: 534e74fa
+        nvidia.com/dynamo-operator-origin-version: 1.2.1
+      creationTimestamp: "2026-08-18T12:30:25Z"
+      finalizers:
+      - nvidia.com/finalizer
+      generation: 1
+      name: karta-e2e-dynamo
+      namespace: test-8m4bc
+      uid: 3e7a3b40-2179-4cfd-8dfd-fa8e65ca46c1
+    spec:
+      services:
+        Frontend:
+          componentType: frontend
+          extraPodSpec:
+            mainContainer:
+              image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
+              imagePullPolicy: IfNotPresent
+              name: ""
+              resources: {}
+          replicas: 1
+        decode:
+          componentType: worker
+          envFromSecret: hf-token-secret
+          extraPodSpec:
+            mainContainer:
+              args:
+              - --model-path
+              - nvidia/Llama-3.1-8B-Instruct-FP8
+              - --model-name
+              - nvidia/Llama-3.1-8B-Instruct-FP8
+              - --speedup-ratio
+              - "1.0"
+              - --planner-profile-data
+              - /workspace/components/src/dynamo/planner/tests/data/profiling_results/H200_TP1P_TP1D
+              command:
+              - python3
+              - -m
+              - dynamo.mocker
+              image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
+              imagePullPolicy: IfNotPresent
+              name: ""
+              resources: {}
+              workingDir: /workspace
+          replicas: 1
+          subComponentType: decode
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:30:45Z"
+        message: All resources are ready
+        reason: all_resources_are_ready
+        status: "True"
+        type: Ready
+      observedGeneration: 1
+      services:
+        Frontend:
+          availableReplicas: 1
+          componentKind: Deployment
+          componentName: karta-e2e-dynamo-frontend
+          componentNames:
+          - karta-e2e-dynamo-frontend
+          readyReplicas: 1
+          replicas: 1
+          updatedReplicas: 1
+        decode:
+          availableReplicas: 1
+          componentKind: Deployment
+          componentName: karta-e2e-dynamo-decode-a7fcd167
+          componentNames:
+          - karta-e2e-dynamo-decode-a7fcd167
+          readyReplicas: 1
+          replicas: 1
+          updatedReplicas: 1
+      state: successful
+  resourceVersion: "9662"
+  state: Running
+flow: running
+kartaFile: docs/catalog/nvidia-com-dynamographdeployment-v1alpha1.yaml
+kartaName: nvidia-com-dynamographdeployment-v1alpha1
+operator: dynamo
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Running

--- a/test/e2e/recorded_data/grove/v1.34.0/grove-io-podcliqueset-v1alpha1/initializing.yaml
+++ b/test/e2e/recorded_data/grove/v1.34.0/grove-io-podcliqueset-v1alpha1/initializing.yaml
@@ -1,0 +1,49 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:41:14Z"
+      generation: 1
+      name: karta-e2e-grove-initializing
+      namespace: test-8m4bc
+      uid: bcb821d6-5f58-4069-8e56-2541b9d3731b
+    spec:
+      replicas: 1
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:99.99.99
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+  resourceVersion: "16650"
+  state: Initializing
+flow: initializing
+kartaFile: docs/catalog/grove-io-podcliqueset-v1alpha1.yaml
+kartaName: grove-io-podcliqueset-v1alpha1
+operator: grove
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Initializing

--- a/test/e2e/recorded_data/grove/v1.34.0/grove-io-podcliqueset-v1alpha1/running.yaml
+++ b/test/e2e/recorded_data/grove/v1.34.0/grove-io-podcliqueset-v1alpha1/running.yaml
@@ -1,0 +1,341 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:41:13Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 1
+      name: karta-e2e-grove
+      namespace: test-8m4bc
+      uid: 52c65a02-447a-44f3-81e7-6a2865caf921
+    spec:
+      replicas: 1
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+  resourceVersion: "16565"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:41:13Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 1
+      name: karta-e2e-grove
+      namespace: test-8m4bc
+      uid: 52c65a02-447a-44f3-81e7-6a2865caf921
+    spec:
+      replicas: 1
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+    status:
+      availableReplicas: 0
+      currentGenerationHash: fcd7c86f456f9f449b
+      updatedReplicas: 0
+  resourceVersion: "16566"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:41:13Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 1
+      name: karta-e2e-grove
+      namespace: test-8m4bc
+      uid: 52c65a02-447a-44f3-81e7-6a2865caf921
+    spec:
+      replicas: 1
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+    status:
+      availableReplicas: 0
+      currentGenerationHash: fcd7c86f456f9f449b
+      lastErrors:
+      - code: ERR_SYNC_ROLEBINDING
+        description: 'failed to sync RoleBinding: [Operation: Sync, Code: ERR_SYNC_ROLEBINDING]
+          message: Error syncing RoleBinding: test-8m4bc/grove.io:pcs:karta-e2e-grove
+          for PodCliqueSet: test-8m4bc/karta-e2e-grove, cause: rolebindings.rbac.authorization.k8s.io
+          "grove.io:pcs:karta-e2e-grove" not found'
+        observedAt: "2026-08-18T12:41:13Z"
+      updatedReplicas: 0
+  resourceVersion: "16574"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:41:13Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 1
+      name: karta-e2e-grove
+      namespace: test-8m4bc
+      uid: 52c65a02-447a-44f3-81e7-6a2865caf921
+    spec:
+      replicas: 1
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+    status:
+      availableReplicas: 0
+      currentGenerationHash: fcd7c86f456f9f449b
+      lastErrors:
+      - code: ERR_SYNC_ROLEBINDING
+        description: 'failed to sync RoleBinding: [Operation: Sync, Code: ERR_SYNC_ROLEBINDING]
+          message: Error syncing RoleBinding: test-8m4bc/grove.io:pcs:karta-e2e-grove
+          for PodCliqueSet: test-8m4bc/karta-e2e-grove, cause: rolebindings.rbac.authorization.k8s.io
+          "grove.io:pcs:karta-e2e-grove" not found'
+        observedAt: "2026-08-18T12:41:13Z"
+      replicas: 1
+      updatedReplicas: 0
+  resourceVersion: "16575"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:41:13Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 1
+      name: karta-e2e-grove
+      namespace: test-8m4bc
+      uid: 52c65a02-447a-44f3-81e7-6a2865caf921
+    spec:
+      replicas: 1
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+    status:
+      availableReplicas: 0
+      currentGenerationHash: fcd7c86f456f9f449b
+      replicas: 1
+      updatedReplicas: 0
+  resourceVersion: "16581"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:41:13Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 1
+      name: karta-e2e-grove
+      namespace: test-8m4bc
+      uid: 52c65a02-447a-44f3-81e7-6a2865caf921
+    spec:
+      replicas: 1
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+    status:
+      availableReplicas: 0
+      currentGenerationHash: fcd7c86f456f9f449b
+      observedGeneration: 1
+      replicas: 1
+      updatedReplicas: 0
+  resourceVersion: "16598"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:41:13Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 1
+      name: karta-e2e-grove
+      namespace: test-8m4bc
+      uid: 52c65a02-447a-44f3-81e7-6a2865caf921
+    spec:
+      replicas: 1
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+    status:
+      availableReplicas: 1
+      currentGenerationHash: fcd7c86f456f9f449b
+      observedGeneration: 1
+      replicas: 1
+      updatedReplicas: 1
+  resourceVersion: "16647"
+  state: Running
+flow: running
+kartaFile: docs/catalog/grove-io-podcliqueset-v1alpha1.yaml
+kartaName: grove-io-podcliqueset-v1alpha1
+operator: grove
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Running

--- a/test/e2e/recorded_data/grove/v1.34.0/grove-io-podcliqueset-v1alpha1/scaled.yaml
+++ b/test/e2e/recorded_data/grove/v1.34.0/grove-io-podcliqueset-v1alpha1/scaled.yaml
@@ -1,0 +1,691 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:41:14Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 1
+      name: karta-e2e-grove-scaled
+      namespace: test-8m4bc
+      uid: 6ee34ae4-41cb-4af0-af90-24f47e5d671a
+    spec:
+      replicas: 1
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+  resourceVersion: "16666"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:41:14Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 1
+      name: karta-e2e-grove-scaled
+      namespace: test-8m4bc
+      uid: 6ee34ae4-41cb-4af0-af90-24f47e5d671a
+    spec:
+      replicas: 1
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+    status:
+      availableReplicas: 0
+      currentGenerationHash: fcd7c86f456f9f449b
+      updatedReplicas: 0
+  resourceVersion: "16667"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:41:14Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 1
+      name: karta-e2e-grove-scaled
+      namespace: test-8m4bc
+      uid: 6ee34ae4-41cb-4af0-af90-24f47e5d671a
+    spec:
+      replicas: 1
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+    status:
+      availableReplicas: 0
+      currentGenerationHash: fcd7c86f456f9f449b
+      lastErrors:
+      - code: ERR_SYNC_ROLEBINDING
+        description: 'failed to sync RoleBinding: [Operation: Sync, Code: ERR_SYNC_ROLEBINDING]
+          message: Error syncing RoleBinding: test-8m4bc/grove.io:pcs:karta-e2e-grove-scaled
+          for PodCliqueSet: test-8m4bc/karta-e2e-grove-scaled, cause: rolebindings.rbac.authorization.k8s.io
+          "grove.io:pcs:karta-e2e-grove-scaled" not found'
+        observedAt: "2026-08-18T12:41:14Z"
+      updatedReplicas: 0
+  resourceVersion: "16676"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:41:14Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 1
+      name: karta-e2e-grove-scaled
+      namespace: test-8m4bc
+      uid: 6ee34ae4-41cb-4af0-af90-24f47e5d671a
+    spec:
+      replicas: 1
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+    status:
+      availableReplicas: 0
+      currentGenerationHash: fcd7c86f456f9f449b
+      lastErrors:
+      - code: ERR_SYNC_ROLEBINDING
+        description: 'failed to sync RoleBinding: [Operation: Sync, Code: ERR_SYNC_ROLEBINDING]
+          message: Error syncing RoleBinding: test-8m4bc/grove.io:pcs:karta-e2e-grove-scaled
+          for PodCliqueSet: test-8m4bc/karta-e2e-grove-scaled, cause: rolebindings.rbac.authorization.k8s.io
+          "grove.io:pcs:karta-e2e-grove-scaled" not found'
+        observedAt: "2026-08-18T12:41:14Z"
+      replicas: 1
+      updatedReplicas: 0
+  resourceVersion: "16677"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:41:14Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 1
+      name: karta-e2e-grove-scaled
+      namespace: test-8m4bc
+      uid: 6ee34ae4-41cb-4af0-af90-24f47e5d671a
+    spec:
+      replicas: 1
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+    status:
+      availableReplicas: 0
+      currentGenerationHash: fcd7c86f456f9f449b
+      replicas: 1
+      updatedReplicas: 0
+  resourceVersion: "16685"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:41:14Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 1
+      name: karta-e2e-grove-scaled
+      namespace: test-8m4bc
+      uid: 6ee34ae4-41cb-4af0-af90-24f47e5d671a
+    spec:
+      replicas: 1
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+    status:
+      availableReplicas: 0
+      currentGenerationHash: fcd7c86f456f9f449b
+      observedGeneration: 1
+      replicas: 1
+      updatedReplicas: 0
+  resourceVersion: "16702"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:41:14Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 1
+      name: karta-e2e-grove-scaled
+      namespace: test-8m4bc
+      uid: 6ee34ae4-41cb-4af0-af90-24f47e5d671a
+    spec:
+      replicas: 1
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+    status:
+      availableReplicas: 1
+      currentGenerationHash: fcd7c86f456f9f449b
+      observedGeneration: 1
+      replicas: 1
+      updatedReplicas: 1
+  resourceVersion: "16753"
+  state: Running
+- action:
+    name: Scale
+    operation:
+      patchType: application/merge-patch+json
+      payload:
+        spec:
+          replicas: 2
+      verb: PATCH
+  kind: ACTION
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:41:14Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 2
+      name: karta-e2e-grove-scaled
+      namespace: test-8m4bc
+      uid: 6ee34ae4-41cb-4af0-af90-24f47e5d671a
+    spec:
+      replicas: 2
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+    status:
+      availableReplicas: 1
+      currentGenerationHash: fcd7c86f456f9f449b
+      observedGeneration: 1
+      replicas: 1
+      updatedReplicas: 1
+  resourceVersion: "16754"
+  staleObservedGeneration: true
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:41:14Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 2
+      name: karta-e2e-grove-scaled
+      namespace: test-8m4bc
+      uid: 6ee34ae4-41cb-4af0-af90-24f47e5d671a
+    spec:
+      replicas: 2
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+    status:
+      availableReplicas: 1
+      currentGenerationHash: fcd7c86f456f9f449b
+      observedGeneration: 1
+      replicas: 2
+      updatedReplicas: 1
+  resourceVersion: "16767"
+  staleObservedGeneration: true
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:41:14Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 2
+      name: karta-e2e-grove-scaled
+      namespace: test-8m4bc
+      uid: 6ee34ae4-41cb-4af0-af90-24f47e5d671a
+    spec:
+      replicas: 2
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+    status:
+      availableReplicas: 1
+      currentGenerationHash: fcd7c86f456f9f449b
+      observedGeneration: 2
+      replicas: 2
+      updatedReplicas: 1
+  resourceVersion: "16781"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:41:14Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 2
+      name: karta-e2e-grove-scaled
+      namespace: test-8m4bc
+      uid: 6ee34ae4-41cb-4af0-af90-24f47e5d671a
+    spec:
+      replicas: 2
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+    status:
+      availableReplicas: 2
+      currentGenerationHash: fcd7c86f456f9f449b
+      observedGeneration: 2
+      replicas: 2
+      updatedReplicas: 2
+  resourceVersion: "16822"
+  state: Running
+- action:
+    name: Scale
+    operation:
+      patchType: application/merge-patch+json
+      payload:
+        spec:
+          replicas: 1
+      verb: PATCH
+  kind: ACTION
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:41:14Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 3
+      name: karta-e2e-grove-scaled
+      namespace: test-8m4bc
+      uid: 6ee34ae4-41cb-4af0-af90-24f47e5d671a
+    spec:
+      replicas: 1
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+    status:
+      availableReplicas: 2
+      currentGenerationHash: fcd7c86f456f9f449b
+      observedGeneration: 2
+      replicas: 2
+      updatedReplicas: 2
+  resourceVersion: "16823"
+  staleObservedGeneration: true
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:41:14Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 3
+      name: karta-e2e-grove-scaled
+      namespace: test-8m4bc
+      uid: 6ee34ae4-41cb-4af0-af90-24f47e5d671a
+    spec:
+      replicas: 1
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+    status:
+      availableReplicas: 2
+      currentGenerationHash: fcd7c86f456f9f449b
+      observedGeneration: 3
+      replicas: 2
+      updatedReplicas: 2
+  resourceVersion: "16827"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-08-18T12:41:14Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 3
+      name: karta-e2e-grove-scaled
+      namespace: test-8m4bc
+      uid: 6ee34ae4-41cb-4af0-af90-24f47e5d671a
+    spec:
+      replicas: 1
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+    status:
+      availableReplicas: 1
+      currentGenerationHash: fcd7c86f456f9f449b
+      observedGeneration: 3
+      replicas: 1
+      updatedReplicas: 1
+  resourceVersion: "16829"
+  state: Running
+flow: scaled
+kartaFile: docs/catalog/grove-io-podcliqueset-v1alpha1.yaml
+kartaName: grove-io-podcliqueset-v1alpha1
+operator: grove
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Running


### PR DESCRIPTION
Part of #139 - one workload type per PR, stacked. Adds the dynamo flow: its spec steps, the predicates it judges stable states with (from the workload's own fields), and its recorded fixtures. Replayed offline by the suite in #260; `make check` green at every layer.