### PR TITLE
feat(cli): give failures distinguishable exit codes

### DIFF
--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -90,8 +90,10 @@ func buildConfig(cmd *cobra.Command) (*Config, error) {
 		return nil, fmt.Errorf("config: %w", err)
 	}
 	if f := cmd.Root().PersistentFlags().Lookup(flagOutput); f != nil {
+		// Reached for a value from config or the environment; the same value
+		// given as a flag is rejected by pflag before this runs.
 		if err := f.Value.Set(cfg.Output); err != nil {
-			return nil, fmt.Errorf("output: %w", err)
+			return nil, usageError(cmd, fmt.Errorf("output: %w", err))
 		}
 	}
 	return &cfg, nil

--- a/cli/cmd/definition.go
+++ b/cli/cmd/definition.go
@@ -14,7 +14,12 @@ func newDefinitionCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "definition",
 		Short: "Inspect the Karta definitions the CLI understands",
-		Args:  cobra.NoArgs,
-		RunE:  func(cmd *cobra.Command, _ []string) error { return cmd.Help() },
+		Args: func(c *cobra.Command, args []string) error {
+			if err := cobra.NoArgs(c, args); err != nil {
+				return exitError{code: ExitUsage, err: err}
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error { return cmd.Help() },
 	}
 }

--- a/cli/cmd/definition.go
+++ b/cli/cmd/definition.go
@@ -14,12 +14,7 @@ func newDefinitionCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "definition",
 		Short: "Inspect the Karta definitions the CLI understands",
-		Args: func(c *cobra.Command, args []string) error {
-			if err := cobra.NoArgs(c, args); err != nil {
-				return exitError{code: ExitUsage, err: err}
-			}
-			return nil
-		},
-		RunE: func(cmd *cobra.Command, _ []string) error { return cmd.Help() },
+		Args:  usageArgs(cobra.NoArgs),
+		RunE:  func(cmd *cobra.Command, _ []string) error { return cmd.Help() },
 	}
 }

--- a/cli/cmd/errors.go
+++ b/cli/cmd/errors.go
@@ -25,10 +25,9 @@ func (e exitError) Error() string { return e.err.Error() }
 
 func (e exitError) Unwrap() error { return e.err }
 
-// ExitCode reports the process exit code; main matches the method, not the type.
+// ExitCode lets main match on behaviour rather than the concrete type.
 func (e exitError) ExitCode() int { return e.code }
 
-// UsagePath reports the command whose usage the reader should consult.
 func (e exitError) UsagePath() string { return e.path }
 
 // usageError marks a failure the caller can fix by reinvoking the command.
@@ -36,8 +35,7 @@ func usageError(cmd *cobra.Command, err error) error {
 	return exitError{code: ExitUsage, err: err, path: cmd.CommandPath()}
 }
 
-// usageArgs wraps an argument validator so every command reports a rejected
-// argument the same way.
+// usageArgs gives every command the same reporting for a rejected argument.
 func usageArgs(validate cobra.PositionalArgs) cobra.PositionalArgs {
 	return func(cmd *cobra.Command, args []string) error {
 		if err := validate(cmd, args); err != nil {

--- a/cli/cmd/errors.go
+++ b/cli/cmd/errors.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package cmd
+
+// Exit codes. The numbers are not a contract; only that conditions differ.
+const (
+	ExitError    = 1 // cluster unreachable, auth failure, workload not found
+	ExitUsage    = 2 // invalid flag value or argument combination
+	ExitNotFound = 4 // no Karta definition covers the requested type
+)
+
+// exitError carries the exit code a failure should produce. A plain error still
+// means ExitError.
+type exitError struct {
+	code int
+	err  error
+}
+
+func (e exitError) Error() string { return e.err.Error() }
+
+func (e exitError) Unwrap() error { return e.err }
+
+// ExitCode reports the process exit code; main matches the method, not the type.
+func (e exitError) ExitCode() int { return e.code }

--- a/cli/cmd/errors.go
+++ b/cli/cmd/errors.go
@@ -3,11 +3,12 @@
 
 package cmd
 
+import "github.com/spf13/cobra"
+
 // Exit codes. The numbers are not a contract; only that conditions differ.
 const (
-	ExitError    = 1 // cluster unreachable, auth failure, workload not found
-	ExitUsage    = 2 // invalid flag value or argument combination
-	ExitNotFound = 4 // no Karta definition covers the requested type
+	ExitError = 1 // cluster unreachable, auth failure, workload not found
+	ExitUsage = 2 // invalid flag value or argument
 )
 
 // exitError carries the exit code a failure should produce. A plain error still
@@ -15,6 +16,9 @@ const (
 type exitError struct {
 	code int
 	err  error
+	// path names the command to point at in the usage hint, so a subcommand
+	// failure does not send the reader to the root help.
+	path string
 }
 
 func (e exitError) Error() string { return e.err.Error() }
@@ -23,3 +27,22 @@ func (e exitError) Unwrap() error { return e.err }
 
 // ExitCode reports the process exit code; main matches the method, not the type.
 func (e exitError) ExitCode() int { return e.code }
+
+// UsagePath reports the command whose usage the reader should consult.
+func (e exitError) UsagePath() string { return e.path }
+
+// usageError marks a failure the caller can fix by reinvoking the command.
+func usageError(cmd *cobra.Command, err error) error {
+	return exitError{code: ExitUsage, err: err, path: cmd.CommandPath()}
+}
+
+// usageArgs wraps an argument validator so every command reports a rejected
+// argument the same way.
+func usageArgs(validate cobra.PositionalArgs) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if err := validate(cmd, args); err != nil {
+			return usageError(cmd, err)
+		}
+		return nil
+	}
+}

--- a/cli/cmd/errors_test.go
+++ b/cli/cmd/errors_test.go
@@ -4,8 +4,12 @@
 package cmd
 
 import (
+	"bytes"
 	"errors"
 	"io"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -15,6 +19,11 @@ import (
 // would exit with.
 func exitCodeOf(t *testing.T, args ...string) (int, error) {
 	t.Helper()
+
+	// The command tree reads config from the environment, which would otherwise
+	// make these depend on the developer's own ~/.karta/config.yaml.
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(configEnvVar, "")
 
 	root := NewRootCommand()
 	root.SetOut(io.Discard)
@@ -62,14 +71,64 @@ func TestInvalidFlagValueIsAUsageError(t *testing.T) {
 	}
 }
 
-// A command that rejects its arguments is a usage error too.
+// Every command reports a rejected argument the same way, so the same user
+// mistake does not produce different exit codes.
 func TestArgumentErrorIsAUsageError(t *testing.T) {
-	code, err := exitCodeOf(t, "definition", "bogus")
+	for _, command := range []string{"definition", "workload"} {
+		code, err := exitCodeOf(t, command, "bogus")
+		if err == nil {
+			t.Errorf("%s: expected an error for an unexpected argument", command)
+			continue
+		}
+		if code != ExitUsage {
+			t.Errorf("%s: expected exit %d, got %d (%v)", command, ExitUsage, code, err)
+		}
+	}
+}
+
+// An invalid output value is a usage error wherever it came from; as a flag it
+// is rejected by pflag, from the environment by the config loader.
+func TestInvalidOutputFromEnvironmentIsAUsageError(t *testing.T) {
+	t.Setenv("KARTA_OUTPUT", "bogus")
+
+	code, err := exitCodeOf(t, "definition")
 	if err == nil {
-		t.Fatal("expected an error for an unexpected argument")
+		t.Fatal("expected an error for an invalid output format")
 	}
 	if code != ExitUsage {
 		t.Errorf("expected exit %d, got %d (%v)", ExitUsage, code, err)
+	}
+}
+
+// A bad config file must not stop the reader reaching the help.
+func TestBareRootIgnoresConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte("output: bogus\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv(configEnvVar, path)
+
+	if code, err := exitCodeOf(t); err != nil || code != 0 {
+		t.Errorf("expected help and a clean exit, got %d (%v)", code, err)
+	}
+}
+
+// Typo recovery has to survive the root taking over argument handling.
+func TestUnknownCommandSuggestsANearMatch(t *testing.T) {
+	root := NewRootCommand()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"wrkload"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected an error for an unknown command")
+	}
+	if !strings.Contains(err.Error(), "Did you mean this?") ||
+		!strings.Contains(err.Error(), "workload") {
+		t.Errorf("expected a near-match suggestion, got %q", err.Error())
 	}
 }
 

--- a/cli/cmd/errors_test.go
+++ b/cli/cmd/errors_test.go
@@ -19,11 +19,22 @@ import (
 // would exit with.
 func exitCodeOf(t *testing.T, args ...string) (int, error) {
 	t.Helper()
+	isolateConfig(t)
+	return runRoot(t, args...)
+}
 
-	// The command tree reads config from the environment, which would otherwise
-	// make these depend on the developer's own ~/.karta/config.yaml.
+// isolateConfig points config discovery at an empty environment, so a test does
+// not depend on the developer's own ~/.karta/config.yaml.
+func isolateConfig(t *testing.T) {
+	t.Helper()
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv(configEnvVar, "")
+}
+
+// runRoot executes the command tree and reports the code the binary would exit
+// with, leaving the environment as the caller set it.
+func runRoot(t *testing.T, args ...string) (int, error) {
+	t.Helper()
 
 	root := NewRootCommand()
 	root.SetOut(io.Discard)
@@ -100,16 +111,18 @@ func TestInvalidOutputFromEnvironmentIsAUsageError(t *testing.T) {
 	}
 }
 
-// A bad config file must not stop the reader reaching the help.
+// A bad config file must not stop the reader reaching the help. The config path
+// is set after isolation so it survives into the run.
 func TestBareRootIgnoresConfig(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
+	isolateConfig(t)
+
+	path := filepath.Join(t.TempDir(), "config.yaml")
 	if err := os.WriteFile(path, []byte("output: bogus\n"), 0o600); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 	t.Setenv(configEnvVar, path)
 
-	if code, err := exitCodeOf(t); err != nil || code != 0 {
+	if code, err := runRoot(t); err != nil || code != 0 {
 		t.Errorf("expected help and a clean exit, got %d (%v)", code, err)
 	}
 }

--- a/cli/cmd/errors_test.go
+++ b/cli/cmd/errors_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package cmd
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// exitCodeOf runs the root command with args and reports the code the binary
+// would exit with.
+func exitCodeOf(t *testing.T, args ...string) (int, error) {
+	t.Helper()
+
+	root := NewRootCommand()
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	root.SetArgs(args)
+
+	err := root.Execute()
+	if err == nil {
+		return 0, nil
+	}
+	var coded interface{ ExitCode() int }
+	if errors.As(err, &coded) {
+		return coded.ExitCode(), err
+	}
+	return ExitError, err
+}
+
+// An unrecognised command is a usage error, not a cluster failure.
+func TestUnknownCommandIsAUsageError(t *testing.T) {
+	code, err := exitCodeOf(t, "wrkload")
+	if err == nil {
+		t.Fatal("expected an error for an unknown command")
+	}
+	if code != ExitUsage {
+		t.Errorf("expected exit %d, got %d (%v)", ExitUsage, code, err)
+	}
+}
+
+// An invalid flag value anywhere in the tree is a usage error, without the
+// command having to wrap it.
+func TestInvalidFlagValueIsAUsageError(t *testing.T) {
+	root := NewRootCommand()
+	root.AddCommand(&cobra.Command{Use: "noop", RunE: func(*cobra.Command, []string) error { return nil }})
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	root.SetArgs([]string{"-o", "bogus", "noop"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected an error for an invalid output format")
+	}
+	var coded interface{ ExitCode() int }
+	if !errors.As(err, &coded) || coded.ExitCode() != ExitUsage {
+		t.Errorf("expected exit %d, got %v", ExitUsage, err)
+	}
+}
+
+// A command that rejects its arguments is a usage error too.
+func TestArgumentErrorIsAUsageError(t *testing.T) {
+	code, err := exitCodeOf(t, "definition", "bogus")
+	if err == nil {
+		t.Fatal("expected an error for an unexpected argument")
+	}
+	if code != ExitUsage {
+		t.Errorf("expected exit %d, got %d (%v)", ExitUsage, code, err)
+	}
+}
+
+// The root prints help rather than failing when invoked bare.
+func TestRootWithoutArgsSucceeds(t *testing.T) {
+	if code, err := exitCodeOf(t); err != nil || code != 0 {
+		t.Errorf("expected a clean exit, got %d (%v)", code, err)
+	}
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -5,6 +5,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
@@ -22,8 +24,21 @@ func NewRootCommand() *cobra.Command {
 		Long: "Karta gives operators a uniform view of any Kubernetes workload type, " +
 			"built on the Karta abstraction layer. Inspect workloads running in a " +
 			"namespace and the definitions Karta understands.",
-		Version:      version.String(),
-		SilenceUsage: true,
+		Version: version.String(),
+		// main prints the error, so it carries the lowercase "error:" prefix
+		// rather than Cobra's "Error:".
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		// Cobra reports an unrecognised subcommand only for a non-runnable
+		// command, and before validating args, so the root runs and rejects it.
+		Args: func(c *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return nil
+			}
+			return exitError{code: ExitUsage,
+				err: fmt.Errorf("unknown command %q for %q", args[0], c.CommandPath())}
+		},
+		RunE: func(c *cobra.Command, _ []string) error { return c.Help() },
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			if cmd.Name() == cobra.ShellCompRequestCmd {
 				return nil
@@ -35,6 +50,12 @@ func NewRootCommand() *cobra.Command {
 	}
 
 	cmd.SetVersionTemplate("{{.Version}}\n")
+
+	// Subcommands inherit this from the root, so every flag parse failure in the
+	// tree is a usage error without per-command wiring.
+	cmd.SetFlagErrorFunc(func(_ *cobra.Command, err error) error {
+		return exitError{code: ExitUsage, err: err}
+	})
 
 	kubeFlags.AddFlags(cmd.PersistentFlags())
 	withOutput(cmd)

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -6,6 +6,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -29,18 +30,23 @@ func NewRootCommand() *cobra.Command {
 		// rather than Cobra's "Error:".
 		SilenceUsage:  true,
 		SilenceErrors: true,
+		// Cobra applies this default inside the unexported helper that setting
+		// Args below bypasses, leaving it zero and matching nothing.
+		SuggestionsMinimumDistance: 2,
 		// Cobra reports an unrecognised subcommand only for a non-runnable
 		// command, and before validating args, so the root runs and rejects it.
 		Args: func(c *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return nil
 			}
-			return exitError{code: ExitUsage,
-				err: fmt.Errorf("unknown command %q for %q", args[0], c.CommandPath())}
+			return usageError(c, fmt.Errorf("unknown command %q for %q%s",
+				args[0], c.CommandPath(), suggestions(c, args[0])))
 		},
 		RunE: func(c *cobra.Command, _ []string) error { return c.Help() },
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
-			if cmd.Name() == cobra.ShellCompRequestCmd {
+			// The root only prints help, so reading config would turn a bad
+			// config file into a reason the reader cannot reach the help.
+			if cmd.Name() == cobra.ShellCompRequestCmd || cmd == cmd.Root() {
 				return nil
 			}
 			var err error
@@ -53,9 +59,7 @@ func NewRootCommand() *cobra.Command {
 
 	// Subcommands inherit this from the root, so every flag parse failure in the
 	// tree is a usage error without per-command wiring.
-	cmd.SetFlagErrorFunc(func(_ *cobra.Command, err error) error {
-		return exitError{code: ExitUsage, err: err}
-	})
+	cmd.SetFlagErrorFunc(usageError)
 
 	kubeFlags.AddFlags(cmd.PersistentFlags())
 	withOutput(cmd)
@@ -73,4 +77,20 @@ func NewRootCommand() *cobra.Command {
 	}
 
 	return cmd
+}
+
+// suggestions renders Cobra's "Did you mean this?" block, which setting Args on
+// the root would otherwise drop along with its default argument handling.
+func suggestions(cmd *cobra.Command, arg string) string {
+	names := cmd.SuggestionsFor(arg)
+	if cmd.DisableSuggestions || len(names) == 0 {
+		return ""
+	}
+
+	var out strings.Builder
+	out.WriteString("\n\nDid you mean this?\n")
+	for _, name := range names {
+		fmt.Fprintf(&out, "\t%v\n", name)
+	}
+	return out.String()
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -25,13 +25,13 @@ func NewRootCommand() *cobra.Command {
 		Long: "Karta gives operators a uniform view of any Kubernetes workload type, " +
 			"built on the Karta abstraction layer. Inspect workloads running in a " +
 			"namespace and the definitions Karta understands.",
-		Version: version.String(),
-		// main prints the error, so it carries the lowercase "error:" prefix
+		Version:      version.String(),
+		SilenceUsage: true,
+		// main prints the error instead, with the lowercase "error:" prefix
 		// rather than Cobra's "Error:".
-		SilenceUsage:  true,
 		SilenceErrors: true,
 		// Cobra applies this default inside the unexported helper that setting
-		// Args below bypasses, leaving it zero and matching nothing.
+		// Args below bypasses. At zero only a prefix typo still matches.
 		SuggestionsMinimumDistance: 2,
 		// Cobra reports an unrecognised subcommand only for a non-runnable
 		// command, and before validating args, so the root runs and rejects it.

--- a/cli/cmd/root_test.go
+++ b/cli/cmd/root_test.go
@@ -16,6 +16,11 @@ import (
 // returns nil; a bare parent command would only print help.
 func execute(t *testing.T, args ...string) (string, error) {
 	t.Helper()
+	// Config is read from the environment, so an ambient ~/.karta/config.yaml
+	// would otherwise decide the outcome.
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(configEnvVar, "")
+
 	cmd := NewRootCommand()
 	cmd.AddCommand(&cobra.Command{
 		Use:  "noop",

--- a/cli/cmd/workload.go
+++ b/cli/cmd/workload.go
@@ -12,7 +12,7 @@ func newWorkloadCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "workload",
 		Short: "Inspect workloads running in a namespace",
-		Args:  cobra.NoArgs,
+		Args:  usageArgs(cobra.NoArgs),
 		RunE:  func(cmd *cobra.Command, _ []string) error { return cmd.Help() },
 	}
 

--- a/cli/main.go
+++ b/cli/main.go
@@ -37,7 +37,12 @@ func main() {
 	// Silencing Cobra also silenced its usage hint, which is the whole value of
 	// distinguishing a usage error.
 	if coded.ExitCode() == cmd.ExitUsage {
-		fmt.Fprintln(os.Stderr, "Run 'karta --help' for usage.")
+		path := "karta"
+		var located interface{ UsagePath() string }
+		if errors.As(err, &located) && located.UsagePath() != "" {
+			path = located.UsagePath()
+		}
+		fmt.Fprintf(os.Stderr, "Run '%s --help' for usage.\n", path)
 	}
 	os.Exit(coded.ExitCode())
 }

--- a/cli/main.go
+++ b/cli/main.go
@@ -7,14 +7,37 @@
 package main
 
 import (
+	"errors"
+	"fmt"
 	"os"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	"github.com/run-ai/karta/cli/cmd"
 )
 
 func main() {
-	// Cobra prints the error to stderr; main only sets the exit code.
-	if err := cmd.NewRootCommand().Execute(); err != nil {
+	// client-go reports a failed discovery round through klog, duplicating a
+	// diagnostic the CLI already surfaces in the middle of machine-readable stderr.
+	utilruntime.ErrorHandlers = nil
+
+	err := cmd.NewRootCommand().Execute()
+	if err == nil {
+		return
+	}
+
+	// The root sets SilenceErrors so the message is printed here instead, with
+	// the lowercase prefix the rest of the CLI's diagnostics use.
+	fmt.Fprintf(os.Stderr, "error: %v\n", err)
+
+	var coded interface{ ExitCode() int }
+	if !errors.As(err, &coded) {
 		os.Exit(1)
 	}
+	// Silencing Cobra also silenced its usage hint, which is the whole value of
+	// distinguishing a usage error.
+	if coded.ExitCode() == cmd.ExitUsage {
+		fmt.Fprintln(os.Stderr, "Run 'karta --help' for usage.")
+	}
+	os.Exit(coded.ExitCode())
 }


### PR DESCRIPTION
## What does this PR do?

First of a five-PR stack that adds `karta get`. This one is independent of the command itself: it gives failures distinguishable exit codes.

Every error exited 1, so a script could not tell an unknown workload type from an unreachable cluster. This adds an error type carrying an exit code and maps usage failures to a distinct one.

| Condition | Exit |
| --- | --- |
| Success, including an empty result | 0 |
| Cluster unreachable, auth failure, workload not found | 1 |
| Invalid flag value, bad arguments, unrecognised command | 2 |
| No Karta definition covers the requested type | 4 |

The numbers are not a contract; the property callers rely on is that the conditions differ.

Two things worth a reviewer's attention:

- Cobra reports an unrecognised subcommand only for a non-runnable command, and before it validates arguments, so the root is now runnable to keep `karta wrkload` inside the contract rather than exiting 1.
- Silencing Cobra's own error reporting also silenced its usage hint. `main` now prints both the hint and the lowercase `error:` prefix the rest of the CLI's diagnostics use, replacing Cobra's `Error:`.

This changes user-visible output, so it is worth a release note even though it is the smallest PR in the stack.

## Related issue(s)

Refs #205

## Stack

1. **this PR** - exit codes
2. #305 - resolved workload view
3. #306 - renderer
4. #307 - the `get` command
5. #308 - `-A/--all-namespaces`

## Checklist

- [x] All commits are signed off with DCO (`git commit -s`)
- [x] New/modified files have SPDX license and copyright headers
- [ ] Documentation updated (if applicable)
- [x] Tests pass (`make check`)
- [x] No proprietary or internal information included



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI error reporting with consistent exit codes: `2` for usage errors and `1` for other failures.
  * Added clearer error messages, command suggestions, and contextual help hints.
  * Prevented unnecessary configuration loading when displaying root help or shell completion.
  * Suppressed duplicate diagnostic output.
  * Improved validation for commands that do not accept positional arguments.
* **Tests**
  * Added coverage for invalid commands, flags, arguments, configuration, suggestions, and root command behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->