### PR TITLE
test(e2e): add the pytorchjob flow and its recorded fixtures

### DIFF
--- a/test/e2e/flows/actions.go
+++ b/test/e2e/flows/actions.go
@@ -14,3 +14,9 @@ import (
 func Suspend() *recorder.Action {
 	return &recorder.Action{Type: recorder.ActionSuspend, Patch: []byte(`{"spec":{"suspend":true}}`)}
 }
+
+// ResumeRunPolicy clears spec.runPolicy.suspend, where Kubeflow jobs (PyTorchJob, MPIJob) keep the
+// suspend flag, unlike the top-level spec.suspend that a plain resume patches.
+func ResumeRunPolicy() *recorder.Action {
+	return &recorder.Action{Type: recorder.ActionResume, Patch: []byte(`{"spec":{"runPolicy":{"suspend":false}}}`)}
+}

--- a/test/e2e/flows/pytorch_test.go
+++ b/test/e2e/flows/pytorch_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package flows
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kartav1alpha1 "github.com/run-ai/karta/pkg/api/runai/v1alpha1"
+	"github.com/run-ai/karta/test/e2e/recorder"
+)
+
+var _ = Describe("PyTorchJob", Ordered, Label("kubeflow", "pytorch"), func() {
+	var rec *recorder.Recorder
+	var fx recorder.Fixture
+
+	BeforeAll(func(ctx SpecContext) {
+		installKarta(ctx, "../../docs/catalog/kubeflow-org-pytorchjob-v1.yaml", "kubeflow-org-pytorchjob-v1")
+		fx = recorder.Fixture{Operator: "kubeflow", Version: operatorVersion("kubeflow"), KartaName: "kubeflow-org-pytorchjob-v1", KartaFile: "docs/catalog/kubeflow-org-pytorchjob-v1.yaml"}
+		rec = recorder.New(cfg).
+			SetTimeout(4*time.Minute).
+			AddState(kartav1alpha1.InitializingStatus, CondTrue("Created")).
+			AddState(kartav1alpha1.RunningStatus, CondTrue("Running")).
+			AddState(kartav1alpha1.CompletedStatus, CondTrue("Succeeded")).
+			AddState(kartav1alpha1.FailedStatus, CondTrue("Failed")).
+			AddState(kartav1alpha1.SuspendedStatus, CondTrue("Suspended"))
+	})
+
+	It("running", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "running", "testdata/pytorch/running.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("completed", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "completed", "testdata/pytorch/completed.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.CompletedStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("failed", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "failed", "testdata/pytorch/failed.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.FailedStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("suspended", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "suspended", "testdata/pytorch/suspended.yaml").
+			Through(recorder.Reaches(kartav1alpha1.SuspendedStatus)).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("resumed", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "resumed", "testdata/pytorch/resumed.yaml").Through(
+			recorder.Reaches(kartav1alpha1.SuspendedStatus).Do(ResumeRunPolicy()),
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+})

--- a/test/e2e/flows/testdata/pytorch/completed.yaml
+++ b/test/e2e/flows/testdata/pytorch/completed.yaml
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A PyTorchJob whose master sleeps briefly then exits 0, so the training-operator
+# marks it Running while it sleeps and Succeeded once it exits. The container must
+# be named "pytorch" for the operator to manage it.
+apiVersion: kubeflow.org/v1
+kind: PyTorchJob
+metadata:
+  name: karta-e2e-pytorch-completed
+  namespace: default
+spec:
+  pytorchReplicaSpecs:
+    Master:
+      replicas: 1
+      restartPolicy: Never
+      template:
+        spec:
+          containers:
+            - name: pytorch
+              image: busybox:1.36
+              command: ["sh", "-c", "sleep 15"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}

--- a/test/e2e/flows/testdata/pytorch/failed.yaml
+++ b/test/e2e/flows/testdata/pytorch/failed.yaml
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A PyTorchJob whose master sleeps briefly then exits 1, so the training-operator
+# marks it Running while it sleeps and Failed once it exits non-zero (restartPolicy
+# Never). The container must be named "pytorch" for the operator to manage it.
+apiVersion: kubeflow.org/v1
+kind: PyTorchJob
+metadata:
+  name: karta-e2e-pytorch-failed
+  namespace: default
+spec:
+  pytorchReplicaSpecs:
+    Master:
+      replicas: 1
+      restartPolicy: Never
+      template:
+        spec:
+          containers:
+            - name: pytorch
+              image: busybox:1.36
+              command: ["sh", "-c", "sleep 15; exit 1"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}

--- a/test/e2e/flows/testdata/pytorch/resumed.yaml
+++ b/test/e2e/flows/testdata/pytorch/resumed.yaml
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A PyTorchJob created suspended (runPolicy.suspend true), then resumed by the e2e action clearing
+# spec.runPolicy.suspend. The master then sleeps and the training-operator marks it Running. The
+# resumed flow records Suspended -> Running, the transition an operator will not make on its own.
+apiVersion: kubeflow.org/v1
+kind: PyTorchJob
+metadata:
+  name: karta-e2e-pytorch-resumed
+  namespace: default
+spec:
+  runPolicy:
+    suspend: true
+  pytorchReplicaSpecs:
+    Master:
+      replicas: 1
+      restartPolicy: Never
+      template:
+        spec:
+          containers:
+            - name: pytorch
+              image: busybox:1.36
+              command: ["sh", "-c", "sleep infinity"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}

--- a/test/e2e/flows/testdata/pytorch/running.yaml
+++ b/test/e2e/flows/testdata/pytorch/running.yaml
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A minimal PyTorchJob (1 master + 1 worker) whose containers sleep, so the
+# Kubeflow training-operator marks it Running on a CPU-only kind cluster. The
+# container must be named "pytorch" for the training-operator to manage it.
+apiVersion: kubeflow.org/v1
+kind: PyTorchJob
+metadata:
+  name: karta-e2e-pytorch
+  namespace: default
+spec:
+  pytorchReplicaSpecs:
+    Master:
+      replicas: 1
+      restartPolicy: Never
+      template:
+        spec:
+          containers:
+            - name: pytorch
+              image: busybox:1.36
+              command: ["sleep", "infinity"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}
+    Worker:
+      replicas: 1
+      restartPolicy: Never
+      template:
+        spec:
+          containers:
+            - name: pytorch
+              image: busybox:1.36
+              command: ["sleep", "infinity"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}

--- a/test/e2e/flows/testdata/pytorch/suspended.yaml
+++ b/test/e2e/flows/testdata/pytorch/suspended.yaml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A PyTorchJob created suspended (runPolicy.suspend true). The training-operator creates no pods and
+# sets the Suspended condition, which the definition reads as Suspended. Karta must read it as Suspended.
+apiVersion: kubeflow.org/v1
+kind: PyTorchJob
+metadata:
+  name: karta-e2e-pytorch-suspended
+  namespace: default
+spec:
+  runPolicy:
+    suspend: true
+  pytorchReplicaSpecs:
+    Master:
+      replicas: 1
+      restartPolicy: Never
+      template:
+        spec:
+          containers:
+            - name: pytorch
+              image: busybox:1.36
+              command: ["sh", "-c", "sleep infinity"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}

--- a/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-pytorchjob-v1/completed.yaml
+++ b/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-pytorchjob-v1/completed.yaml
@@ -1,0 +1,177 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-09-09T09:02:08Z"
+      generation: 1
+      name: karta-e2e-pytorch-completed
+      namespace: test-f5v9f
+      uid: 219001b9-af56-4433-9351-15c4239fc494
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 15
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+    status:
+      conditions:
+      - lastTransitionTime: "2026-09-09T09:02:08Z"
+        lastUpdateTime: "2026-09-09T09:02:08Z"
+        message: PyTorchJob karta-e2e-pytorch-completed is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      replicaStatuses:
+        Master:
+          selector: training.kubeflow.org/job-name=karta-e2e-pytorch-completed,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=master
+      startTime: "2026-09-09T09:02:08Z"
+  phases:
+  - Initializing
+  resourceVersion: "238260"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-09-09T09:02:08Z"
+      generation: 1
+      name: karta-e2e-pytorch-completed
+      namespace: test-f5v9f
+      uid: 219001b9-af56-4433-9351-15c4239fc494
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 15
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+    status:
+      conditions:
+      - lastTransitionTime: "2026-09-09T09:02:08Z"
+        lastUpdateTime: "2026-09-09T09:02:08Z"
+        message: PyTorchJob karta-e2e-pytorch-completed is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-09-09T09:02:09Z"
+        lastUpdateTime: "2026-09-09T09:02:09Z"
+        message: PyTorchJob karta-e2e-pytorch-completed is running.
+        reason: PyTorchJobRunning
+        status: "True"
+        type: Running
+      replicaStatuses:
+        Master:
+          active: 1
+          selector: training.kubeflow.org/job-name=karta-e2e-pytorch-completed,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=master
+      startTime: "2026-09-09T09:02:08Z"
+  phases:
+  - Initializing
+  - Running
+  resourceVersion: "238282"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-09-09T09:02:08Z"
+      generation: 1
+      name: karta-e2e-pytorch-completed
+      namespace: test-f5v9f
+      uid: 219001b9-af56-4433-9351-15c4239fc494
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 15
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+    status:
+      completionTime: "2026-09-09T09:02:25Z"
+      conditions:
+      - lastTransitionTime: "2026-09-09T09:02:08Z"
+        lastUpdateTime: "2026-09-09T09:02:08Z"
+        message: PyTorchJob karta-e2e-pytorch-completed is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-09-09T09:02:09Z"
+        lastUpdateTime: "2026-09-09T09:02:09Z"
+        message: PyTorchJob karta-e2e-pytorch-completed is running.
+        reason: PyTorchJobRunning
+        status: "False"
+        type: Running
+      - lastTransitionTime: "2026-09-09T09:02:25Z"
+        lastUpdateTime: "2026-09-09T09:02:25Z"
+        message: PyTorchJob karta-e2e-pytorch-completed is successfully completed.
+        reason: PyTorchJobSucceeded
+        status: "True"
+        type: Succeeded
+      replicaStatuses:
+        Master:
+          selector: training.kubeflow.org/job-name=karta-e2e-pytorch-completed,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=master
+          succeeded: 1
+      startTime: "2026-09-09T09:02:08Z"
+  phases:
+  - Initializing
+  - Completed
+  resourceVersion: "238406"
+  state: Completed
+flow: completed
+kartaFile: docs/catalog/kubeflow-org-pytorchjob-v1.yaml
+kartaName: kubeflow-org-pytorchjob-v1
+operator: kubeflow
+result:
+  succeeded: true
+schemaVersion: 1
+summary:
+- amount: 1
+  phases:
+  - Initializing
+- amount: 1
+  phases:
+  - Initializing
+  - Running
+- amount: 1
+  phases:
+  - Initializing
+  - Completed
+version: v1.34.0
+want: Completed

--- a/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-pytorchjob-v1/failed.yaml
+++ b/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-pytorchjob-v1/failed.yaml
@@ -1,0 +1,178 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-09-09T09:02:26Z"
+      generation: 1
+      name: karta-e2e-pytorch-failed
+      namespace: test-f5v9f
+      uid: 95a2c6df-893e-4b9b-8258-c276e1c019c4
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 15; exit 1
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+    status:
+      conditions:
+      - lastTransitionTime: "2026-09-09T09:02:26Z"
+        lastUpdateTime: "2026-09-09T09:02:26Z"
+        message: PyTorchJob karta-e2e-pytorch-failed is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      replicaStatuses:
+        Master:
+          selector: training.kubeflow.org/job-name=karta-e2e-pytorch-failed,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=master
+      startTime: "2026-09-09T09:02:26Z"
+  phases:
+  - Initializing
+  resourceVersion: "238424"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-09-09T09:02:26Z"
+      generation: 1
+      name: karta-e2e-pytorch-failed
+      namespace: test-f5v9f
+      uid: 95a2c6df-893e-4b9b-8258-c276e1c019c4
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 15; exit 1
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+    status:
+      conditions:
+      - lastTransitionTime: "2026-09-09T09:02:26Z"
+        lastUpdateTime: "2026-09-09T09:02:26Z"
+        message: PyTorchJob karta-e2e-pytorch-failed is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-09-09T09:02:26Z"
+        lastUpdateTime: "2026-09-09T09:02:26Z"
+        message: PyTorchJob karta-e2e-pytorch-failed is running.
+        reason: PyTorchJobRunning
+        status: "True"
+        type: Running
+      replicaStatuses:
+        Master:
+          active: 1
+          selector: training.kubeflow.org/job-name=karta-e2e-pytorch-failed,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=master
+      startTime: "2026-09-09T09:02:26Z"
+  phases:
+  - Initializing
+  - Running
+  resourceVersion: "238440"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-09-09T09:02:26Z"
+      generation: 1
+      name: karta-e2e-pytorch-failed
+      namespace: test-f5v9f
+      uid: 95a2c6df-893e-4b9b-8258-c276e1c019c4
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 15; exit 1
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+    status:
+      completionTime: "2026-09-09T09:02:43Z"
+      conditions:
+      - lastTransitionTime: "2026-09-09T09:02:26Z"
+        lastUpdateTime: "2026-09-09T09:02:26Z"
+        message: PyTorchJob karta-e2e-pytorch-failed is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-09-09T09:02:26Z"
+        lastUpdateTime: "2026-09-09T09:02:26Z"
+        message: PyTorchJob karta-e2e-pytorch-failed is running.
+        reason: PyTorchJobRunning
+        status: "False"
+        type: Running
+      - lastTransitionTime: "2026-09-09T09:02:43Z"
+        lastUpdateTime: "2026-09-09T09:02:43Z"
+        message: PyTorchJob karta-e2e-pytorch-failed is failed because 1 Master replica(s)
+          failed.
+        reason: PyTorchJobFailed
+        status: "True"
+        type: Failed
+      replicaStatuses:
+        Master:
+          failed: 1
+          selector: training.kubeflow.org/job-name=karta-e2e-pytorch-failed,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=master
+      startTime: "2026-09-09T09:02:26Z"
+  phases:
+  - Initializing
+  - Failed
+  resourceVersion: "238579"
+  state: Failed
+flow: failed
+kartaFile: docs/catalog/kubeflow-org-pytorchjob-v1.yaml
+kartaName: kubeflow-org-pytorchjob-v1
+operator: kubeflow
+result:
+  succeeded: true
+schemaVersion: 1
+summary:
+- amount: 1
+  phases:
+  - Initializing
+- amount: 1
+  phases:
+  - Initializing
+  - Running
+- amount: 1
+  phases:
+  - Initializing
+  - Failed
+version: v1.34.0
+want: Failed

--- a/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-pytorchjob-v1/resumed.yaml
+++ b/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-pytorchjob-v1/resumed.yaml
@@ -1,0 +1,242 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-09-09T09:02:43Z"
+      generation: 1
+      name: karta-e2e-pytorch-resumed
+      namespace: test-f5v9f
+      uid: d9ceae5a-1f4c-4b28-a3fd-958f7440bbd6
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep infinity
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runPolicy:
+        suspend: true
+    status:
+      conditions:
+      - lastTransitionTime: "2026-09-09T09:02:43Z"
+        lastUpdateTime: "2026-09-09T09:02:43Z"
+        message: PyTorchJob karta-e2e-pytorch-resumed is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-09-09T09:02:43Z"
+        lastUpdateTime: "2026-09-09T09:02:43Z"
+        message: PyTorchJob karta-e2e-pytorch-resumed is suspended.
+        reason: PyTorchJobSuspended
+        status: "True"
+        type: Suspended
+  phases:
+  - Initializing
+  - Suspended
+  resourceVersion: "238595"
+  state: Suspended
+- action:
+    name: Resume
+    operation:
+      patchType: application/merge-patch+json
+      payload:
+        spec:
+          runPolicy:
+            suspend: false
+      verb: PATCH
+  kind: ACTION
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-09-09T09:02:43Z"
+      generation: 2
+      name: karta-e2e-pytorch-resumed
+      namespace: test-f5v9f
+      uid: d9ceae5a-1f4c-4b28-a3fd-958f7440bbd6
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep infinity
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runPolicy:
+        suspend: false
+    status:
+      conditions:
+      - lastTransitionTime: "2026-09-09T09:02:43Z"
+        lastUpdateTime: "2026-09-09T09:02:43Z"
+        message: PyTorchJob karta-e2e-pytorch-resumed is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-09-09T09:02:43Z"
+        lastUpdateTime: "2026-09-09T09:02:43Z"
+        message: PyTorchJob karta-e2e-pytorch-resumed is suspended.
+        reason: PyTorchJobSuspended
+        status: "True"
+        type: Suspended
+  phases:
+  - Initializing
+  - Suspended
+  resourceVersion: "238598"
+  state: Suspended
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-09-09T09:02:43Z"
+      generation: 2
+      name: karta-e2e-pytorch-resumed
+      namespace: test-f5v9f
+      uid: d9ceae5a-1f4c-4b28-a3fd-958f7440bbd6
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep infinity
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runPolicy:
+        suspend: false
+    status:
+      conditions:
+      - lastTransitionTime: "2026-09-09T09:02:43Z"
+        lastUpdateTime: "2026-09-09T09:02:43Z"
+        message: PyTorchJob karta-e2e-pytorch-resumed is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-09-09T09:02:43Z"
+        lastUpdateTime: "2026-09-09T09:02:43Z"
+        message: PyTorchJob karta-e2e-pytorch-resumed is resumed.
+        reason: PyTorchJobResumed
+        status: "False"
+        type: Suspended
+      replicaStatuses:
+        Master:
+          selector: training.kubeflow.org/job-name=karta-e2e-pytorch-resumed,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=master
+      startTime: "2026-09-09T09:02:43Z"
+  phases:
+  - Initializing
+  resourceVersion: "238608"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-09-09T09:02:43Z"
+      generation: 2
+      name: karta-e2e-pytorch-resumed
+      namespace: test-f5v9f
+      uid: d9ceae5a-1f4c-4b28-a3fd-958f7440bbd6
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep infinity
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runPolicy:
+        suspend: false
+    status:
+      conditions:
+      - lastTransitionTime: "2026-09-09T09:02:43Z"
+        lastUpdateTime: "2026-09-09T09:02:43Z"
+        message: PyTorchJob karta-e2e-pytorch-resumed is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-09-09T09:02:43Z"
+        lastUpdateTime: "2026-09-09T09:02:43Z"
+        message: PyTorchJob karta-e2e-pytorch-resumed is resumed.
+        reason: PyTorchJobResumed
+        status: "False"
+        type: Suspended
+      - lastTransitionTime: "2026-09-09T09:02:43Z"
+        lastUpdateTime: "2026-09-09T09:02:43Z"
+        message: PyTorchJob karta-e2e-pytorch-resumed is running.
+        reason: PyTorchJobRunning
+        status: "True"
+        type: Running
+      replicaStatuses:
+        Master:
+          active: 1
+          selector: training.kubeflow.org/job-name=karta-e2e-pytorch-resumed,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=master
+      startTime: "2026-09-09T09:02:43Z"
+  phases:
+  - Initializing
+  - Running
+  resourceVersion: "238623"
+  state: Running
+flow: resumed
+kartaFile: docs/catalog/kubeflow-org-pytorchjob-v1.yaml
+kartaName: kubeflow-org-pytorchjob-v1
+operator: kubeflow
+result:
+  succeeded: true
+schemaVersion: 1
+summary:
+- amount: 2
+  phases:
+  - Initializing
+  - Suspended
+- amount: 1
+  phases:
+  - Initializing
+- amount: 1
+  phases:
+  - Initializing
+  - Running
+version: v1.34.0
+want: Running

--- a/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-pytorchjob-v1/running.yaml
+++ b/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-pytorchjob-v1/running.yaml
@@ -1,0 +1,146 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-09-09T09:02:07Z"
+      generation: 1
+      name: karta-e2e-pytorch
+      namespace: test-f5v9f
+      uid: 05d09193-4b0f-4b5c-8793-ac83e8589f54
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+    status:
+      conditions:
+      - lastTransitionTime: "2026-09-09T09:02:07Z"
+        lastUpdateTime: "2026-09-09T09:02:07Z"
+        message: PyTorchJob karta-e2e-pytorch is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      replicaStatuses:
+        Master:
+          selector: training.kubeflow.org/job-name=karta-e2e-pytorch,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=master
+        Worker:
+          selector: training.kubeflow.org/job-name=karta-e2e-pytorch,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=worker
+      startTime: "2026-09-09T09:02:07Z"
+  phases:
+  - Initializing
+  resourceVersion: "238213"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-09-09T09:02:07Z"
+      generation: 1
+      name: karta-e2e-pytorch
+      namespace: test-f5v9f
+      uid: 05d09193-4b0f-4b5c-8793-ac83e8589f54
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+    status:
+      conditions:
+      - lastTransitionTime: "2026-09-09T09:02:07Z"
+        lastUpdateTime: "2026-09-09T09:02:07Z"
+        message: PyTorchJob karta-e2e-pytorch is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-09-09T09:02:08Z"
+        lastUpdateTime: "2026-09-09T09:02:08Z"
+        message: PyTorchJob karta-e2e-pytorch is running.
+        reason: PyTorchJobRunning
+        status: "True"
+        type: Running
+      replicaStatuses:
+        Master:
+          active: 1
+          selector: training.kubeflow.org/job-name=karta-e2e-pytorch,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=master
+        Worker:
+          selector: training.kubeflow.org/job-name=karta-e2e-pytorch,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=worker
+      startTime: "2026-09-09T09:02:07Z"
+  phases:
+  - Initializing
+  - Running
+  resourceVersion: "238236"
+  state: Running
+flow: running
+kartaFile: docs/catalog/kubeflow-org-pytorchjob-v1.yaml
+kartaName: kubeflow-org-pytorchjob-v1
+operator: kubeflow
+result:
+  succeeded: true
+schemaVersion: 1
+summary:
+- amount: 1
+  phases:
+  - Initializing
+- amount: 1
+  phases:
+  - Initializing
+  - Running
+version: v1.34.0
+want: Running

--- a/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-pytorchjob-v1/suspended.yaml
+++ b/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-pytorchjob-v1/suspended.yaml
@@ -1,0 +1,64 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      creationTimestamp: "2026-09-09T09:02:43Z"
+      generation: 1
+      name: karta-e2e-pytorch-suspended
+      namespace: test-f5v9f
+      uid: b917c6a4-85f2-4337-8c52-0777b20bdd64
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: Never
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep infinity
+                image: busybox:1.36
+                name: pytorch
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runPolicy:
+        suspend: true
+    status:
+      conditions:
+      - lastTransitionTime: "2026-09-09T09:02:43Z"
+        lastUpdateTime: "2026-09-09T09:02:43Z"
+        message: PyTorchJob karta-e2e-pytorch-suspended is created.
+        reason: PyTorchJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-09-09T09:02:43Z"
+        lastUpdateTime: "2026-09-09T09:02:43Z"
+        message: PyTorchJob karta-e2e-pytorch-suspended is suspended.
+        reason: PyTorchJobSuspended
+        status: "True"
+        type: Suspended
+  phases:
+  - Initializing
+  - Suspended
+  resourceVersion: "238589"
+  state: Suspended
+flow: suspended
+kartaFile: docs/catalog/kubeflow-org-pytorchjob-v1.yaml
+kartaName: kubeflow-org-pytorchjob-v1
+operator: kubeflow
+result:
+  succeeded: true
+schemaVersion: 1
+summary:
+- amount: 1
+  phases:
+  - Initializing
+  - Suspended
+version: v1.34.0
+want: Suspended

--- a/test/e2e/recorder/flow.go
+++ b/test/e2e/recorder/flow.go
@@ -39,7 +39,10 @@ type journeyStep struct {
 
 type ActionType string
 
-const ActionSuspend ActionType = "Suspend"
+const (
+	ActionSuspend ActionType = "Suspend"
+	ActionResume  ActionType = "Resume"
+)
 
 // Action is a merge-patch applied to the workload to drive a transition.
 type Action struct {


### PR DESCRIPTION
Part of the e2e flow recording stack. Reordered so flows independent of the catalog fix (#262) come before it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for Kubeflow PyTorchJob workflows.
  * Validates running, completed, failed, suspended, and resumed job states.
  * Added scenarios for resuming suspended jobs and verifying successful state transitions.
  * Added test scenarios and recorded results for Kubeflow v1.34.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->