### PR TITLE
test(e2e): add the mpijob flow and its recorded fixtures

### DIFF
--- a/test/e2e/flows/mpijob_test.go
+++ b/test/e2e/flows/mpijob_test.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package flows
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kartav1alpha1 "github.com/run-ai/karta/pkg/api/runai/v1alpha1"
+	"github.com/run-ai/karta/test/e2e/recorder"
+)
+
+var _ = Describe("MPIJob", Ordered, Label("kubeflow", "mpijob"), func() {
+	var rec *recorder.Recorder
+	var fx recorder.Fixture
+
+	BeforeAll(func(ctx SpecContext) {
+		installKarta(ctx, "../../docs/catalog/kubeflow-org-mpijob-v2beta1.yaml", "kubeflow-org-mpijob-v2beta1")
+		fx = recorder.Fixture{Operator: "kubeflow", Version: operatorVersion("kubeflow"), KartaName: "kubeflow-org-mpijob-v2beta1", KartaFile: "docs/catalog/kubeflow-org-mpijob-v2beta1.yaml"}
+		rec = recorder.New(cfg).
+			AddState(kartav1alpha1.InitializingStatus, CondTrue("Created")).
+			AddState(kartav1alpha1.RunningStatus, CondTrue("Running")).
+			AddState(kartav1alpha1.CompletedStatus, CondTrue("Succeeded")).
+			AddState(kartav1alpha1.FailedStatus, CondTrue("Failed")).
+			AddState(kartav1alpha1.SuspendedStatus, CondTrue("Suspended"))
+	})
+
+	It("running", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "running", "testdata/mpijob/running.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	// The launcher can finish before Running is observed (Optional), and Kubeflow keeps Created set so the
+	// CR reads Initializing again for a tick before the terminal.
+	It("completed", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "completed", "testdata/mpijob/completed.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.CompletedStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("failed", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "failed", "testdata/mpijob/failed.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.FailedStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("suspended", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "suspended", "testdata/mpijob/suspended.yaml").
+			Through(recorder.Reaches(kartav1alpha1.SuspendedStatus)).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("resumed", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "resumed", "testdata/mpijob/resumed.yaml").Through(
+			recorder.Reaches(kartav1alpha1.SuspendedStatus).Do(ResumeRunPolicy()),
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+})

--- a/test/e2e/flows/testdata/mpijob/completed.yaml
+++ b/test/e2e/flows/testdata/mpijob/completed.yaml
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A minimal MPIJob (kubeflow.org/v2beta1, served by the mpi-operator). The launcher runs `true`
+# and completes, so the job reaches a stable Succeeded condition on a CPU-only kind cluster.
+# cleanPodPolicy None keeps the worker pod so the component extraction still finds it.
+apiVersion: kubeflow.org/v2beta1
+kind: MPIJob
+metadata:
+  name: karta-e2e-mpi
+  namespace: default
+spec:
+  slotsPerWorker: 1
+  runPolicy:
+    cleanPodPolicy: None
+  mpiReplicaSpecs:
+    Launcher:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: mpi-launcher
+              image: busybox:1.36
+              command: ["true"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}
+    Worker:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: mpi-worker
+              image: busybox:1.36
+              command: ["sleep", "infinity"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}

--- a/test/e2e/flows/testdata/mpijob/failed.yaml
+++ b/test/e2e/flows/testdata/mpijob/failed.yaml
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A minimal MPIJob (kubeflow.org/v2beta1) whose launcher runs `false` and exits non-zero.
+# With backoffLimit 0 the mpi-operator gives up after the first failure and marks the job
+# Failed on a CPU-only kind cluster. cleanPodPolicy None keeps the worker pod for extraction.
+apiVersion: kubeflow.org/v2beta1
+kind: MPIJob
+metadata:
+  name: karta-e2e-mpi-failed
+  namespace: default
+spec:
+  slotsPerWorker: 1
+  runPolicy:
+    cleanPodPolicy: None
+    backoffLimit: 0
+  mpiReplicaSpecs:
+    Launcher:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: mpi-launcher
+              image: busybox:1.36
+              command: ["false"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}
+    Worker:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: mpi-worker
+              image: busybox:1.36
+              command: ["sleep", "infinity"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}

--- a/test/e2e/flows/testdata/mpijob/resumed.yaml
+++ b/test/e2e/flows/testdata/mpijob/resumed.yaml
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# An MPIJob created suspended (runPolicy.suspend true), then resumed by the e2e action clearing
+# spec.runPolicy.suspend. The launcher then sleeps and the mpi-operator marks it Running. The resumed
+# flow records Suspended -> Running.
+apiVersion: kubeflow.org/v2beta1
+kind: MPIJob
+metadata:
+  name: karta-e2e-mpi-resumed
+  namespace: default
+spec:
+  slotsPerWorker: 1
+  runPolicy:
+    cleanPodPolicy: None
+    suspend: true
+  mpiReplicaSpecs:
+    Launcher:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: mpi-launcher
+              image: busybox:1.36
+              command: ["sh", "-c", "sleep 300"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}
+    Worker:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: mpi-worker
+              image: busybox:1.36
+              command: ["sleep", "infinity"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}

--- a/test/e2e/flows/testdata/mpijob/running.yaml
+++ b/test/e2e/flows/testdata/mpijob/running.yaml
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# An MPIJob whose launcher sleeps for 5 minutes, so the mpi-operator holds it in the Running condition
+# long enough to record before it would finish. cleanPodPolicy None keeps the worker pod for extraction.
+apiVersion: kubeflow.org/v2beta1
+kind: MPIJob
+metadata:
+  name: karta-e2e-mpi-running
+  namespace: default
+spec:
+  slotsPerWorker: 1
+  runPolicy:
+    cleanPodPolicy: None
+  mpiReplicaSpecs:
+    Launcher:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: mpi-launcher
+              image: busybox:1.36
+              command: ["sh", "-c", "sleep 300"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}
+    Worker:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: mpi-worker
+              image: busybox:1.36
+              command: ["sleep", "infinity"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}

--- a/test/e2e/flows/testdata/mpijob/suspended.yaml
+++ b/test/e2e/flows/testdata/mpijob/suspended.yaml
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# An MPIJob created suspended (runPolicy.suspend true). The mpi-operator creates no pods and sets the
+# Suspended condition, which the definition reads as Suspended. Karta must read it as Suspended.
+apiVersion: kubeflow.org/v2beta1
+kind: MPIJob
+metadata:
+  name: karta-e2e-mpi-suspended
+  namespace: default
+spec:
+  slotsPerWorker: 1
+  runPolicy:
+    cleanPodPolicy: None
+    suspend: true
+  mpiReplicaSpecs:
+    Launcher:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: mpi-launcher
+              image: busybox:1.36
+              command: ["true"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}
+    Worker:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: mpi-worker
+              image: busybox:1.36
+              command: ["sleep", "infinity"]
+              resources:
+                requests: {cpu: 50m, memory: 64Mi}

--- a/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-mpijob-v2beta1/completed.yaml
+++ b/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-mpijob-v2beta1/completed.yaml
@@ -1,0 +1,224 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-09-09T10:35:19Z"
+      generation: 1
+      name: karta-e2e-mpi
+      namespace: test-dgxjr
+      uid: 71dd71be-5ad5-461a-9997-bf0593a18bb6
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - "true"
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-09-09T10:35:19Z"
+        lastUpdateTime: "2026-09-09T10:35:19Z"
+        message: MPIJob test-dgxjr/karta-e2e-mpi is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      replicaStatuses:
+        Launcher: {}
+        Worker: {}
+      startTime: "2026-09-09T10:35:19Z"
+  phases:
+  - Initializing
+  resourceVersion: "281060"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-09-09T10:35:19Z"
+      generation: 1
+      name: karta-e2e-mpi
+      namespace: test-dgxjr
+      uid: 71dd71be-5ad5-461a-9997-bf0593a18bb6
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - "true"
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-09-09T10:35:19Z"
+        lastUpdateTime: "2026-09-09T10:35:19Z"
+        message: MPIJob test-dgxjr/karta-e2e-mpi is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      replicaStatuses:
+        Launcher: {}
+        Worker:
+          active: 1
+      startTime: "2026-09-09T10:35:19Z"
+  phases:
+  - Initializing
+  resourceVersion: "281093"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-09-09T10:35:19Z"
+      generation: 1
+      name: karta-e2e-mpi
+      namespace: test-dgxjr
+      uid: 71dd71be-5ad5-461a-9997-bf0593a18bb6
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - "true"
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      completionTime: "2026-09-09T10:35:22Z"
+      conditions:
+      - lastTransitionTime: "2026-09-09T10:35:19Z"
+        lastUpdateTime: "2026-09-09T10:35:19Z"
+        message: MPIJob test-dgxjr/karta-e2e-mpi is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-09-09T10:35:22Z"
+        lastUpdateTime: "2026-09-09T10:35:22Z"
+        message: MPIJob test-dgxjr/karta-e2e-mpi successfully completed.
+        reason: MPIJobSucceeded
+        status: "True"
+        type: Succeeded
+      - lastTransitionTime: "2026-09-09T10:35:22Z"
+        lastUpdateTime: "2026-09-09T10:35:22Z"
+        message: MPIJob test-dgxjr/karta-e2e-mpi is finished but Running condition
+          was never set.
+        reason: MPIJobRunning
+        status: "False"
+        type: Running
+      replicaStatuses:
+        Launcher:
+          succeeded: 1
+        Worker: {}
+      startTime: "2026-09-09T10:35:19Z"
+  phases:
+  - Initializing
+  - Completed
+  resourceVersion: "281122"
+  state: Completed
+flow: completed
+kartaFile: docs/catalog/kubeflow-org-mpijob-v2beta1.yaml
+kartaName: kubeflow-org-mpijob-v2beta1
+operator: kubeflow
+result:
+  succeeded: true
+schemaVersion: 1
+summary:
+- amount: 2
+  phases:
+  - Initializing
+- amount: 1
+  phases:
+  - Initializing
+  - Completed
+version: v1.34.0
+want: Completed

--- a/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-mpijob-v2beta1/failed.yaml
+++ b/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-mpijob-v2beta1/failed.yaml
@@ -1,0 +1,385 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-09-09T10:35:23Z"
+      generation: 1
+      name: karta-e2e-mpi-failed
+      namespace: test-dgxjr
+      uid: d4af6aa1-b63a-4e7e-817f-c6bbfdbc1a1e
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - "false"
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        backoffLimit: 0
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-09-09T10:35:23Z"
+        lastUpdateTime: "2026-09-09T10:35:23Z"
+        message: MPIJob test-dgxjr/karta-e2e-mpi-failed is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      replicaStatuses:
+        Launcher: {}
+        Worker: {}
+      startTime: "2026-09-09T10:35:23Z"
+  phases:
+  - Initializing
+  resourceVersion: "281146"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-09-09T10:35:23Z"
+      generation: 1
+      name: karta-e2e-mpi-failed
+      namespace: test-dgxjr
+      uid: d4af6aa1-b63a-4e7e-817f-c6bbfdbc1a1e
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - "false"
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        backoffLimit: 0
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-09-09T10:35:23Z"
+        lastUpdateTime: "2026-09-09T10:35:23Z"
+        message: MPIJob test-dgxjr/karta-e2e-mpi-failed is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-09-09T10:35:23Z"
+        lastUpdateTime: "2026-09-09T10:35:23Z"
+        message: MPIJob test-dgxjr/karta-e2e-mpi-failed is running.
+        reason: MPIJobRunning
+        status: "True"
+        type: Running
+      replicaStatuses:
+        Launcher:
+          active: 1
+        Worker:
+          active: 1
+      startTime: "2026-09-09T10:35:23Z"
+  phases:
+  - Initializing
+  - Running
+  resourceVersion: "281173"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-09-09T10:35:23Z"
+      generation: 1
+      name: karta-e2e-mpi-failed
+      namespace: test-dgxjr
+      uid: d4af6aa1-b63a-4e7e-817f-c6bbfdbc1a1e
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - "false"
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        backoffLimit: 0
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-09-09T10:35:23Z"
+        lastUpdateTime: "2026-09-09T10:35:23Z"
+        message: MPIJob test-dgxjr/karta-e2e-mpi-failed is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-09-09T10:35:23Z"
+        lastUpdateTime: "2026-09-09T10:35:23Z"
+        message: MPIJob test-dgxjr/karta-e2e-mpi-failed is running.
+        reason: MPIJobRunning
+        status: "True"
+        type: Running
+      replicaStatuses:
+        Launcher:
+          active: 1
+          failed: 1
+        Worker:
+          active: 1
+      startTime: "2026-09-09T10:35:23Z"
+  phases:
+  - Initializing
+  - Running
+  resourceVersion: "281206"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-09-09T10:35:23Z"
+      generation: 1
+      name: karta-e2e-mpi-failed
+      namespace: test-dgxjr
+      uid: d4af6aa1-b63a-4e7e-817f-c6bbfdbc1a1e
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - "false"
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        backoffLimit: 0
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-09-09T10:35:23Z"
+        lastUpdateTime: "2026-09-09T10:35:23Z"
+        message: MPIJob test-dgxjr/karta-e2e-mpi-failed is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-09-09T10:35:23Z"
+        lastUpdateTime: "2026-09-09T10:35:23Z"
+        message: MPIJob test-dgxjr/karta-e2e-mpi-failed is running.
+        reason: MPIJobRunning
+        status: "True"
+        type: Running
+      replicaStatuses:
+        Launcher:
+          failed: 1
+        Worker:
+          active: 1
+      startTime: "2026-09-09T10:35:23Z"
+  phases:
+  - Initializing
+  - Running
+  resourceVersion: "281212"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-09-09T10:35:23Z"
+      generation: 1
+      name: karta-e2e-mpi-failed
+      namespace: test-dgxjr
+      uid: d4af6aa1-b63a-4e7e-817f-c6bbfdbc1a1e
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - "false"
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        backoffLimit: 0
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      completionTime: "2026-09-09T10:35:26Z"
+      conditions:
+      - lastTransitionTime: "2026-09-09T10:35:23Z"
+        lastUpdateTime: "2026-09-09T10:35:23Z"
+        message: MPIJob test-dgxjr/karta-e2e-mpi-failed is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-09-09T10:35:23Z"
+        lastUpdateTime: "2026-09-09T10:35:23Z"
+        message: MPIJob test-dgxjr/karta-e2e-mpi-failed is running.
+        reason: MPIJobRunning
+        status: "False"
+        type: Running
+      - lastTransitionTime: "2026-09-09T10:35:26Z"
+        lastUpdateTime: "2026-09-09T10:35:26Z"
+        message: Job has reached the specified backoff limit
+        reason: BackoffLimitExceeded
+        status: "True"
+        type: Failed
+      replicaStatuses:
+        Launcher:
+          failed: 1
+        Worker: {}
+      startTime: "2026-09-09T10:35:23Z"
+  phases:
+  - Initializing
+  - Failed
+  resourceVersion: "281226"
+  state: Failed
+flow: failed
+kartaFile: docs/catalog/kubeflow-org-mpijob-v2beta1.yaml
+kartaName: kubeflow-org-mpijob-v2beta1
+operator: kubeflow
+result:
+  succeeded: true
+schemaVersion: 1
+summary:
+- amount: 1
+  phases:
+  - Initializing
+- amount: 3
+  phases:
+  - Initializing
+  - Running
+- amount: 1
+  phases:
+  - Initializing
+  - Failed
+version: v1.34.0
+want: Failed

--- a/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-mpijob-v2beta1/resumed.yaml
+++ b/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-mpijob-v2beta1/resumed.yaml
@@ -1,0 +1,343 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-09-09T10:35:26Z"
+      generation: 1
+      name: karta-e2e-mpi-resumed
+      namespace: test-dgxjr
+      uid: bfe68c78-3744-4c9b-8f74-b5f6e4c41017
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 300
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        cleanPodPolicy: None
+        suspend: true
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-09-09T10:35:26Z"
+        lastUpdateTime: "2026-09-09T10:35:26Z"
+        message: MPIJob test-dgxjr/karta-e2e-mpi-resumed is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-09-09T10:35:27Z"
+        lastUpdateTime: "2026-09-09T10:35:27Z"
+        message: MPIJob suspended
+        reason: MPIJobSuspended
+        status: "True"
+        type: Suspended
+      - lastTransitionTime: "2026-09-09T10:35:27Z"
+        lastUpdateTime: "2026-09-09T10:35:27Z"
+        message: MPIJob test-dgxjr/karta-e2e-mpi-resumed is suspended.
+        reason: MPIJobSuspended
+        status: "False"
+        type: Running
+      replicaStatuses:
+        Launcher: {}
+        Worker: {}
+  phases:
+  - Initializing
+  - Suspended
+  resourceVersion: "281270"
+  state: Suspended
+- action:
+    name: Resume
+    operation:
+      patchType: application/merge-patch+json
+      payload:
+        spec:
+          runPolicy:
+            suspend: false
+      verb: PATCH
+  kind: ACTION
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-09-09T10:35:26Z"
+      generation: 2
+      name: karta-e2e-mpi-resumed
+      namespace: test-dgxjr
+      uid: bfe68c78-3744-4c9b-8f74-b5f6e4c41017
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 300
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-09-09T10:35:26Z"
+        lastUpdateTime: "2026-09-09T10:35:26Z"
+        message: MPIJob test-dgxjr/karta-e2e-mpi-resumed is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-09-09T10:35:27Z"
+        lastUpdateTime: "2026-09-09T10:35:27Z"
+        message: MPIJob suspended
+        reason: MPIJobSuspended
+        status: "True"
+        type: Suspended
+      - lastTransitionTime: "2026-09-09T10:35:27Z"
+        lastUpdateTime: "2026-09-09T10:35:27Z"
+        message: MPIJob test-dgxjr/karta-e2e-mpi-resumed is suspended.
+        reason: MPIJobSuspended
+        status: "False"
+        type: Running
+      replicaStatuses:
+        Launcher: {}
+        Worker: {}
+  phases:
+  - Initializing
+  - Suspended
+  resourceVersion: "281273"
+  state: Suspended
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-09-09T10:35:26Z"
+      generation: 2
+      name: karta-e2e-mpi-resumed
+      namespace: test-dgxjr
+      uid: bfe68c78-3744-4c9b-8f74-b5f6e4c41017
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 300
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-09-09T10:35:26Z"
+        lastUpdateTime: "2026-09-09T10:35:26Z"
+        message: MPIJob test-dgxjr/karta-e2e-mpi-resumed is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-09-09T10:35:27Z"
+        lastUpdateTime: "2026-09-09T10:35:27Z"
+        message: MPIJob test-dgxjr/karta-e2e-mpi-resumed is suspended.
+        reason: MPIJobSuspended
+        status: "False"
+        type: Running
+      - lastTransitionTime: "2026-09-09T10:35:27Z"
+        lastUpdateTime: "2026-09-09T10:35:27Z"
+        message: MPIJob resumed
+        reason: MPIJobResumed
+        status: "False"
+        type: Suspended
+      replicaStatuses:
+        Launcher: {}
+        Worker: {}
+      startTime: "2026-09-09T10:35:27Z"
+  phases:
+  - Initializing
+  resourceVersion: "281282"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-09-09T10:35:26Z"
+      generation: 2
+      name: karta-e2e-mpi-resumed
+      namespace: test-dgxjr
+      uid: bfe68c78-3744-4c9b-8f74-b5f6e4c41017
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 300
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-09-09T10:35:26Z"
+        lastUpdateTime: "2026-09-09T10:35:26Z"
+        message: MPIJob test-dgxjr/karta-e2e-mpi-resumed is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-09-09T10:35:27Z"
+        lastUpdateTime: "2026-09-09T10:35:27Z"
+        message: MPIJob resumed
+        reason: MPIJobResumed
+        status: "False"
+        type: Suspended
+      - lastTransitionTime: "2026-09-09T10:35:28Z"
+        lastUpdateTime: "2026-09-09T10:35:28Z"
+        message: MPIJob test-dgxjr/karta-e2e-mpi-resumed is running.
+        reason: MPIJobRunning
+        status: "True"
+        type: Running
+      replicaStatuses:
+        Launcher:
+          active: 1
+        Worker:
+          active: 1
+      startTime: "2026-09-09T10:35:27Z"
+  phases:
+  - Initializing
+  - Running
+  resourceVersion: "281312"
+  state: Running
+flow: resumed
+kartaFile: docs/catalog/kubeflow-org-mpijob-v2beta1.yaml
+kartaName: kubeflow-org-mpijob-v2beta1
+operator: kubeflow
+result:
+  succeeded: true
+schemaVersion: 1
+summary:
+- amount: 2
+  phases:
+  - Initializing
+  - Suspended
+- amount: 1
+  phases:
+  - Initializing
+- amount: 1
+  phases:
+  - Initializing
+  - Running
+version: v1.34.0
+want: Running

--- a/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-mpijob-v2beta1/running.yaml
+++ b/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-mpijob-v2beta1/running.yaml
@@ -1,0 +1,157 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-09-09T10:35:19Z"
+      generation: 1
+      name: karta-e2e-mpi-running
+      namespace: test-dgxjr
+      uid: 6de254ad-660d-4d9f-ab6f-8dbc524f3037
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 300
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-09-09T10:35:19Z"
+        lastUpdateTime: "2026-09-09T10:35:19Z"
+        message: MPIJob test-dgxjr/karta-e2e-mpi-running is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      replicaStatuses:
+        Launcher: {}
+        Worker: {}
+      startTime: "2026-09-09T10:35:19Z"
+  phases:
+  - Initializing
+  resourceVersion: "281013"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-09-09T10:35:19Z"
+      generation: 1
+      name: karta-e2e-mpi-running
+      namespace: test-dgxjr
+      uid: 6de254ad-660d-4d9f-ab6f-8dbc524f3037
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sh
+                - -c
+                - sleep 300
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        cleanPodPolicy: None
+        suspend: false
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-09-09T10:35:19Z"
+        lastUpdateTime: "2026-09-09T10:35:19Z"
+        message: MPIJob test-dgxjr/karta-e2e-mpi-running is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-09-09T10:35:19Z"
+        lastUpdateTime: "2026-09-09T10:35:19Z"
+        message: MPIJob test-dgxjr/karta-e2e-mpi-running is running.
+        reason: MPIJobRunning
+        status: "True"
+        type: Running
+      replicaStatuses:
+        Launcher:
+          active: 1
+        Worker:
+          active: 1
+      startTime: "2026-09-09T10:35:19Z"
+  phases:
+  - Initializing
+  - Running
+  resourceVersion: "281036"
+  state: Running
+flow: running
+kartaFile: docs/catalog/kubeflow-org-mpijob-v2beta1.yaml
+kartaName: kubeflow-org-mpijob-v2beta1
+operator: kubeflow
+result:
+  succeeded: true
+schemaVersion: 1
+summary:
+- amount: 1
+  phases:
+  - Initializing
+- amount: 1
+  phases:
+  - Initializing
+  - Running
+version: v1.34.0
+want: Running

--- a/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-mpijob-v2beta1/suspended.yaml
+++ b/test/e2e/recorded_data/kubeflow/v1.34.0/kubeflow-org-mpijob-v2beta1/suspended.yaml
@@ -1,0 +1,90 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+    metadata:
+      creationTimestamp: "2026-09-09T10:35:26Z"
+      generation: 1
+      name: karta-e2e-mpi-suspended
+      namespace: test-dgxjr
+      uid: 2055005f-fe44-463c-a6f0-ba0adc0c4fd2
+    spec:
+      launcherCreationPolicy: AtStartup
+      mpiImplementation: OpenMPI
+      mpiReplicaSpecs:
+        Launcher:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - "true"
+                image: busybox:1.36
+                name: mpi-launcher
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+        Worker:
+          replicas: 1
+          template:
+            spec:
+              containers:
+              - command:
+                - sleep
+                - infinity
+                image: busybox:1.36
+                name: mpi-worker
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+      runLauncherAsWorker: false
+      runPolicy:
+        cleanPodPolicy: None
+        suspend: true
+      slotsPerWorker: 1
+      sshAuthMountPath: /root/.ssh
+    status:
+      conditions:
+      - lastTransitionTime: "2026-09-09T10:35:26Z"
+        lastUpdateTime: "2026-09-09T10:35:26Z"
+        message: MPIJob test-dgxjr/karta-e2e-mpi-suspended is created.
+        reason: MPIJobCreated
+        status: "True"
+        type: Created
+      - lastTransitionTime: "2026-09-09T10:35:26Z"
+        lastUpdateTime: "2026-09-09T10:35:26Z"
+        message: MPIJob suspended
+        reason: MPIJobSuspended
+        status: "True"
+        type: Suspended
+      - lastTransitionTime: "2026-09-09T10:35:26Z"
+        lastUpdateTime: "2026-09-09T10:35:26Z"
+        message: MPIJob test-dgxjr/karta-e2e-mpi-suspended is suspended.
+        reason: MPIJobSuspended
+        status: "False"
+        type: Running
+      replicaStatuses:
+        Launcher: {}
+        Worker: {}
+  phases:
+  - Initializing
+  - Suspended
+  resourceVersion: "281248"
+  state: Suspended
+flow: suspended
+kartaFile: docs/catalog/kubeflow-org-mpijob-v2beta1.yaml
+kartaName: kubeflow-org-mpijob-v2beta1
+operator: kubeflow
+result:
+  succeeded: true
+schemaVersion: 1
+summary:
+- amount: 1
+  phases:
+  - Initializing
+  - Suspended
+version: v1.34.0
+want: Suspended


### PR DESCRIPTION
Part of the e2e flow recording stack. Reordered so flows independent of the catalog fix (#262) come before it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for MPIJob lifecycle states, including running, completed, failed, suspended, and resumed workflows.
  * Added test scenarios covering successful execution, failures, suspension behavior, and resumption.
  * Added recorded test data for Kubeflow MPIJob resources across supported lifecycle transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->