### PR TITLE
test(e2e): add the milvus flow and its recorded fixtures

### DIFF
--- a/test/e2e/flows/milvus_test.go
+++ b/test/e2e/flows/milvus_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package flows
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kartav1alpha1 "github.com/run-ai/karta/pkg/api/runai/v1alpha1"
+	"github.com/run-ai/karta/test/e2e/recorder"
+)
+
+var _ = Describe("Milvus", Ordered, Label("milvus"), func() {
+	var rec *recorder.Recorder
+	var fx recorder.Fixture
+
+	BeforeAll(func(ctx SpecContext) {
+		installKarta(ctx, "../../docs/catalog/milvus-io-milvus-v1beta1.yaml", "milvus-io-milvus-v1beta1")
+		fx = recorder.Fixture{Operator: "milvus", Version: operatorVersion("milvus"), KartaName: "milvus-io-milvus-v1beta1", KartaFile: "docs/catalog/milvus-io-milvus-v1beta1.yaml"}
+		rec = recorder.New(cfg).
+			SetTimeout(8*time.Minute).
+			AddState(kartav1alpha1.InitializingStatus, PhaseAny([]string{"Pending", ""}, "status", "status")).
+			AddState(kartav1alpha1.RunningStatus, CondTrue("MilvusReady"))
+	})
+
+	It("running", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "running", "testdata/milvus/running.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("initializing", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "initializing", "testdata/milvus/initializing.yaml").Through(recorder.Reaches(kartav1alpha1.InitializingStatus)).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+})

--- a/test/e2e/flows/testdata/milvus/initializing.yaml
+++ b/test/e2e/flows/testdata/milvus/initializing.yaml
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A Milvus pointed at external etcd and storage endpoints that do not exist, with a
+# nonexistent image. The operator creates no in-cluster dependencies (no etcd/minio helm
+# releases, so nothing to leak) and holds .status.status=Pending because the standalone pod
+# never becomes ready. The definition reads Pending as Initializing. Karta must read it as
+# Initializing, not Running.
+apiVersion: milvus.io/v1beta1
+kind: Milvus
+metadata:
+  name: karta-e2e-milvus-initializing
+  namespace: default
+spec:
+  mode: standalone
+  dependencies:
+    etcd:
+      external: true
+      endpoints: ["nonexistent-etcd:2379"]
+    msgStreamType: rocksmq
+    storage:
+      external: true
+      endpoint: "nonexistent-minio:9000"
+  components:
+    image: milvusdb/milvus:v0.0.0-nonexistent
+    standalone:
+      replicas: 1

--- a/test/e2e/flows/testdata/milvus/running.yaml
+++ b/test/e2e/flows/testdata/milvus/running.yaml
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A real standalone Milvus driven by the milvus-operator (installed by
+# hack/e2e/up.sh). The operator brings up the in-cluster dependencies (a
+# single-replica etcd and a standalone MinIO) and the Milvus standalone pod, then
+# sets EtcdReady, StorageReady, MsgStreamReady, and MilvusReady; the test waits
+# for MilvusReady. Kept lightweight (standalone, embedded rocksmq) for local kind.
+apiVersion: milvus.io/v1beta1
+kind: Milvus
+metadata:
+  name: karta-e2e-milvus
+  namespace: default
+spec:
+  mode: standalone
+  dependencies:
+    etcd:
+      inCluster:
+        values:
+          replicaCount: 1
+    storage:
+      inCluster:
+        values:
+          mode: standalone
+          resources:
+            requests:
+              memory: 256Mi
+  components:
+    standalone:
+      replicas: 1
+      resources:
+        requests:
+          cpu: 250m
+          memory: 1Gi

--- a/test/e2e/recorded_data/milvus/v1.34.0/milvus-io-milvus-v1beta1/initializing.yaml
+++ b/test/e2e/recorded_data/milvus/v1.34.0/milvus-io-milvus-v1beta1/initializing.yaml
@@ -1,0 +1,41 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: milvus.io/v1beta1
+    kind: Milvus
+    metadata:
+      creationTimestamp: "2026-08-18T12:32:39Z"
+      generation: 1
+      name: karta-e2e-milvus-initializing
+      namespace: test-8m4bc
+      uid: 526f93d3-a6e1-4ae5-9f18-38bd3cf18a9a
+    spec:
+      components:
+        image: milvusdb/milvus:v0.0.0-nonexistent
+        imageUpdateMode: rollingUpgrade
+        standalone:
+          replicas: 1
+          serviceType: ClusterIP
+        targetPortType: string
+      dependencies:
+        etcd:
+          endpoints:
+          - nonexistent-etcd:2379
+          external: true
+        msgStreamType: rocksmq
+        storage:
+          endpoint: nonexistent-minio:9000
+          external: true
+          type: MinIO
+      mode: standalone
+  resourceVersion: "11025"
+  state: Initializing
+flow: initializing
+kartaFile: docs/catalog/milvus-io-milvus-v1beta1.yaml
+kartaName: milvus-io-milvus-v1beta1
+operator: milvus
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Initializing

--- a/test/e2e/recorded_data/milvus/v1.34.0/milvus-io-milvus-v1beta1/running.yaml
+++ b/test/e2e/recorded_data/milvus/v1.34.0/milvus-io-milvus-v1beta1/running.yaml
@@ -1,0 +1,1796 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: milvus.io/v1beta1
+    kind: Milvus
+    metadata:
+      creationTimestamp: "2026-08-18T12:31:01Z"
+      finalizers:
+      - milvus.milvus.io/finalizer
+      generation: 2
+      name: karta-e2e-milvus
+      namespace: test-8m4bc
+      uid: 5203ee08-7610-4519-8646-3345e466cae0
+    spec:
+      components:
+        disableMetric: false
+        imageUpdateMode: rollingUpgrade
+        metricInterval: ""
+        paused: false
+        probes: null
+        securityContext: null
+        standalone:
+          paused: false
+          probes: null
+          replicas: 1
+          resources:
+            requests:
+              cpu: 250m
+              memory: 1Gi
+          securityContext: null
+          serviceType: ClusterIP
+        targetPortType: string
+      dependencies:
+        customMsgStream: null
+        etcd:
+          external: false
+          inCluster:
+            deletionPolicy: Retain
+            values:
+              replicaCount: 1
+        kafka:
+          external: false
+        natsmq:
+          persistence:
+            persistentVolumeClaim:
+              spec: null
+        pulsar:
+          endpoint: ""
+          external: false
+        rocksmq:
+          persistence:
+            persistentVolumeClaim:
+              spec: null
+        storage:
+          endpoint: ""
+          external: false
+          inCluster:
+            deletionPolicy: Retain
+            values:
+              mode: standalone
+              resources:
+                requests:
+                  memory: 256Mi
+          secretRef: ""
+          type: MinIO
+        tei:
+          enabled: false
+        woodpecker:
+          persistence:
+            persistentVolumeClaim:
+              spec: null
+      hookConfig: null
+      mode: standalone
+  resourceVersion: "10089"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: milvus.io/v1beta1
+    kind: Milvus
+    metadata:
+      annotations:
+        milvus.io/dependency-values-merged: "true"
+        milvus.io/pod-service-label-added: "true"
+      creationTimestamp: "2026-08-18T12:31:01Z"
+      finalizers:
+      - milvus.milvus.io/finalizer
+      generation: 3
+      labels:
+        milvus.io/operator-version: 1.3.7
+      name: karta-e2e-milvus
+      namespace: test-8m4bc
+      uid: 5203ee08-7610-4519-8646-3345e466cae0
+    spec:
+      components:
+        disableMetric: false
+        enableRollingUpdate: true
+        image: milvusdb/milvus:v2.6.11
+        imageUpdateMode: rollingUpgrade
+        metricInterval: ""
+        paused: false
+        probes: null
+        rollingMode: 2
+        securityContext: null
+        standalone:
+          paused: false
+          probes: null
+          replicas: 1
+          resources:
+            requests:
+              cpu: 250m
+              memory: 1Gi
+          securityContext: null
+          serviceType: ClusterIP
+        targetPortType: string
+        updateConfigMapOnly: true
+      config:
+        dataCoord:
+          enableActiveStandby: true
+        indexCoord:
+          enableActiveStandby: true
+        queryCoord:
+          enableActiveStandby: true
+        rootCoord:
+          enableActiveStandby: true
+      dependencies:
+        customMsgStream: null
+        etcd:
+          endpoints:
+          - karta-e2e-milvus-etcd-0.karta-e2e-milvus-etcd-headless.test-8m4bc:2379
+          external: false
+          inCluster:
+            chartVersion: etcd-v8
+            deletionPolicy: Retain
+            values:
+              auth:
+                rbac:
+                  create: false
+                  enabled: false
+                token:
+                  enabled: false
+              autoCompactionMode: revision
+              autoCompactionRetention: "1000"
+              enabled: true
+              extraEnvVars:
+              - name: ETCD_QUOTA_BACKEND_BYTES
+                value: "4294967296"
+              - name: ETCD_HEARTBEAT_INTERVAL
+                value: "500"
+              - name: ETCD_ELECTION_TIMEOUT
+                value: "2500"
+              image:
+                pullPolicy: IfNotPresent
+                repository: milvusdb/etcd
+                tag: 3.5.25-r1
+              livenessProbe:
+                enabled: true
+                timeoutSeconds: 10
+              name: etcd
+              pdb:
+                create: false
+              persistence:
+                accessMode: ReadWriteOnce
+                enabled: true
+                size: 10Gi
+                storageClass: null
+              readinessProbe:
+                enabled: true
+                periodSeconds: 20
+                timeoutSeconds: 10
+              replicaCount: 1
+              service:
+                peerPort: 2380
+                port: 2379
+                type: ClusterIP
+        kafka:
+          external: false
+        msgStreamType: woodpecker
+        natsmq:
+          persistence:
+            persistentVolumeClaim:
+              spec: null
+        pulsar:
+          endpoint: ""
+          external: false
+        rocksmq:
+          persistence:
+            persistentVolumeClaim:
+              spec: null
+        storage:
+          endpoint: karta-e2e-milvus-minio.test-8m4bc:9000
+          external: false
+          inCluster:
+            deletionPolicy: Retain
+            values:
+              accessKey: minioadmin
+              bucketName: milvus-bucket
+              enabled: true
+              existingSecret: ""
+              iamEndpoint: ""
+              image:
+                pullPolicy: IfNotPresent
+                tag: RELEASE.2024-12-18T13-15-44Z
+              livenessProbe:
+                enabled: true
+                failureThreshold: 5
+                initialDelaySeconds: 5
+                periodSeconds: 5
+                successThreshold: 1
+                timeoutSeconds: 5
+              mode: standalone
+              name: minio
+              persistence:
+                accessMode: ReadWriteOnce
+                enabled: true
+                existingClaim: ""
+                size: 500Gi
+                storageClass: null
+              podDisruptionBudget:
+                enabled: false
+              readinessProbe:
+                enabled: true
+                failureThreshold: 5
+                initialDelaySeconds: 5
+                periodSeconds: 5
+                successThreshold: 1
+                timeoutSeconds: 1
+              region: ""
+              resources:
+                requests:
+                  memory: 256Mi
+              rootPath: file
+              secretKey: minioadmin
+              service:
+                port: 9000
+                type: ClusterIP
+              startupProbe:
+                enabled: true
+                failureThreshold: 60
+                initialDelaySeconds: 0
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 5
+              useIAM: false
+              useVirtualHost: false
+          secretRef: karta-e2e-milvus-minio
+          type: MinIO
+        tei:
+          enabled: false
+        woodpecker:
+          persistence:
+            persistentVolumeClaim:
+              spec: null
+      hookConfig: null
+      mode: standalone
+  resourceVersion: "10090"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: milvus.io/v1beta1
+    kind: Milvus
+    metadata:
+      annotations:
+        milvus.io/dependency-values-merged: "true"
+        milvus.io/pod-service-label-added: "true"
+      creationTimestamp: "2026-08-18T12:31:01Z"
+      finalizers:
+      - milvus.milvus.io/finalizer
+      generation: 3
+      labels:
+        milvus.io/operator-version: 1.3.7
+      name: karta-e2e-milvus
+      namespace: test-8m4bc
+      uid: 5203ee08-7610-4519-8646-3345e466cae0
+    spec:
+      components:
+        disableMetric: false
+        enableRollingUpdate: true
+        image: milvusdb/milvus:v2.6.11
+        imageUpdateMode: rollingUpgrade
+        metricInterval: ""
+        paused: false
+        probes: null
+        rollingMode: 2
+        securityContext: null
+        standalone:
+          paused: false
+          probes: null
+          replicas: 1
+          resources:
+            requests:
+              cpu: 250m
+              memory: 1Gi
+          securityContext: null
+          serviceType: ClusterIP
+        targetPortType: string
+        updateConfigMapOnly: true
+      config:
+        dataCoord:
+          enableActiveStandby: true
+        indexCoord:
+          enableActiveStandby: true
+        queryCoord:
+          enableActiveStandby: true
+        rootCoord:
+          enableActiveStandby: true
+      dependencies:
+        customMsgStream: null
+        etcd:
+          endpoints:
+          - karta-e2e-milvus-etcd-0.karta-e2e-milvus-etcd-headless.test-8m4bc:2379
+          external: false
+          inCluster:
+            chartVersion: etcd-v8
+            deletionPolicy: Retain
+            values:
+              auth:
+                rbac:
+                  create: false
+                  enabled: false
+                token:
+                  enabled: false
+              autoCompactionMode: revision
+              autoCompactionRetention: "1000"
+              enabled: true
+              extraEnvVars:
+              - name: ETCD_QUOTA_BACKEND_BYTES
+                value: "4294967296"
+              - name: ETCD_HEARTBEAT_INTERVAL
+                value: "500"
+              - name: ETCD_ELECTION_TIMEOUT
+                value: "2500"
+              image:
+                pullPolicy: IfNotPresent
+                repository: milvusdb/etcd
+                tag: 3.5.25-r1
+              livenessProbe:
+                enabled: true
+                timeoutSeconds: 10
+              name: etcd
+              pdb:
+                create: false
+              persistence:
+                accessMode: ReadWriteOnce
+                enabled: true
+                size: 10Gi
+                storageClass: null
+              readinessProbe:
+                enabled: true
+                periodSeconds: 20
+                timeoutSeconds: 10
+              replicaCount: 1
+              service:
+                peerPort: 2380
+                port: 2379
+                type: ClusterIP
+        kafka:
+          external: false
+        msgStreamType: woodpecker
+        natsmq:
+          persistence:
+            persistentVolumeClaim:
+              spec: null
+        pulsar:
+          endpoint: ""
+          external: false
+        rocksmq:
+          persistence:
+            persistentVolumeClaim:
+              spec: null
+        storage:
+          endpoint: karta-e2e-milvus-minio.test-8m4bc:9000
+          external: false
+          inCluster:
+            deletionPolicy: Retain
+            values:
+              accessKey: minioadmin
+              bucketName: milvus-bucket
+              enabled: true
+              existingSecret: ""
+              iamEndpoint: ""
+              image:
+                pullPolicy: IfNotPresent
+                tag: RELEASE.2024-12-18T13-15-44Z
+              livenessProbe:
+                enabled: true
+                failureThreshold: 5
+                initialDelaySeconds: 5
+                periodSeconds: 5
+                successThreshold: 1
+                timeoutSeconds: 5
+              mode: standalone
+              name: minio
+              persistence:
+                accessMode: ReadWriteOnce
+                enabled: true
+                existingClaim: ""
+                size: 500Gi
+                storageClass: null
+              podDisruptionBudget:
+                enabled: false
+              readinessProbe:
+                enabled: true
+                failureThreshold: 5
+                initialDelaySeconds: 5
+                periodSeconds: 5
+                successThreshold: 1
+                timeoutSeconds: 1
+              region: ""
+              resources:
+                requests:
+                  memory: 256Mi
+              rootPath: file
+              secretKey: minioadmin
+              service:
+                port: 9000
+                type: ClusterIP
+              startupProbe:
+                enabled: true
+                failureThreshold: 60
+                initialDelaySeconds: 0
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 5
+              useIAM: false
+              useVirtualHost: false
+          secretRef: karta-e2e-milvus-minio
+          type: MinIO
+        tei:
+          enabled: false
+        woodpecker:
+          persistence:
+            persistentVolumeClaim:
+              spec: null
+      hookConfig: null
+      mode: standalone
+    status:
+      currentImage: milvusdb/milvus:v2.6.11
+      ingress:
+        loadBalancer: {}
+      rollingModeVersion: 2
+      status: Pending
+  resourceVersion: "10091"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: milvus.io/v1beta1
+    kind: Milvus
+    metadata:
+      annotations:
+        milvus.io/dependency-values-merged: "true"
+        milvus.io/pod-service-label-added: "true"
+      creationTimestamp: "2026-08-18T12:31:01Z"
+      finalizers:
+      - milvus.milvus.io/finalizer
+      generation: 3
+      labels:
+        milvus.io/operator-version: 1.3.7
+      name: karta-e2e-milvus
+      namespace: test-8m4bc
+      uid: 5203ee08-7610-4519-8646-3345e466cae0
+    spec:
+      components:
+        disableMetric: false
+        enableRollingUpdate: true
+        image: milvusdb/milvus:v2.6.11
+        imageUpdateMode: rollingUpgrade
+        metricInterval: ""
+        paused: false
+        probes: null
+        rollingMode: 2
+        securityContext: null
+        standalone:
+          paused: false
+          probes: null
+          replicas: 1
+          resources:
+            requests:
+              cpu: 250m
+              memory: 1Gi
+          securityContext: null
+          serviceType: ClusterIP
+        targetPortType: string
+        updateConfigMapOnly: true
+      config:
+        dataCoord:
+          enableActiveStandby: true
+        indexCoord:
+          enableActiveStandby: true
+        queryCoord:
+          enableActiveStandby: true
+        rootCoord:
+          enableActiveStandby: true
+      dependencies:
+        customMsgStream: null
+        etcd:
+          endpoints:
+          - karta-e2e-milvus-etcd-0.karta-e2e-milvus-etcd-headless.test-8m4bc:2379
+          external: false
+          inCluster:
+            chartVersion: etcd-v8
+            deletionPolicy: Retain
+            values:
+              auth:
+                rbac:
+                  create: false
+                  enabled: false
+                token:
+                  enabled: false
+              autoCompactionMode: revision
+              autoCompactionRetention: "1000"
+              enabled: true
+              extraEnvVars:
+              - name: ETCD_QUOTA_BACKEND_BYTES
+                value: "4294967296"
+              - name: ETCD_HEARTBEAT_INTERVAL
+                value: "500"
+              - name: ETCD_ELECTION_TIMEOUT
+                value: "2500"
+              image:
+                pullPolicy: IfNotPresent
+                repository: milvusdb/etcd
+                tag: 3.5.25-r1
+              livenessProbe:
+                enabled: true
+                timeoutSeconds: 10
+              name: etcd
+              pdb:
+                create: false
+              persistence:
+                accessMode: ReadWriteOnce
+                enabled: true
+                size: 10Gi
+                storageClass: null
+              readinessProbe:
+                enabled: true
+                periodSeconds: 20
+                timeoutSeconds: 10
+              replicaCount: 1
+              service:
+                peerPort: 2380
+                port: 2379
+                type: ClusterIP
+        kafka:
+          external: false
+        msgStreamType: woodpecker
+        natsmq:
+          persistence:
+            persistentVolumeClaim:
+              spec: null
+        pulsar:
+          endpoint: ""
+          external: false
+        rocksmq:
+          persistence:
+            persistentVolumeClaim:
+              spec: null
+        storage:
+          endpoint: karta-e2e-milvus-minio.test-8m4bc:9000
+          external: false
+          inCluster:
+            deletionPolicy: Retain
+            values:
+              accessKey: minioadmin
+              bucketName: milvus-bucket
+              enabled: true
+              existingSecret: ""
+              iamEndpoint: ""
+              image:
+                pullPolicy: IfNotPresent
+                tag: RELEASE.2024-12-18T13-15-44Z
+              livenessProbe:
+                enabled: true
+                failureThreshold: 5
+                initialDelaySeconds: 5
+                periodSeconds: 5
+                successThreshold: 1
+                timeoutSeconds: 5
+              mode: standalone
+              name: minio
+              persistence:
+                accessMode: ReadWriteOnce
+                enabled: true
+                existingClaim: ""
+                size: 500Gi
+                storageClass: null
+              podDisruptionBudget:
+                enabled: false
+              readinessProbe:
+                enabled: true
+                failureThreshold: 5
+                initialDelaySeconds: 5
+                periodSeconds: 5
+                successThreshold: 1
+                timeoutSeconds: 1
+              region: ""
+              resources:
+                requests:
+                  memory: 256Mi
+              rootPath: file
+              secretKey: minioadmin
+              service:
+                port: 9000
+                type: ClusterIP
+              startupProbe:
+                enabled: true
+                failureThreshold: 60
+                initialDelaySeconds: 0
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 5
+              useIAM: false
+              useVirtualHost: false
+          secretRef: karta-e2e-milvus-minio
+          type: MinIO
+        tei:
+          enabled: false
+        woodpecker:
+          persistence:
+            persistentVolumeClaim:
+              spec: null
+      hookConfig: null
+      mode: standalone
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:31:01Z"
+        message: '[standalone] not ready, detail: component[standalone]: deployment
+          not created'
+        reason: MilvusComponentNotHealthy
+        status: "False"
+        type: MilvusReady
+      - lastTransitionTime: "2026-08-18T12:31:01Z"
+        message: Milvus is performing rolling upgrade pending components[standalone]
+        reason: MilvusUpgradingImage
+        status: "False"
+        type: MilvusUpdated
+      currentImage: milvusdb/milvus:v2.6.11
+      endpoint: karta-e2e-milvus-milvus.test-8m4bc:19530
+      ingress:
+        loadBalancer: {}
+      observedGeneration: 3
+      rollingModeVersion: 2
+      status: Pending
+  resourceVersion: "10136"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: milvus.io/v1beta1
+    kind: Milvus
+    metadata:
+      annotations:
+        milvus.io/dependency-values-merged: "true"
+        milvus.io/pod-service-label-added: "true"
+      creationTimestamp: "2026-08-18T12:31:01Z"
+      finalizers:
+      - milvus.milvus.io/finalizer
+      generation: 3
+      labels:
+        milvus.io/operator-version: 1.3.7
+      name: karta-e2e-milvus
+      namespace: test-8m4bc
+      uid: 5203ee08-7610-4519-8646-3345e466cae0
+    spec:
+      components:
+        disableMetric: false
+        enableRollingUpdate: true
+        image: milvusdb/milvus:v2.6.11
+        imageUpdateMode: rollingUpgrade
+        metricInterval: ""
+        paused: false
+        probes: null
+        rollingMode: 2
+        securityContext: null
+        standalone:
+          paused: false
+          probes: null
+          replicas: 1
+          resources:
+            requests:
+              cpu: 250m
+              memory: 1Gi
+          securityContext: null
+          serviceType: ClusterIP
+        targetPortType: string
+        updateConfigMapOnly: true
+      config:
+        dataCoord:
+          enableActiveStandby: true
+        indexCoord:
+          enableActiveStandby: true
+        queryCoord:
+          enableActiveStandby: true
+        rootCoord:
+          enableActiveStandby: true
+      dependencies:
+        customMsgStream: null
+        etcd:
+          endpoints:
+          - karta-e2e-milvus-etcd-0.karta-e2e-milvus-etcd-headless.test-8m4bc:2379
+          external: false
+          inCluster:
+            chartVersion: etcd-v8
+            deletionPolicy: Retain
+            values:
+              auth:
+                rbac:
+                  create: false
+                  enabled: false
+                token:
+                  enabled: false
+              autoCompactionMode: revision
+              autoCompactionRetention: "1000"
+              enabled: true
+              extraEnvVars:
+              - name: ETCD_QUOTA_BACKEND_BYTES
+                value: "4294967296"
+              - name: ETCD_HEARTBEAT_INTERVAL
+                value: "500"
+              - name: ETCD_ELECTION_TIMEOUT
+                value: "2500"
+              image:
+                pullPolicy: IfNotPresent
+                repository: milvusdb/etcd
+                tag: 3.5.25-r1
+              livenessProbe:
+                enabled: true
+                timeoutSeconds: 10
+              name: etcd
+              pdb:
+                create: false
+              persistence:
+                accessMode: ReadWriteOnce
+                enabled: true
+                size: 10Gi
+                storageClass: null
+              readinessProbe:
+                enabled: true
+                periodSeconds: 20
+                timeoutSeconds: 10
+              replicaCount: 1
+              service:
+                peerPort: 2380
+                port: 2379
+                type: ClusterIP
+        kafka:
+          external: false
+        msgStreamType: woodpecker
+        natsmq:
+          persistence:
+            persistentVolumeClaim:
+              spec: null
+        pulsar:
+          endpoint: ""
+          external: false
+        rocksmq:
+          persistence:
+            persistentVolumeClaim:
+              spec: null
+        storage:
+          endpoint: karta-e2e-milvus-minio.test-8m4bc:9000
+          external: false
+          inCluster:
+            deletionPolicy: Retain
+            values:
+              accessKey: minioadmin
+              bucketName: milvus-bucket
+              enabled: true
+              existingSecret: ""
+              iamEndpoint: ""
+              image:
+                pullPolicy: IfNotPresent
+                tag: RELEASE.2024-12-18T13-15-44Z
+              livenessProbe:
+                enabled: true
+                failureThreshold: 5
+                initialDelaySeconds: 5
+                periodSeconds: 5
+                successThreshold: 1
+                timeoutSeconds: 5
+              mode: standalone
+              name: minio
+              persistence:
+                accessMode: ReadWriteOnce
+                enabled: true
+                existingClaim: ""
+                size: 500Gi
+                storageClass: null
+              podDisruptionBudget:
+                enabled: false
+              readinessProbe:
+                enabled: true
+                failureThreshold: 5
+                initialDelaySeconds: 5
+                periodSeconds: 5
+                successThreshold: 1
+                timeoutSeconds: 1
+              region: ""
+              resources:
+                requests:
+                  memory: 256Mi
+              rootPath: file
+              secretKey: minioadmin
+              service:
+                port: 9000
+                type: ClusterIP
+              startupProbe:
+                enabled: true
+                failureThreshold: 60
+                initialDelaySeconds: 0
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 5
+              useIAM: false
+              useVirtualHost: false
+          secretRef: karta-e2e-milvus-minio
+          type: MinIO
+        tei:
+          enabled: false
+        woodpecker:
+          persistence:
+            persistentVolumeClaim:
+              spec: null
+      hookConfig: null
+      mode: standalone
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:31:01Z"
+        message: '[standalone] not ready, detail: component[standalone]: deployment
+          not created'
+        reason: MilvusComponentNotHealthy
+        status: "False"
+        type: MilvusReady
+      - lastTransitionTime: "2026-08-18T12:31:01Z"
+        message: Milvus is performing rolling upgrade pending components[standalone]
+        reason: MilvusUpgradingImage
+        status: "False"
+        type: MilvusUpdated
+      - lastTransitionTime: "2026-08-18T12:31:12Z"
+        message: Etcd endpoints is healthy
+        reason: EtcdReady
+        status: "True"
+        type: EtcdReady
+      - lastTransitionTime: "2026-08-18T12:31:12Z"
+        message: 'dowithbackoff[checkMinIO] failed after 3 retries: Get "http://karta-e2e-milvus-minio.test-8m4bc:9000/minio/admin/v3/info":
+          dial tcp 10.96.243.136:9000: connect: connection refused'
+        reason: ClientError
+        status: "False"
+        type: StorageReady
+      - lastTransitionTime: "2026-08-18T12:31:12Z"
+        reason: MsgStreamReady
+        status: "True"
+        type: MsgStreamReady
+      currentImage: milvusdb/milvus:v2.6.11
+      endpoint: karta-e2e-milvus-milvus.test-8m4bc:19530
+      ingress:
+        loadBalancer: {}
+      observedGeneration: 3
+      rollingModeVersion: 2
+      status: Pending
+  resourceVersion: "10275"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: milvus.io/v1beta1
+    kind: Milvus
+    metadata:
+      annotations:
+        milvus.io/dependency-values-merged: "true"
+        milvus.io/pod-service-label-added: "true"
+      creationTimestamp: "2026-08-18T12:31:01Z"
+      finalizers:
+      - milvus.milvus.io/finalizer
+      generation: 3
+      labels:
+        milvus.io/operator-version: 1.3.7
+      name: karta-e2e-milvus
+      namespace: test-8m4bc
+      uid: 5203ee08-7610-4519-8646-3345e466cae0
+    spec:
+      components:
+        disableMetric: false
+        enableRollingUpdate: true
+        image: milvusdb/milvus:v2.6.11
+        imageUpdateMode: rollingUpgrade
+        metricInterval: ""
+        paused: false
+        probes: null
+        rollingMode: 2
+        securityContext: null
+        standalone:
+          paused: false
+          probes: null
+          replicas: 1
+          resources:
+            requests:
+              cpu: 250m
+              memory: 1Gi
+          securityContext: null
+          serviceType: ClusterIP
+        targetPortType: string
+        updateConfigMapOnly: true
+      config:
+        dataCoord:
+          enableActiveStandby: true
+        indexCoord:
+          enableActiveStandby: true
+        queryCoord:
+          enableActiveStandby: true
+        rootCoord:
+          enableActiveStandby: true
+      dependencies:
+        customMsgStream: null
+        etcd:
+          endpoints:
+          - karta-e2e-milvus-etcd-0.karta-e2e-milvus-etcd-headless.test-8m4bc:2379
+          external: false
+          inCluster:
+            chartVersion: etcd-v8
+            deletionPolicy: Retain
+            values:
+              auth:
+                rbac:
+                  create: false
+                  enabled: false
+                token:
+                  enabled: false
+              autoCompactionMode: revision
+              autoCompactionRetention: "1000"
+              enabled: true
+              extraEnvVars:
+              - name: ETCD_QUOTA_BACKEND_BYTES
+                value: "4294967296"
+              - name: ETCD_HEARTBEAT_INTERVAL
+                value: "500"
+              - name: ETCD_ELECTION_TIMEOUT
+                value: "2500"
+              image:
+                pullPolicy: IfNotPresent
+                repository: milvusdb/etcd
+                tag: 3.5.25-r1
+              livenessProbe:
+                enabled: true
+                timeoutSeconds: 10
+              name: etcd
+              pdb:
+                create: false
+              persistence:
+                accessMode: ReadWriteOnce
+                enabled: true
+                size: 10Gi
+                storageClass: null
+              readinessProbe:
+                enabled: true
+                periodSeconds: 20
+                timeoutSeconds: 10
+              replicaCount: 1
+              service:
+                peerPort: 2380
+                port: 2379
+                type: ClusterIP
+        kafka:
+          external: false
+        msgStreamType: woodpecker
+        natsmq:
+          persistence:
+            persistentVolumeClaim:
+              spec: null
+        pulsar:
+          endpoint: ""
+          external: false
+        rocksmq:
+          persistence:
+            persistentVolumeClaim:
+              spec: null
+        storage:
+          endpoint: karta-e2e-milvus-minio.test-8m4bc:9000
+          external: false
+          inCluster:
+            deletionPolicy: Retain
+            values:
+              accessKey: minioadmin
+              bucketName: milvus-bucket
+              enabled: true
+              existingSecret: ""
+              iamEndpoint: ""
+              image:
+                pullPolicy: IfNotPresent
+                tag: RELEASE.2024-12-18T13-15-44Z
+              livenessProbe:
+                enabled: true
+                failureThreshold: 5
+                initialDelaySeconds: 5
+                periodSeconds: 5
+                successThreshold: 1
+                timeoutSeconds: 5
+              mode: standalone
+              name: minio
+              persistence:
+                accessMode: ReadWriteOnce
+                enabled: true
+                existingClaim: ""
+                size: 500Gi
+                storageClass: null
+              podDisruptionBudget:
+                enabled: false
+              readinessProbe:
+                enabled: true
+                failureThreshold: 5
+                initialDelaySeconds: 5
+                periodSeconds: 5
+                successThreshold: 1
+                timeoutSeconds: 1
+              region: ""
+              resources:
+                requests:
+                  memory: 256Mi
+              rootPath: file
+              secretKey: minioadmin
+              service:
+                port: 9000
+                type: ClusterIP
+              startupProbe:
+                enabled: true
+                failureThreshold: 60
+                initialDelaySeconds: 0
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 5
+              useIAM: false
+              useVirtualHost: false
+          secretRef: karta-e2e-milvus-minio
+          type: MinIO
+        tei:
+          enabled: false
+        woodpecker:
+          persistence:
+            persistentVolumeClaim:
+              spec: null
+      hookConfig: null
+      mode: standalone
+    status:
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:31:01Z"
+        message: '[standalone] not ready, detail: component[standalone]: deployment
+          not created'
+        reason: MilvusComponentNotHealthy
+        status: "False"
+        type: MilvusReady
+      - lastTransitionTime: "2026-08-18T12:31:01Z"
+        message: Milvus is performing rolling upgrade pending components[standalone]
+        reason: MilvusUpgradingImage
+        status: "False"
+        type: MilvusUpdated
+      - lastTransitionTime: "2026-08-18T12:31:12Z"
+        message: Etcd endpoints is healthy
+        reason: EtcdReady
+        status: "True"
+        type: EtcdReady
+      - lastTransitionTime: "2026-08-18T12:31:39Z"
+        reason: StorageReady
+        status: "True"
+        type: StorageReady
+      - lastTransitionTime: "2026-08-18T12:31:12Z"
+        reason: MsgStreamReady
+        status: "True"
+        type: MsgStreamReady
+      currentImage: milvusdb/milvus:v2.6.11
+      endpoint: karta-e2e-milvus-milvus.test-8m4bc:19530
+      ingress:
+        loadBalancer: {}
+      observedGeneration: 3
+      rollingModeVersion: 2
+      status: Pending
+  resourceVersion: "10516"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: milvus.io/v1beta1
+    kind: Milvus
+    metadata:
+      annotations:
+        milvus.io/dependency-values-merged: "true"
+        milvus.io/pod-service-label-added: "true"
+      creationTimestamp: "2026-08-18T12:31:01Z"
+      finalizers:
+      - milvus.milvus.io/finalizer
+      generation: 3
+      labels:
+        milvus.io/operator-version: 1.3.7
+      name: karta-e2e-milvus
+      namespace: test-8m4bc
+      uid: 5203ee08-7610-4519-8646-3345e466cae0
+    spec:
+      components:
+        disableMetric: false
+        enableRollingUpdate: true
+        image: milvusdb/milvus:v2.6.11
+        imageUpdateMode: rollingUpgrade
+        metricInterval: ""
+        paused: false
+        probes: null
+        rollingMode: 2
+        securityContext: null
+        standalone:
+          paused: false
+          probes: null
+          replicas: 1
+          resources:
+            requests:
+              cpu: 250m
+              memory: 1Gi
+          securityContext: null
+          serviceType: ClusterIP
+        targetPortType: string
+        updateConfigMapOnly: true
+      config:
+        dataCoord:
+          enableActiveStandby: true
+        indexCoord:
+          enableActiveStandby: true
+        queryCoord:
+          enableActiveStandby: true
+        rootCoord:
+          enableActiveStandby: true
+      dependencies:
+        customMsgStream: null
+        etcd:
+          endpoints:
+          - karta-e2e-milvus-etcd-0.karta-e2e-milvus-etcd-headless.test-8m4bc:2379
+          external: false
+          inCluster:
+            chartVersion: etcd-v8
+            deletionPolicy: Retain
+            values:
+              auth:
+                rbac:
+                  create: false
+                  enabled: false
+                token:
+                  enabled: false
+              autoCompactionMode: revision
+              autoCompactionRetention: "1000"
+              enabled: true
+              extraEnvVars:
+              - name: ETCD_QUOTA_BACKEND_BYTES
+                value: "4294967296"
+              - name: ETCD_HEARTBEAT_INTERVAL
+                value: "500"
+              - name: ETCD_ELECTION_TIMEOUT
+                value: "2500"
+              image:
+                pullPolicy: IfNotPresent
+                repository: milvusdb/etcd
+                tag: 3.5.25-r1
+              livenessProbe:
+                enabled: true
+                timeoutSeconds: 10
+              name: etcd
+              pdb:
+                create: false
+              persistence:
+                accessMode: ReadWriteOnce
+                enabled: true
+                size: 10Gi
+                storageClass: null
+              readinessProbe:
+                enabled: true
+                periodSeconds: 20
+                timeoutSeconds: 10
+              replicaCount: 1
+              service:
+                peerPort: 2380
+                port: 2379
+                type: ClusterIP
+        kafka:
+          external: false
+        msgStreamType: woodpecker
+        natsmq:
+          persistence:
+            persistentVolumeClaim:
+              spec: null
+        pulsar:
+          endpoint: ""
+          external: false
+        rocksmq:
+          persistence:
+            persistentVolumeClaim:
+              spec: null
+        storage:
+          endpoint: karta-e2e-milvus-minio.test-8m4bc:9000
+          external: false
+          inCluster:
+            deletionPolicy: Retain
+            values:
+              accessKey: minioadmin
+              bucketName: milvus-bucket
+              enabled: true
+              existingSecret: ""
+              iamEndpoint: ""
+              image:
+                pullPolicy: IfNotPresent
+                tag: RELEASE.2024-12-18T13-15-44Z
+              livenessProbe:
+                enabled: true
+                failureThreshold: 5
+                initialDelaySeconds: 5
+                periodSeconds: 5
+                successThreshold: 1
+                timeoutSeconds: 5
+              mode: standalone
+              name: minio
+              persistence:
+                accessMode: ReadWriteOnce
+                enabled: true
+                existingClaim: ""
+                size: 500Gi
+                storageClass: null
+              podDisruptionBudget:
+                enabled: false
+              readinessProbe:
+                enabled: true
+                failureThreshold: 5
+                initialDelaySeconds: 5
+                periodSeconds: 5
+                successThreshold: 1
+                timeoutSeconds: 1
+              region: ""
+              resources:
+                requests:
+                  memory: 256Mi
+              rootPath: file
+              secretKey: minioadmin
+              service:
+                port: 9000
+                type: ClusterIP
+              startupProbe:
+                enabled: true
+                failureThreshold: 60
+                initialDelaySeconds: 0
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 5
+              useIAM: false
+              useVirtualHost: false
+          secretRef: karta-e2e-milvus-minio
+          type: MinIO
+        tei:
+          enabled: false
+        woodpecker:
+          persistence:
+            persistentVolumeClaim:
+              spec: null
+      hookConfig: null
+      mode: standalone
+    status:
+      componentsDeployStatus:
+        standalone:
+          generation: 1
+          image: milvusdb/milvus:v2.6.11
+          status:
+            conditions:
+            - lastTransitionTime: "2026-08-18T12:31:39Z"
+              lastUpdateTime: "2026-08-18T12:31:39Z"
+              message: Deployment does not have minimum availability.
+              reason: MinimumReplicasUnavailable
+              status: "False"
+              type: Available
+            - lastTransitionTime: "2026-08-18T12:31:39Z"
+              lastUpdateTime: "2026-08-18T12:31:39Z"
+              message: ReplicaSet "karta-e2e-milvus-milvus-standalone-5bb7989f65"
+                is progressing.
+              reason: ReplicaSetUpdated
+              status: "True"
+              type: Progressing
+            observedGeneration: 1
+            replicas: 1
+            unavailableReplicas: 1
+            updatedReplicas: 1
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:31:39Z"
+        message: '[standalone] not ready, detail: component[standalone]: pod[karta-e2e-milvus-milvus-standalone-5bb7989f65-7hl25]:
+          container[standalone]: currentState[waiting] reason[PodInitializing]'
+        reason: MilvusComponentNotHealthy
+        status: "False"
+        type: MilvusReady
+      - lastTransitionTime: "2026-08-18T12:31:39Z"
+        message: Milvus components[standalone] are updating
+        reason: MilvusComponentsUpdating
+        status: "False"
+        type: MilvusUpdated
+      - lastTransitionTime: "2026-08-18T12:31:12Z"
+        message: Etcd endpoints is healthy
+        reason: EtcdReady
+        status: "True"
+        type: EtcdReady
+      - lastTransitionTime: "2026-08-18T12:31:39Z"
+        reason: StorageReady
+        status: "True"
+        type: StorageReady
+      - lastTransitionTime: "2026-08-18T12:31:12Z"
+        reason: MsgStreamReady
+        status: "True"
+        type: MsgStreamReady
+      currentImage: milvusdb/milvus:v2.6.11
+      endpoint: karta-e2e-milvus-milvus.test-8m4bc:19530
+      ingress:
+        loadBalancer: {}
+      observedGeneration: 3
+      rollingModeVersion: 2
+      status: Pending
+  resourceVersion: "10535"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: milvus.io/v1beta1
+    kind: Milvus
+    metadata:
+      annotations:
+        milvus.io/dependency-values-merged: "true"
+        milvus.io/pod-service-label-added: "true"
+      creationTimestamp: "2026-08-18T12:31:01Z"
+      finalizers:
+      - milvus.milvus.io/finalizer
+      generation: 3
+      labels:
+        milvus.io/operator-version: 1.3.7
+      name: karta-e2e-milvus
+      namespace: test-8m4bc
+      uid: 5203ee08-7610-4519-8646-3345e466cae0
+    spec:
+      components:
+        disableMetric: false
+        enableRollingUpdate: true
+        image: milvusdb/milvus:v2.6.11
+        imageUpdateMode: rollingUpgrade
+        metricInterval: ""
+        paused: false
+        probes: null
+        rollingMode: 2
+        securityContext: null
+        standalone:
+          paused: false
+          probes: null
+          replicas: 1
+          resources:
+            requests:
+              cpu: 250m
+              memory: 1Gi
+          securityContext: null
+          serviceType: ClusterIP
+        targetPortType: string
+        updateConfigMapOnly: true
+      config:
+        dataCoord:
+          enableActiveStandby: true
+        indexCoord:
+          enableActiveStandby: true
+        queryCoord:
+          enableActiveStandby: true
+        rootCoord:
+          enableActiveStandby: true
+      dependencies:
+        customMsgStream: null
+        etcd:
+          endpoints:
+          - karta-e2e-milvus-etcd-0.karta-e2e-milvus-etcd-headless.test-8m4bc:2379
+          external: false
+          inCluster:
+            chartVersion: etcd-v8
+            deletionPolicy: Retain
+            values:
+              auth:
+                rbac:
+                  create: false
+                  enabled: false
+                token:
+                  enabled: false
+              autoCompactionMode: revision
+              autoCompactionRetention: "1000"
+              enabled: true
+              extraEnvVars:
+              - name: ETCD_QUOTA_BACKEND_BYTES
+                value: "4294967296"
+              - name: ETCD_HEARTBEAT_INTERVAL
+                value: "500"
+              - name: ETCD_ELECTION_TIMEOUT
+                value: "2500"
+              image:
+                pullPolicy: IfNotPresent
+                repository: milvusdb/etcd
+                tag: 3.5.25-r1
+              livenessProbe:
+                enabled: true
+                timeoutSeconds: 10
+              name: etcd
+              pdb:
+                create: false
+              persistence:
+                accessMode: ReadWriteOnce
+                enabled: true
+                size: 10Gi
+                storageClass: null
+              readinessProbe:
+                enabled: true
+                periodSeconds: 20
+                timeoutSeconds: 10
+              replicaCount: 1
+              service:
+                peerPort: 2380
+                port: 2379
+                type: ClusterIP
+        kafka:
+          external: false
+        msgStreamType: woodpecker
+        natsmq:
+          persistence:
+            persistentVolumeClaim:
+              spec: null
+        pulsar:
+          endpoint: ""
+          external: false
+        rocksmq:
+          persistence:
+            persistentVolumeClaim:
+              spec: null
+        storage:
+          endpoint: karta-e2e-milvus-minio.test-8m4bc:9000
+          external: false
+          inCluster:
+            deletionPolicy: Retain
+            values:
+              accessKey: minioadmin
+              bucketName: milvus-bucket
+              enabled: true
+              existingSecret: ""
+              iamEndpoint: ""
+              image:
+                pullPolicy: IfNotPresent
+                tag: RELEASE.2024-12-18T13-15-44Z
+              livenessProbe:
+                enabled: true
+                failureThreshold: 5
+                initialDelaySeconds: 5
+                periodSeconds: 5
+                successThreshold: 1
+                timeoutSeconds: 5
+              mode: standalone
+              name: minio
+              persistence:
+                accessMode: ReadWriteOnce
+                enabled: true
+                existingClaim: ""
+                size: 500Gi
+                storageClass: null
+              podDisruptionBudget:
+                enabled: false
+              readinessProbe:
+                enabled: true
+                failureThreshold: 5
+                initialDelaySeconds: 5
+                periodSeconds: 5
+                successThreshold: 1
+                timeoutSeconds: 1
+              region: ""
+              resources:
+                requests:
+                  memory: 256Mi
+              rootPath: file
+              secretKey: minioadmin
+              service:
+                port: 9000
+                type: ClusterIP
+              startupProbe:
+                enabled: true
+                failureThreshold: 60
+                initialDelaySeconds: 0
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 5
+              useIAM: false
+              useVirtualHost: false
+          secretRef: karta-e2e-milvus-minio
+          type: MinIO
+        tei:
+          enabled: false
+        woodpecker:
+          persistence:
+            persistentVolumeClaim:
+              spec: null
+      hookConfig: null
+      mode: standalone
+    status:
+      componentsDeployStatus:
+        standalone:
+          generation: 1
+          image: milvusdb/milvus:v2.6.11
+          status:
+            conditions:
+            - lastTransitionTime: "2026-08-18T12:31:39Z"
+              lastUpdateTime: "2026-08-18T12:31:39Z"
+              message: Deployment does not have minimum availability.
+              reason: MinimumReplicasUnavailable
+              status: "False"
+              type: Available
+            - lastTransitionTime: "2026-08-18T12:31:39Z"
+              lastUpdateTime: "2026-08-18T12:31:50Z"
+              message: ReplicaSet "karta-e2e-milvus-milvus-standalone-5bb7989f65"
+                is progressing.
+              reason: ReplicaSetUpdated
+              status: "True"
+              type: Progressing
+            observedGeneration: 1
+            readyReplicas: 1
+            replicas: 1
+            unavailableReplicas: 1
+            updatedReplicas: 1
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:32:09Z"
+        message: '[standalone] not ready, detail: component[standalone]: deployment
+          status[Available:False]: reason[MinimumReplicasUnavailable]: Deployment
+          does not have minimum availability.'
+        reason: MilvusComponentNotHealthy
+        status: "False"
+        type: MilvusReady
+      - lastTransitionTime: "2026-08-18T12:31:39Z"
+        message: Milvus components[standalone] are updating
+        reason: MilvusComponentsUpdating
+        status: "False"
+        type: MilvusUpdated
+      - lastTransitionTime: "2026-08-18T12:31:12Z"
+        message: Etcd endpoints is healthy
+        reason: EtcdReady
+        status: "True"
+        type: EtcdReady
+      - lastTransitionTime: "2026-08-18T12:31:39Z"
+        reason: StorageReady
+        status: "True"
+        type: StorageReady
+      - lastTransitionTime: "2026-08-18T12:31:12Z"
+        reason: MsgStreamReady
+        status: "True"
+        type: MsgStreamReady
+      currentImage: milvusdb/milvus:v2.6.11
+      endpoint: karta-e2e-milvus-milvus.test-8m4bc:19530
+      ingress:
+        loadBalancer: {}
+      observedGeneration: 3
+      rollingModeVersion: 2
+      status: Pending
+  resourceVersion: "10786"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: milvus.io/v1beta1
+    kind: Milvus
+    metadata:
+      annotations:
+        milvus.io/dependency-values-merged: "true"
+        milvus.io/pod-service-label-added: "true"
+      creationTimestamp: "2026-08-18T12:31:01Z"
+      finalizers:
+      - milvus.milvus.io/finalizer
+      generation: 3
+      labels:
+        milvus.io/operator-version: 1.3.7
+      name: karta-e2e-milvus
+      namespace: test-8m4bc
+      uid: 5203ee08-7610-4519-8646-3345e466cae0
+    spec:
+      components:
+        disableMetric: false
+        enableRollingUpdate: true
+        image: milvusdb/milvus:v2.6.11
+        imageUpdateMode: rollingUpgrade
+        metricInterval: ""
+        paused: false
+        probes: null
+        rollingMode: 2
+        securityContext: null
+        standalone:
+          paused: false
+          probes: null
+          replicas: 1
+          resources:
+            requests:
+              cpu: 250m
+              memory: 1Gi
+          securityContext: null
+          serviceType: ClusterIP
+        targetPortType: string
+        updateConfigMapOnly: true
+      config:
+        dataCoord:
+          enableActiveStandby: true
+        indexCoord:
+          enableActiveStandby: true
+        queryCoord:
+          enableActiveStandby: true
+        rootCoord:
+          enableActiveStandby: true
+      dependencies:
+        customMsgStream: null
+        etcd:
+          endpoints:
+          - karta-e2e-milvus-etcd-0.karta-e2e-milvus-etcd-headless.test-8m4bc:2379
+          external: false
+          inCluster:
+            chartVersion: etcd-v8
+            deletionPolicy: Retain
+            values:
+              auth:
+                rbac:
+                  create: false
+                  enabled: false
+                token:
+                  enabled: false
+              autoCompactionMode: revision
+              autoCompactionRetention: "1000"
+              enabled: true
+              extraEnvVars:
+              - name: ETCD_QUOTA_BACKEND_BYTES
+                value: "4294967296"
+              - name: ETCD_HEARTBEAT_INTERVAL
+                value: "500"
+              - name: ETCD_ELECTION_TIMEOUT
+                value: "2500"
+              image:
+                pullPolicy: IfNotPresent
+                repository: milvusdb/etcd
+                tag: 3.5.25-r1
+              livenessProbe:
+                enabled: true
+                timeoutSeconds: 10
+              name: etcd
+              pdb:
+                create: false
+              persistence:
+                accessMode: ReadWriteOnce
+                enabled: true
+                size: 10Gi
+                storageClass: null
+              readinessProbe:
+                enabled: true
+                periodSeconds: 20
+                timeoutSeconds: 10
+              replicaCount: 1
+              service:
+                peerPort: 2380
+                port: 2379
+                type: ClusterIP
+        kafka:
+          external: false
+        msgStreamType: woodpecker
+        natsmq:
+          persistence:
+            persistentVolumeClaim:
+              spec: null
+        pulsar:
+          endpoint: ""
+          external: false
+        rocksmq:
+          persistence:
+            persistentVolumeClaim:
+              spec: null
+        storage:
+          endpoint: karta-e2e-milvus-minio.test-8m4bc:9000
+          external: false
+          inCluster:
+            deletionPolicy: Retain
+            values:
+              accessKey: minioadmin
+              bucketName: milvus-bucket
+              enabled: true
+              existingSecret: ""
+              iamEndpoint: ""
+              image:
+                pullPolicy: IfNotPresent
+                tag: RELEASE.2024-12-18T13-15-44Z
+              livenessProbe:
+                enabled: true
+                failureThreshold: 5
+                initialDelaySeconds: 5
+                periodSeconds: 5
+                successThreshold: 1
+                timeoutSeconds: 5
+              mode: standalone
+              name: minio
+              persistence:
+                accessMode: ReadWriteOnce
+                enabled: true
+                existingClaim: ""
+                size: 500Gi
+                storageClass: null
+              podDisruptionBudget:
+                enabled: false
+              readinessProbe:
+                enabled: true
+                failureThreshold: 5
+                initialDelaySeconds: 5
+                periodSeconds: 5
+                successThreshold: 1
+                timeoutSeconds: 1
+              region: ""
+              resources:
+                requests:
+                  memory: 256Mi
+              rootPath: file
+              secretKey: minioadmin
+              service:
+                port: 9000
+                type: ClusterIP
+              startupProbe:
+                enabled: true
+                failureThreshold: 60
+                initialDelaySeconds: 0
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 5
+              useIAM: false
+              useVirtualHost: false
+          secretRef: karta-e2e-milvus-minio
+          type: MinIO
+        tei:
+          enabled: false
+        woodpecker:
+          persistence:
+            persistentVolumeClaim:
+              spec: null
+      hookConfig: null
+      mode: standalone
+    status:
+      componentsDeployStatus:
+        standalone:
+          generation: 1
+          image: milvusdb/milvus:v2.6.11
+          status:
+            availableReplicas: 1
+            conditions:
+            - lastTransitionTime: "2026-08-18T12:32:20Z"
+              lastUpdateTime: "2026-08-18T12:32:20Z"
+              message: Deployment has minimum availability.
+              reason: MinimumReplicasAvailable
+              status: "True"
+              type: Available
+            - lastTransitionTime: "2026-08-18T12:31:39Z"
+              lastUpdateTime: "2026-08-18T12:32:20Z"
+              message: ReplicaSet "karta-e2e-milvus-milvus-standalone-5bb7989f65"
+                has successfully progressed.
+              reason: NewReplicaSetAvailable
+              status: "True"
+              type: Progressing
+            observedGeneration: 1
+            readyReplicas: 1
+            replicas: 1
+            updatedReplicas: 1
+      conditions:
+      - lastTransitionTime: "2026-08-18T12:32:39Z"
+        message: All Milvus components are healthy
+        reason: ReasonMilvusHealthy
+        status: "True"
+        type: MilvusReady
+      - lastTransitionTime: "2026-08-18T12:32:39Z"
+        message: Milvus components are all updated
+        reason: MilvusComponentsUpdated
+        status: "True"
+        type: MilvusUpdated
+      - lastTransitionTime: "2026-08-18T12:31:12Z"
+        message: Etcd endpoints is healthy
+        reason: EtcdReady
+        status: "True"
+        type: EtcdReady
+      - lastTransitionTime: "2026-08-18T12:31:39Z"
+        reason: StorageReady
+        status: "True"
+        type: StorageReady
+      - lastTransitionTime: "2026-08-18T12:31:12Z"
+        reason: MsgStreamReady
+        status: "True"
+        type: MsgStreamReady
+      currentImage: milvusdb/milvus:v2.6.11
+      endpoint: karta-e2e-milvus-milvus.test-8m4bc:19530
+      ingress:
+        loadBalancer: {}
+      observedGeneration: 3
+      rollingModeVersion: 2
+      status: Healthy
+  resourceVersion: "11023"
+  state: Running
+flow: running
+kartaFile: docs/catalog/milvus-io-milvus-v1beta1.yaml
+kartaName: milvus-io-milvus-v1beta1
+operator: milvus
+result:
+  succeeded: true
+schemaVersion: 1
+version: v1.34.0
+want: Running


### PR DESCRIPTION
Part of #139 - one workload type per PR, stacked. Adds the milvus flow: its spec steps, the predicates it judges stable states with (from the workload's own fields), and its recorded fixtures. Replayed offline by the suite in #260; `make check` green at every layer.