### PR TITLE
test(e2e): add the grove flow and its recorded fixtures

### DIFF
--- a/test/e2e/flows/actions.go
+++ b/test/e2e/flows/actions.go
@@ -4,6 +4,8 @@
 package flows
 
 import (
+	"fmt"
+
 	"github.com/run-ai/karta/test/e2e/recorder"
 )
 
@@ -19,4 +21,10 @@ func Suspend() *recorder.Action {
 // suspend flag, unlike the top-level spec.suspend that a plain resume patches.
 func ResumeRunPolicy() *recorder.Action {
 	return &recorder.Action{Type: recorder.ActionResume, Patch: []byte(`{"spec":{"runPolicy":{"suspend":false}}}`)}
+}
+
+// ScaleReplicas sets spec.replicas, for any workload with a scalar replica count (Deployment,
+// StatefulSet, LeaderWorkerSet, Grove, ...).
+func ScaleReplicas(n int) *recorder.Action {
+	return &recorder.Action{Type: recorder.ActionScale, Patch: []byte(fmt.Sprintf(`{"spec":{"replicas":%d}}`, n))}
 }

--- a/test/e2e/flows/grove_test.go
+++ b/test/e2e/flows/grove_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package flows
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kartav1alpha1 "github.com/run-ai/karta/pkg/api/runai/v1alpha1"
+	"github.com/run-ai/karta/test/e2e/recorder"
+)
+
+var _ = Describe("Grove PodCliqueSet", Ordered, Label("grove"), func() {
+	var rec *recorder.Recorder
+	var fx recorder.Fixture
+
+	BeforeAll(func(ctx SpecContext) {
+		installKarta(ctx, "../../docs/catalog/grove-io-podcliqueset-v1alpha1.yaml", "grove-io-podcliqueset-v1alpha1")
+		fx = recorder.Fixture{Operator: "grove", Version: operatorVersion("grove"), KartaName: "grove-io-podcliqueset-v1alpha1", KartaFile: "docs/catalog/grove-io-podcliqueset-v1alpha1.yaml"}
+		rec = recorder.New(cfg).
+			SetTimeout(4*time.Minute).
+			AddState(kartav1alpha1.InitializingStatus, ReplicasComingUp()).
+			AddState(kartav1alpha1.RunningStatus, AllReplicasAvailable())
+	})
+
+	It("running", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "running", "testdata/grove/running.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus),
+			recorder.Reaches(kartav1alpha1.RunningStatus),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("initializing", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "initializing", "testdata/grove/initializing.yaml").Through(recorder.Reaches(kartav1alpha1.InitializingStatus)).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+
+	It("scaled", func(ctx SpecContext) {
+		out, err := recorder.NewFlow(rec, "scaled", "testdata/grove/scaled.yaml").Through(
+			recorder.Reaches(kartav1alpha1.InitializingStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.RunningStatus).With(IntEq(1, "status", "availableReplicas")).Do(ScaleReplicas(2)),
+			recorder.Reaches(kartav1alpha1.InitializingStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.RunningStatus).With(IntEq(2, "status", "availableReplicas")).Do(ScaleReplicas(1)),
+			recorder.Reaches(kartav1alpha1.InitializingStatus).Optional(),
+			recorder.Reaches(kartav1alpha1.RunningStatus).With(IntEq(1, "status", "availableReplicas")),
+		).Run(ctx)
+		Expect(rec.Save(fx, out)).Error().NotTo(HaveOccurred())
+		Expect(err).To(Succeed())
+	})
+})

--- a/test/e2e/flows/testdata/grove/initializing.yaml
+++ b/test/e2e/flows/testdata/grove/initializing.yaml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A Grove PodCliqueSet whose clique references a nonexistent image tag, so its pods stay in
+# ImagePullBackOff and never become available. The operator keeps status.availableReplicas
+# below spec.replicas, which the definition reads as Initializing - a workload still coming
+# up (here, permanently). Karta must read it as Initializing, not Running.
+apiVersion: grove.io/v1alpha1
+kind: PodCliqueSet
+metadata:
+  name: karta-e2e-grove-initializing
+  namespace: default
+spec:
+  replicas: 1
+  template:
+    cliques:
+      - name: worker
+        spec:
+          roleName: worker
+          replicas: 2
+          podSpec:
+            containers:
+              - name: worker
+                image: busybox:99.99.99
+                command: ["/bin/sh", "-c", "echo karta-e2e-grove && sleep infinity"]
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi

--- a/test/e2e/flows/testdata/grove/running.yaml
+++ b/test/e2e/flows/testdata/grove/running.yaml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A real Grove PodCliqueSet driven by the Grove operator (installed by
+# hack/e2e/up.sh alongside kai-scheduler). The operator creates the clique's
+# pods and reports availableReplicas once they are running; the test waits for
+# that. Kept tiny (busybox sleeping) so it runs CPU-only on local kind.
+apiVersion: grove.io/v1alpha1
+kind: PodCliqueSet
+metadata:
+  name: karta-e2e-grove
+  namespace: default
+spec:
+  replicas: 1
+  template:
+    cliques:
+      - name: worker
+        spec:
+          roleName: worker
+          replicas: 2
+          podSpec:
+            containers:
+              - name: worker
+                image: busybox:1.36
+                command: ["/bin/sh", "-c", "echo karta-e2e-grove && sleep infinity"]
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi

--- a/test/e2e/flows/testdata/grove/scaled.yaml
+++ b/test/e2e/flows/testdata/grove/scaled.yaml
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# A Grove PodCliqueSet the scaled flow drives 1 -> 2 -> 1 replicas (spec.replicas). Each replica is a
+# full worker clique; status.availableReplicas tracks how many are up. The definition reads Running
+# once availableReplicas >= spec.replicas. Karta reads Running at each settled count, extraction differs.
+apiVersion: grove.io/v1alpha1
+kind: PodCliqueSet
+metadata:
+  name: karta-e2e-grove-scaled
+  namespace: default
+spec:
+  replicas: 1
+  template:
+    cliques:
+      - name: worker
+        spec:
+          roleName: worker
+          replicas: 2
+          podSpec:
+            containers:
+              - name: worker
+                image: busybox:1.36
+                command: ["/bin/sh", "-c", "echo karta-e2e-grove && sleep infinity"]
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi

--- a/test/e2e/recorded_data/grove/v1.34.0/grove-io-podcliqueset-v1alpha1/initializing.yaml
+++ b/test/e2e/recorded_data/grove/v1.34.0/grove-io-podcliqueset-v1alpha1/initializing.yaml
@@ -1,0 +1,55 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-09-09T11:02:55Z"
+      generation: 1
+      name: karta-e2e-grove-initializing
+      namespace: test-rsskf
+      uid: 4be6b242-6fbd-4ec1-9357-090ff6c18f43
+    spec:
+      replicas: 1
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:99.99.99
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+  phases:
+  - Initializing
+  resourceVersion: "294033"
+  state: Initializing
+flow: initializing
+kartaFile: docs/catalog/grove-io-podcliqueset-v1alpha1.yaml
+kartaName: grove-io-podcliqueset-v1alpha1
+operator: grove
+result:
+  succeeded: true
+schemaVersion: 1
+summary:
+- amount: 1
+  phases:
+  - Initializing
+version: v1.34.0
+want: Initializing

--- a/test/e2e/recorded_data/grove/v1.34.0/grove-io-podcliqueset-v1alpha1/running.yaml
+++ b/test/e2e/recorded_data/grove/v1.34.0/grove-io-podcliqueset-v1alpha1/running.yaml
@@ -1,0 +1,362 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-09-09T11:02:54Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 1
+      name: karta-e2e-grove
+      namespace: test-rsskf
+      uid: fe565981-9362-41ef-8018-039463f179c8
+    spec:
+      replicas: 1
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+  phases:
+  - Initializing
+  resourceVersion: "293952"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-09-09T11:02:54Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 1
+      name: karta-e2e-grove
+      namespace: test-rsskf
+      uid: fe565981-9362-41ef-8018-039463f179c8
+    spec:
+      replicas: 1
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+    status:
+      availableReplicas: 0
+      currentGenerationHash: fcd7c86f456f9f449b
+      updatedReplicas: 0
+  phases:
+  - Initializing
+  resourceVersion: "293953"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-09-09T11:02:54Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 1
+      name: karta-e2e-grove
+      namespace: test-rsskf
+      uid: fe565981-9362-41ef-8018-039463f179c8
+    spec:
+      replicas: 1
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+    status:
+      availableReplicas: 0
+      currentGenerationHash: fcd7c86f456f9f449b
+      lastErrors:
+      - code: ERR_SYNC_ROLEBINDING
+        description: 'failed to sync RoleBinding: [Operation: Sync, Code: ERR_SYNC_ROLEBINDING]
+          message: Error syncing RoleBinding: test-rsskf/grove.io:pcs:karta-e2e-grove
+          for PodCliqueSet: test-rsskf/karta-e2e-grove, cause: rolebindings.rbac.authorization.k8s.io
+          "grove.io:pcs:karta-e2e-grove" not found'
+        observedAt: "2026-09-09T11:02:54Z"
+      updatedReplicas: 0
+  phases:
+  - Initializing
+  resourceVersion: "293963"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-09-09T11:02:54Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 1
+      name: karta-e2e-grove
+      namespace: test-rsskf
+      uid: fe565981-9362-41ef-8018-039463f179c8
+    spec:
+      replicas: 1
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+    status:
+      availableReplicas: 0
+      currentGenerationHash: fcd7c86f456f9f449b
+      lastErrors:
+      - code: ERR_SYNC_ROLEBINDING
+        description: 'failed to sync RoleBinding: [Operation: Sync, Code: ERR_SYNC_ROLEBINDING]
+          message: Error syncing RoleBinding: test-rsskf/grove.io:pcs:karta-e2e-grove
+          for PodCliqueSet: test-rsskf/karta-e2e-grove, cause: rolebindings.rbac.authorization.k8s.io
+          "grove.io:pcs:karta-e2e-grove" not found'
+        observedAt: "2026-09-09T11:02:54Z"
+      replicas: 1
+      updatedReplicas: 0
+  phases:
+  - Initializing
+  resourceVersion: "293964"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-09-09T11:02:54Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 1
+      name: karta-e2e-grove
+      namespace: test-rsskf
+      uid: fe565981-9362-41ef-8018-039463f179c8
+    spec:
+      replicas: 1
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+    status:
+      availableReplicas: 0
+      currentGenerationHash: fcd7c86f456f9f449b
+      replicas: 1
+      updatedReplicas: 0
+  phases:
+  - Initializing
+  resourceVersion: "293977"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-09-09T11:02:54Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 1
+      name: karta-e2e-grove
+      namespace: test-rsskf
+      uid: fe565981-9362-41ef-8018-039463f179c8
+    spec:
+      replicas: 1
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+    status:
+      availableReplicas: 0
+      currentGenerationHash: fcd7c86f456f9f449b
+      observedGeneration: 1
+      replicas: 1
+      updatedReplicas: 0
+  phases:
+  - Initializing
+  resourceVersion: "293992"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-09-09T11:02:54Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 1
+      name: karta-e2e-grove
+      namespace: test-rsskf
+      uid: fe565981-9362-41ef-8018-039463f179c8
+    spec:
+      replicas: 1
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+    status:
+      availableReplicas: 1
+      currentGenerationHash: fcd7c86f456f9f449b
+      observedGeneration: 1
+      replicas: 1
+      updatedReplicas: 1
+  phases:
+  - Running
+  resourceVersion: "294027"
+  state: Running
+flow: running
+kartaFile: docs/catalog/grove-io-podcliqueset-v1alpha1.yaml
+kartaName: grove-io-podcliqueset-v1alpha1
+operator: grove
+result:
+  succeeded: true
+schemaVersion: 1
+summary:
+- amount: 6
+  phases:
+  - Initializing
+- amount: 1
+  phases:
+  - Running
+version: v1.34.0
+want: Running

--- a/test/e2e/recorded_data/grove/v1.34.0/grove-io-podcliqueset-v1alpha1/scaled.yaml
+++ b/test/e2e/recorded_data/grove/v1.34.0/grove-io-podcliqueset-v1alpha1/scaled.yaml
@@ -1,0 +1,732 @@
+events:
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-09-09T11:02:55Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 1
+      name: karta-e2e-grove-scaled
+      namespace: test-rsskf
+      uid: d89e702d-281d-405c-8af1-3140458abd09
+    spec:
+      replicas: 1
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+  phases:
+  - Initializing
+  resourceVersion: "294049"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-09-09T11:02:55Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 1
+      name: karta-e2e-grove-scaled
+      namespace: test-rsskf
+      uid: d89e702d-281d-405c-8af1-3140458abd09
+    spec:
+      replicas: 1
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+    status:
+      availableReplicas: 0
+      currentGenerationHash: fcd7c86f456f9f449b
+      updatedReplicas: 0
+  phases:
+  - Initializing
+  resourceVersion: "294050"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-09-09T11:02:55Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 1
+      name: karta-e2e-grove-scaled
+      namespace: test-rsskf
+      uid: d89e702d-281d-405c-8af1-3140458abd09
+    spec:
+      replicas: 1
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+    status:
+      availableReplicas: 0
+      currentGenerationHash: fcd7c86f456f9f449b
+      lastErrors:
+      - code: ERR_SYNC_ROLEBINDING
+        description: 'failed to sync RoleBinding: [Operation: Sync, Code: ERR_SYNC_ROLEBINDING]
+          message: Error syncing RoleBinding: test-rsskf/grove.io:pcs:karta-e2e-grove-scaled
+          for PodCliqueSet: test-rsskf/karta-e2e-grove-scaled, cause: rolebindings.rbac.authorization.k8s.io
+          "grove.io:pcs:karta-e2e-grove-scaled" not found'
+        observedAt: "2026-09-09T11:02:55Z"
+      updatedReplicas: 0
+  phases:
+  - Initializing
+  resourceVersion: "294059"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-09-09T11:02:55Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 1
+      name: karta-e2e-grove-scaled
+      namespace: test-rsskf
+      uid: d89e702d-281d-405c-8af1-3140458abd09
+    spec:
+      replicas: 1
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+    status:
+      availableReplicas: 0
+      currentGenerationHash: fcd7c86f456f9f449b
+      lastErrors:
+      - code: ERR_SYNC_ROLEBINDING
+        description: 'failed to sync RoleBinding: [Operation: Sync, Code: ERR_SYNC_ROLEBINDING]
+          message: Error syncing RoleBinding: test-rsskf/grove.io:pcs:karta-e2e-grove-scaled
+          for PodCliqueSet: test-rsskf/karta-e2e-grove-scaled, cause: rolebindings.rbac.authorization.k8s.io
+          "grove.io:pcs:karta-e2e-grove-scaled" not found'
+        observedAt: "2026-09-09T11:02:55Z"
+      replicas: 1
+      updatedReplicas: 0
+  phases:
+  - Initializing
+  resourceVersion: "294060"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-09-09T11:02:55Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 1
+      name: karta-e2e-grove-scaled
+      namespace: test-rsskf
+      uid: d89e702d-281d-405c-8af1-3140458abd09
+    spec:
+      replicas: 1
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+    status:
+      availableReplicas: 0
+      currentGenerationHash: fcd7c86f456f9f449b
+      replicas: 1
+      updatedReplicas: 0
+  phases:
+  - Initializing
+  resourceVersion: "294065"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-09-09T11:02:55Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 1
+      name: karta-e2e-grove-scaled
+      namespace: test-rsskf
+      uid: d89e702d-281d-405c-8af1-3140458abd09
+    spec:
+      replicas: 1
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+    status:
+      availableReplicas: 0
+      currentGenerationHash: fcd7c86f456f9f449b
+      observedGeneration: 1
+      replicas: 1
+      updatedReplicas: 0
+  phases:
+  - Initializing
+  resourceVersion: "294085"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-09-09T11:02:55Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 1
+      name: karta-e2e-grove-scaled
+      namespace: test-rsskf
+      uid: d89e702d-281d-405c-8af1-3140458abd09
+    spec:
+      replicas: 1
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+    status:
+      availableReplicas: 1
+      currentGenerationHash: fcd7c86f456f9f449b
+      observedGeneration: 1
+      replicas: 1
+      updatedReplicas: 1
+  phases:
+  - Running
+  resourceVersion: "294124"
+  state: Running
+- action:
+    name: Scale
+    operation:
+      patchType: application/merge-patch+json
+      payload:
+        spec:
+          replicas: 2
+      verb: PATCH
+  kind: ACTION
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-09-09T11:02:55Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 2
+      name: karta-e2e-grove-scaled
+      namespace: test-rsskf
+      uid: d89e702d-281d-405c-8af1-3140458abd09
+    spec:
+      replicas: 2
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+    status:
+      availableReplicas: 1
+      currentGenerationHash: fcd7c86f456f9f449b
+      observedGeneration: 1
+      replicas: 1
+      updatedReplicas: 1
+  phases:
+  - Initializing
+  resourceVersion: "294126"
+  staleObservedGeneration: true
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-09-09T11:02:55Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 2
+      name: karta-e2e-grove-scaled
+      namespace: test-rsskf
+      uid: d89e702d-281d-405c-8af1-3140458abd09
+    spec:
+      replicas: 2
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+    status:
+      availableReplicas: 1
+      currentGenerationHash: fcd7c86f456f9f449b
+      observedGeneration: 1
+      replicas: 2
+      updatedReplicas: 1
+  phases:
+  - Initializing
+  resourceVersion: "294141"
+  staleObservedGeneration: true
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-09-09T11:02:55Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 2
+      name: karta-e2e-grove-scaled
+      namespace: test-rsskf
+      uid: d89e702d-281d-405c-8af1-3140458abd09
+    spec:
+      replicas: 2
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+    status:
+      availableReplicas: 1
+      currentGenerationHash: fcd7c86f456f9f449b
+      observedGeneration: 2
+      replicas: 2
+      updatedReplicas: 1
+  phases:
+  - Initializing
+  resourceVersion: "294161"
+  state: Initializing
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-09-09T11:02:55Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 2
+      name: karta-e2e-grove-scaled
+      namespace: test-rsskf
+      uid: d89e702d-281d-405c-8af1-3140458abd09
+    spec:
+      replicas: 2
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+    status:
+      availableReplicas: 2
+      currentGenerationHash: fcd7c86f456f9f449b
+      observedGeneration: 2
+      replicas: 2
+      updatedReplicas: 2
+  phases:
+  - Running
+  resourceVersion: "294197"
+  state: Running
+- action:
+    name: Scale
+    operation:
+      patchType: application/merge-patch+json
+      payload:
+        spec:
+          replicas: 1
+      verb: PATCH
+  kind: ACTION
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-09-09T11:02:55Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 3
+      name: karta-e2e-grove-scaled
+      namespace: test-rsskf
+      uid: d89e702d-281d-405c-8af1-3140458abd09
+    spec:
+      replicas: 1
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+    status:
+      availableReplicas: 2
+      currentGenerationHash: fcd7c86f456f9f449b
+      observedGeneration: 2
+      replicas: 2
+      updatedReplicas: 2
+  phases:
+  - Running
+  resourceVersion: "294198"
+  staleObservedGeneration: true
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-09-09T11:02:55Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 3
+      name: karta-e2e-grove-scaled
+      namespace: test-rsskf
+      uid: d89e702d-281d-405c-8af1-3140458abd09
+    spec:
+      replicas: 1
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+    status:
+      availableReplicas: 2
+      currentGenerationHash: fcd7c86f456f9f449b
+      observedGeneration: 3
+      replicas: 2
+      updatedReplicas: 2
+  phases:
+  - Running
+  resourceVersion: "294202"
+  state: Running
+- kind: STATE
+  object:
+    apiVersion: grove.io/v1alpha1
+    kind: PodCliqueSet
+    metadata:
+      creationTimestamp: "2026-09-09T11:02:55Z"
+      finalizers:
+      - grove.io/podcliqueset.grove.io
+      generation: 3
+      name: karta-e2e-grove-scaled
+      namespace: test-rsskf
+      uid: d89e702d-281d-405c-8af1-3140458abd09
+    spec:
+      replicas: 1
+      template:
+        cliqueStartupType: CliqueStartupTypeAnyOrder
+        cliques:
+        - name: worker
+          spec:
+            minAvailable: 2
+            podSpec:
+              containers:
+              - command:
+                - /bin/sh
+                - -c
+                - echo karta-e2e-grove && sleep infinity
+                image: busybox:1.36
+                name: worker
+                resources:
+                  requests:
+                    cpu: 20m
+                    memory: 32Mi
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30
+            replicas: 2
+            roleName: worker
+        headlessServiceConfig:
+          publishNotReadyAddresses: true
+        terminationDelay: 4h0m0s
+    status:
+      availableReplicas: 1
+      currentGenerationHash: fcd7c86f456f9f449b
+      observedGeneration: 3
+      replicas: 1
+      updatedReplicas: 1
+  phases:
+  - Running
+  resourceVersion: "294204"
+  state: Running
+flow: scaled
+kartaFile: docs/catalog/grove-io-podcliqueset-v1alpha1.yaml
+kartaName: grove-io-podcliqueset-v1alpha1
+operator: grove
+result:
+  succeeded: true
+schemaVersion: 1
+summary:
+- amount: 6
+  phases:
+  - Initializing
+- amount: 1
+  phases:
+  - Running
+- amount: 3
+  phases:
+  - Initializing
+- amount: 4
+  phases:
+  - Running
+version: v1.34.0
+want: Running

--- a/test/e2e/recorder/flow.go
+++ b/test/e2e/recorder/flow.go
@@ -42,6 +42,7 @@ type ActionType string
 const (
 	ActionSuspend ActionType = "Suspend"
 	ActionResume  ActionType = "Resume"
+	ActionScale   ActionType = "Scale"
 )
 
 // Action is a merge-patch applied to the workload to drive a transition.


### PR DESCRIPTION
Part of the e2e flow recording stack. Reordered so flows independent of the catalog fix (#262) come before it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added end-to-end coverage for Grove PodCliqueSet workloads, including running, initializing, and scaling scenarios.
  - Added validation for scaling workloads up and down while tracking replica availability and status transitions.
  - Added recorded execution scenarios covering initialization, reconciliation, transient errors, and successful completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->