### PR TITLE
Feat/cli definitions command

### DIFF
--- a/cli/cmd/definitions.go
+++ b/cli/cmd/definitions.go
@@ -27,6 +27,33 @@ const (
 )
 
 const (
+	definitionsUse   = "definitions [NAME]"
+	definitionsShort = "List the Karta definitions the CLI understands"
+
+	definitionsLong = `List the Karta definitions the CLI understands, merging the built-in catalog
+with the Karta definitions installed in the cluster. A cluster definition overrides a
+catalog one describing the same workload type and is listed once, as cluster.
+Definitions are not namespaced, and without cluster access the command still lists the
+catalog definitions.
+
+Give a NAME to address one definition, or use --group, and optionally --kind and
+--version, to narrow the list to one workload type. The table is the human view; json
+and yaml always emit the definitions themselves.`
+
+	definitionsExample = `  # Everything the CLI understands (catalog + cluster)
+  kli definitions
+
+  # One definition, by the name the list shows
+  kli definitions kubeflow-org-pytorchjob-v1
+
+  # Which definition covers JobSet?
+  kli definitions --group jobset.x-k8s.io --kind JobSet
+
+  # Dump them as applyable YAML
+  kli definitions -o yaml`
+)
+
+const (
 	usageGroup   = "Show the definitions covering this API group"
 	usageKind    = "Show the definitions covering this kind; needs --" + flagGroup
 	usageVersion = "Show the definitions covering this version; needs --" + flagKind
@@ -59,29 +86,11 @@ func newDefinitionsCommand(rcg genericclioptions.RESTClientGetter) *cobra.Comman
 	)
 
 	cmd := &cobra.Command{
-		Use:   "definitions [NAME]",
-		Short: "List the Karta definitions the CLI understands",
-		Long: `List the Karta definitions the CLI understands, merging the built-in catalog
-with the Karta definitions installed in the cluster. A cluster definition overrides a
-catalog one describing the same workload type and is listed once, as cluster.
-Definitions are not namespaced, and without cluster access the command still lists the
-catalog definitions.
-
-Give a NAME to address one definition, or use --group, and optionally --kind and
---version, to narrow the list to one workload type. The table is the human view; json
-and yaml always emit the definitions themselves.`,
-		Example: `  # Everything the CLI understands (catalog + cluster)
-  kli definitions
-
-  # One definition, by the name the list shows
-  kli definitions kubeflow-org-pytorchjob-v1
-
-  # Which definition covers JobSet?
-  kli definitions --group jobset.x-k8s.io --kind JobSet
-
-  # Dump them as applyable YAML
-  kli definitions -o yaml`,
-		Args: usageArgs(cobra.MaximumNArgs(1)),
+		Use:     definitionsUse,
+		Short:   definitionsShort,
+		Long:    definitionsLong,
+		Example: definitionsExample,
+		Args:    usageArgs(cobra.MaximumNArgs(1)),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			if format, err = outputFormat(cmd); err != nil {

--- a/cli/cmd/definitions.go
+++ b/cli/cmd/definitions.go
@@ -53,7 +53,7 @@ var definitionsOutputs = []generator.Output{
 	generator.OutputTable, generator.OutputJSON, generator.OutputYAML,
 }
 
-// newDefinitionsCommand builds the "karta definitions" command. The client getter
+// newDefinitionsCommand builds the "kli definitions" command. The client getter
 // is a parameter so a test can inject a fake without mutating package state.
 func newDefinitionsCommand(rcg genericclioptions.RESTClientGetter) *cobra.Command {
 	var group, kind, version string
@@ -71,16 +71,16 @@ func newDefinitionsCommand(rcg genericclioptions.RESTClientGetter) *cobra.Comman
 			"workload type. The table is the human view; json and yaml always emit " +
 			"the definitions themselves.",
 		Example: "  # Everything the CLI understands (catalog + cluster)\n" +
-			"  karta definitions\n" +
+			"  kli definitions\n" +
 			"\n" +
 			"  # One definition, by the name the list shows\n" +
-			"  karta definitions kubeflow-org-pytorchjob-v1\n" +
+			"  kli definitions kubeflow-org-pytorchjob-v1\n" +
 			"\n" +
 			"  # Which definition covers JobSet?\n" +
-			"  karta definitions --group jobset.x-k8s.io --kind JobSet\n" +
+			"  kli definitions --group jobset.x-k8s.io --kind JobSet\n" +
 			"\n" +
 			"  # Dump them as applyable YAML\n" +
-			"  karta definitions -o yaml",
+			"  kli definitions -o yaml",
 		Args: usageArgs(cobra.MaximumNArgs(1)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			format, err := supportedOutput(cmd, definitionsOutputs)
@@ -107,7 +107,7 @@ func newDefinitionsCommand(rcg genericclioptions.RESTClientGetter) *cobra.Comman
 				def, err := resolver.ByName(args[0])
 				if err != nil {
 					return fmt.Errorf(
-						`no Karta definition named %q. Run "karta definitions" to see what is available`,
+						`no Karta definition named %q. Run "kli definitions" to see what is available`,
 						args[0])
 				}
 				matches = []definitions.Definition{def}
@@ -115,7 +115,7 @@ func newDefinitionsCommand(rcg genericclioptions.RESTClientGetter) *cobra.Comman
 			case filter.set:
 				if matches = filter.narrow(matches); len(matches) == 0 {
 					return fmt.Errorf(
-						`no Karta definition covers %q. Run "karta definitions" to see what is available`,
+						`no Karta definition covers %q. Run "kli definitions" to see what is available`,
 						filter.String())
 				}
 			}

--- a/cli/cmd/definitions.go
+++ b/cli/cmd/definitions.go
@@ -39,10 +39,6 @@ const (
 // cannot render.
 var ErrUnsupportedOutput = errors.New("unsupported output format")
 
-var definitionsOutputs = []generator.Output{
-	generator.OutputTable, generator.OutputJSON, generator.OutputYAML,
-}
-
 // definitionRow is one row of the table. json and yaml emit the definitions
 // themselves, so this never leaves the process and carries no tags.
 type definitionRow struct {
@@ -60,6 +56,10 @@ type definitionFilter struct {
 	set     bool
 }
 
+var definitionsOutputs = []generator.Output{
+	generator.OutputTable, generator.OutputJSON, generator.OutputYAML,
+}
+
 // newDefinitionsCommand builds the "karta definitions" command. The client getter
 // is a parameter so a test can inject a fake without mutating package state.
 func newDefinitionsCommand(rcg genericclioptions.RESTClientGetter) *cobra.Command {
@@ -73,17 +73,17 @@ func newDefinitionsCommand(rcg genericclioptions.RESTClientGetter) *cobra.Comman
 			"A cluster definition overrides a catalog one describing the same " +
 			"workload type and is listed once, as cluster. Definitions are not " +
 			"namespaced, and without cluster access the command still lists the " +
-			"catalog definitions. Use --for to narrow the list to the definitions " +
-			"covering one workload type, in which case json and yaml emit the raw " +
-			"definitions instead of list rows.",
+			"catalog definitions. Use --group, and optionally --kind and --version, " +
+			"to narrow the list to one workload type. The table is the human view; " +
+			"json and yaml always emit the definitions themselves.",
 		Example: "  # Everything the CLI understands (catalog + cluster)\n" +
 			"  karta definitions\n" +
 			"\n" +
 			"  # Which definition covers JobSet?\n" +
-			"  karta definitions --for jobset\n" +
+			"  karta definitions --group jobset.x-k8s.io --kind JobSet\n" +
 			"\n" +
-			"  # Dump it as applyable YAML\n" +
-			"  karta definitions --for jobset -o yaml",
+			"  # Dump them as applyable YAML\n" +
+			"  karta definitions -o yaml",
 		Args: usageArgs(cobra.NoArgs),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			format, err := supportedOutput(cmd, definitionsOutputs)

--- a/cli/cmd/definitions.go
+++ b/cli/cmd/definitions.go
@@ -59,26 +59,30 @@ func newDefinitionsCommand(rcg genericclioptions.RESTClientGetter) *cobra.Comman
 	var group, kind, version string
 
 	cmd := &cobra.Command{
-		Use:   "definitions",
+		Use:   "definitions [NAME]",
 		Short: "List the Karta definitions the CLI understands",
 		Long: "List the Karta definitions the CLI understands, merging the built-in " +
 			"catalog with the Karta definitions installed in the cluster. " +
 			"A cluster definition overrides a catalog one describing the same " +
 			"workload type and is listed once, as cluster. Definitions are not " +
 			"namespaced, and without cluster access the command still lists the " +
-			"catalog definitions. Use --group, and optionally --kind and --version, " +
-			"to narrow the list to one workload type. The table is the human view; " +
-			"json and yaml always emit the definitions themselves.",
+			"catalog definitions. Give a NAME to address one definition, or use " +
+			"--group, and optionally --kind and --version, to narrow the list to one " +
+			"workload type. The table is the human view; json and yaml always emit " +
+			"the definitions themselves.",
 		Example: "  # Everything the CLI understands (catalog + cluster)\n" +
 			"  karta definitions\n" +
+			"\n" +
+			"  # One definition, by the name the list shows\n" +
+			"  karta definitions kubeflow-org-pytorchjob-v1\n" +
 			"\n" +
 			"  # Which definition covers JobSet?\n" +
 			"  karta definitions --group jobset.x-k8s.io --kind JobSet\n" +
 			"\n" +
 			"  # Dump them as applyable YAML\n" +
 			"  karta definitions -o yaml",
-		Args: usageArgs(cobra.NoArgs),
-		RunE: func(cmd *cobra.Command, _ []string) error {
+		Args: usageArgs(cobra.MaximumNArgs(1)),
+		RunE: func(cmd *cobra.Command, args []string) error {
 			format, err := supportedOutput(cmd, definitionsOutputs)
 			if err != nil {
 				return err
@@ -87,6 +91,10 @@ func newDefinitionsCommand(rcg genericclioptions.RESTClientGetter) *cobra.Comman
 			if err != nil {
 				return err
 			}
+			if len(args) == 1 && filter.set {
+				return usageError(cmd, fmt.Errorf(
+					"a NAME and --%s address the same definition; give one or the other", flagGroup))
+			}
 
 			resolver, warnings := definitions.Load(cmd.Context(), rcg)
 			for _, warning := range warnings {
@@ -94,7 +102,17 @@ func newDefinitionsCommand(rcg genericclioptions.RESTClientGetter) *cobra.Comman
 			}
 
 			matches := resolver.List()
-			if filter.set {
+			switch {
+			case len(args) == 1:
+				def, err := resolver.ByName(args[0])
+				if err != nil {
+					return fmt.Errorf(
+						`no Karta definition named %q. Run "karta definitions" to see what is available`,
+						args[0])
+				}
+				matches = []definitions.Definition{def}
+
+			case filter.set:
 				if matches = filter.narrow(matches); len(matches) == 0 {
 					return fmt.Errorf(
 						`no Karta definition covers %q. Run "karta definitions" to see what is available`,

--- a/cli/cmd/definitions.go
+++ b/cli/cmd/definitions.go
@@ -93,7 +93,7 @@ and yaml always emit the definitions themselves.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			resolver, warnings := definitions.Load(cmd.Context(), rcg)
 			for _, warning := range warnings {
-				fmt.Fprintln(cmd.ErrOrStderr(), "warning: "+warning.Message)
+				cmd.PrintErrln("warning: " + warning.Message)
 			}
 
 			matches := resolver.List()

--- a/cli/cmd/definitions.go
+++ b/cli/cmd/definitions.go
@@ -49,53 +49,48 @@ type definitionFilter struct {
 	set     bool
 }
 
-var definitionsOutputs = []generator.Output{
-	generator.OutputTable, generator.OutputJSON, generator.OutputYAML,
-}
-
 // newDefinitionsCommand builds the "kli definitions" command. The client getter
 // is a parameter so a test can inject a fake without mutating package state.
 func newDefinitionsCommand(rcg genericclioptions.RESTClientGetter) *cobra.Command {
 	var group, kind, version string
+	var (
+		format generator.Output
+		filter definitionFilter
+	)
 
 	cmd := &cobra.Command{
 		Use:   "definitions [NAME]",
 		Short: "List the Karta definitions the CLI understands",
-		Long: "List the Karta definitions the CLI understands, merging the built-in " +
-			"catalog with the Karta definitions installed in the cluster. " +
-			"A cluster definition overrides a catalog one describing the same " +
-			"workload type and is listed once, as cluster. Definitions are not " +
-			"namespaced, and without cluster access the command still lists the " +
-			"catalog definitions. Give a NAME to address one definition, or use " +
-			"--group, and optionally --kind and --version, to narrow the list to one " +
-			"workload type. The table is the human view; json and yaml always emit " +
-			"the definitions themselves.",
-		Example: "  # Everything the CLI understands (catalog + cluster)\n" +
-			"  kli definitions\n" +
-			"\n" +
-			"  # One definition, by the name the list shows\n" +
-			"  kli definitions kubeflow-org-pytorchjob-v1\n" +
-			"\n" +
-			"  # Which definition covers JobSet?\n" +
-			"  kli definitions --group jobset.x-k8s.io --kind JobSet\n" +
-			"\n" +
-			"  # Dump them as applyable YAML\n" +
-			"  kli definitions -o yaml",
-		Args: usageArgs(cobra.MaximumNArgs(1)),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			format, err := supportedOutput(cmd, definitionsOutputs)
-			if err != nil {
-				return err
-			}
-			filter, err := definitionFilterFrom(cmd, group, kind, version)
-			if err != nil {
-				return err
-			}
-			if len(args) == 1 && filter.set {
-				return usageError(cmd, fmt.Errorf(
-					"a NAME and --%s address the same definition; give one or the other", flagGroup))
-			}
+		Long: `List the Karta definitions the CLI understands, merging the built-in catalog
+with the Karta definitions installed in the cluster. A cluster definition overrides a
+catalog one describing the same workload type and is listed once, as cluster.
+Definitions are not namespaced, and without cluster access the command still lists the
+catalog definitions.
 
+Give a NAME to address one definition, or use --group, and optionally --kind and
+--version, to narrow the list to one workload type. The table is the human view; json
+and yaml always emit the definitions themselves.`,
+		Example: `  # Everything the CLI understands (catalog + cluster)
+  kli definitions
+
+  # One definition, by the name the list shows
+  kli definitions kubeflow-org-pytorchjob-v1
+
+  # Which definition covers JobSet?
+  kli definitions --group jobset.x-k8s.io --kind JobSet
+
+  # Dump them as applyable YAML
+  kli definitions -o yaml`,
+		Args: usageArgs(cobra.MaximumNArgs(1)),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			var err error
+			if format, err = outputFormat(cmd); err != nil {
+				return err
+			}
+			filter, err = definitionFilterFrom(cmd, args, group, kind, version)
+			return err
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
 			resolver, warnings := definitions.Load(cmd.Context(), rcg)
 			for _, warning := range warnings {
 				fmt.Fprintln(cmd.ErrOrStderr(), "warning: "+warning.Message)
@@ -130,6 +125,7 @@ func newDefinitionsCommand(rcg genericclioptions.RESTClientGetter) *cobra.Comman
 		},
 	}
 
+	withOutput(cmd, cmd.Flags(), false)
 	cmd.Flags().StringVar(&group, flagGroup, "", usageGroup)
 	cmd.Flags().StringVar(&kind, flagKind, "", usageKind)
 	cmd.Flags().StringVar(&version, flagVersion, "", usageVersion)
@@ -138,14 +134,17 @@ func newDefinitionsCommand(rcg genericclioptions.RESTClientGetter) *cobra.Comman
 }
 
 // definitionFilterFrom rejects a combination that addresses nothing: a kind
-// outside a group would match across unrelated APIs.
-func definitionFilterFrom(cmd *cobra.Command, group, kind, version string) (definitionFilter, error) {
+// outside a group would match across unrelated APIs, and a NAME addresses the
+// same definition the flags do.
+func definitionFilterFrom(cmd *cobra.Command, args []string, group, kind, version string) (definitionFilter, error) {
 	groupSet := cmd.Flags().Changed(flagGroup)
 	kindSet := cmd.Flags().Changed(flagKind)
 	versionSet := cmd.Flags().Changed(flagVersion)
 
 	var err error
 	switch {
+	case len(args) == 1 && groupSet:
+		err = fmt.Errorf("a NAME and --%s address the same definition; give one or the other", flagGroup)
 	case kindSet && !groupSet:
 		err = fmt.Errorf("--%s needs --%s, for example --%s kubeflow.org --%s PyTorchJob",
 			flagKind, flagGroup, flagGroup, flagKind)
@@ -244,12 +243,4 @@ func renderDefinitions(out, errOut io.Writer, rows []definitionRow) error {
 		return fmt.Errorf("write definitions table: %w", err)
 	}
 	return nil
-}
-
-func unsupportedOutputError(format generator.Output, allowed []generator.Output) error {
-	names := make([]string, 0, len(allowed))
-	for _, a := range allowed {
-		names = append(names, string(a))
-	}
-	return fmt.Errorf("%w %q: supported formats are %s", generator.ErrUnsupportedOutput, format, strings.Join(names, ", "))
 }

--- a/cli/cmd/definitions.go
+++ b/cli/cmd/definitions.go
@@ -7,12 +7,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// newDefinitionCommand builds the "karta definition" command tree: inspection
+// newDefinitionsCommand builds the "karta definitions" command tree: inspection
 // of the Karta definitions the CLI understands. Definitions are cluster-scoped,
 // so these commands do not require a namespace.
-func newDefinitionCommand() *cobra.Command {
+func newDefinitionsCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:   "definition",
+		Use:   "definitions",
 		Short: "Inspect the Karta definitions the CLI understands",
 		Args:  usageArgs(cobra.NoArgs),
 		RunE:  func(cmd *cobra.Command, _ []string) error { return cmd.Help() },

--- a/cli/cmd/definitions.go
+++ b/cli/cmd/definitions.go
@@ -29,20 +29,18 @@ const (
 	flagVersion = "version"
 )
 
+const (
+	usageGroup   = "Show the definitions covering this API group"
+	usageKind    = "Show the definitions covering this kind; needs --" + flagGroup
+	usageVersion = "Show the definitions covering this version; needs --" + flagKind
+)
+
 // ErrUnsupportedOutput reports a format the root enum accepts but this command
 // cannot render.
 var ErrUnsupportedOutput = errors.New("unsupported output format")
 
 var definitionsOutputs = []generator.Output{
 	generator.OutputTable, generator.OutputJSON, generator.OutputYAML,
-}
-
-func unsupportedOutputError(format generator.Output, allowed []generator.Output) error {
-	names := make([]string, 0, len(allowed))
-	for _, a := range allowed {
-		names = append(names, string(a))
-	}
-	return fmt.Errorf("%w %q: supported formats are %s", ErrUnsupportedOutput, format, strings.Join(names, ", "))
 }
 
 // definitionRow is one row of the table. json and yaml emit the definitions
@@ -52,6 +50,14 @@ type definitionRow struct {
 	Kind       string
 	Origin     string
 	Components []string
+}
+
+// definitionFilter is the workload type --group, --kind and --version address.
+type definitionFilter struct {
+	group   string
+	kind    string
+	version string
+	set     bool
 }
 
 // newDefinitionsCommand builds the "karta definitions" command. The client getter
@@ -80,11 +86,10 @@ func newDefinitionsCommand(rcg genericclioptions.RESTClientGetter) *cobra.Comman
 			"  karta definitions --for jobset -o yaml",
 		Args: usageArgs(cobra.NoArgs),
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			format, err := supportedOutput(cmd, definitionsOutputs...)
+			format, err := supportedOutput(cmd, definitionsOutputs)
 			if err != nil {
 				return err
 			}
-			// Both validations run before Load: a usage mistake costs no cluster read.
 			filter, err := definitionFilterFrom(cmd, group, kind, version)
 			if err != nil {
 				return err
@@ -92,7 +97,7 @@ func newDefinitionsCommand(rcg genericclioptions.RESTClientGetter) *cobra.Comman
 
 			resolver, warnings := definitions.Load(cmd.Context(), rcg)
 			for _, warning := range warnings {
-				fmt.Fprintln(cmd.ErrOrStderr(), warningPrefix+warning.Message)
+				fmt.Fprintln(cmd.ErrOrStderr(), "warning: "+warning.Message)
 			}
 
 			matches := resolver.List()
@@ -111,19 +116,11 @@ func newDefinitionsCommand(rcg genericclioptions.RESTClientGetter) *cobra.Comman
 		},
 	}
 
-	cmd.Flags().StringVar(&group, flagGroup, "", "Show the definitions covering this API group")
-	cmd.Flags().StringVar(&kind, flagKind, "", "Show the definitions covering this kind; needs --"+flagGroup)
-	cmd.Flags().StringVar(&version, flagVersion, "", "Show the definitions covering this version; needs --"+flagKind)
+	cmd.Flags().StringVar(&group, flagGroup, "", usageGroup)
+	cmd.Flags().StringVar(&kind, flagKind, "", usageKind)
+	cmd.Flags().StringVar(&version, flagVersion, "", usageVersion)
 
 	return cmd
-}
-
-// definitionFilter is the workload type --group, --kind and --version address.
-type definitionFilter struct {
-	group   string
-	kind    string
-	version string
-	set     bool
 }
 
 // definitionFilterFrom rejects a combination that addresses nothing: a kind
@@ -189,9 +186,6 @@ func (f definitionFilter) String() string {
 	}
 }
 
-// warningPrefix opens every diagnostic the CLI writes to stderr.
-const warningPrefix = "warning: "
-
 // definitionRows projects definitions into rows sorted by name. Resolver.List
 // sorts by GVK, so display order is set here.
 func definitionRows(defs []definitions.Definition) []definitionRow {
@@ -238,8 +232,14 @@ func renderDefinitions(out, errOut io.Writer, rows []definitionRow) error {
 	return nil
 }
 
-// renderRawDefinitions writes the definitions themselves, so "-o yaml" pipes
-// straight into "kubectl apply -f -".
+func unsupportedOutputError(format generator.Output, allowed []generator.Output) error {
+	names := make([]string, 0, len(allowed))
+	for _, a := range allowed {
+		names = append(names, string(a))
+	}
+	return fmt.Errorf("%w %q: supported formats are %s", ErrUnsupportedOutput, format, strings.Join(names, ", "))
+}
+
 func renderRawDefinitions(out io.Writer, defs []definitions.Definition, format generator.Output) error {
 	switch format {
 	case generator.OutputJSON:

--- a/cli/cmd/definitions.go
+++ b/cli/cmd/definitions.go
@@ -4,8 +4,6 @@
 package cmd
 
 import (
-	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"slices"
@@ -15,7 +13,6 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"sigs.k8s.io/yaml"
 
 	"github.com/run-ai/karta/cli/pkg/definitions"
 	"github.com/run-ai/karta/cli/pkg/generator"
@@ -34,10 +31,6 @@ const (
 	usageKind    = "Show the definitions covering this kind; needs --" + flagGroup
 	usageVersion = "Show the definitions covering this version; needs --" + flagKind
 )
-
-// ErrUnsupportedOutput reports a format the root enum accepts but this command
-// cannot render.
-var ErrUnsupportedOutput = errors.New("unsupported output format")
 
 // definitionRow is one row of the table. json and yaml emit the definitions
 // themselves, so this never leaves the process and carries no tags.
@@ -109,10 +102,13 @@ func newDefinitionsCommand(rcg genericclioptions.RESTClientGetter) *cobra.Comman
 				}
 			}
 
-			if format == generator.OutputTable {
-				return renderDefinitions(cmd.OutOrStdout(), cmd.ErrOrStderr(), definitionRows(matches))
+			kartas := make([]*v1alpha1.Karta, 0, len(matches))
+			for _, def := range matches {
+				kartas = append(kartas, def.Karta)
 			}
-			return renderRawDefinitions(cmd.OutOrStdout(), matches, format)
+			return generator.Render(cmd.OutOrStdout(), format, kartas, func(out io.Writer) error {
+				return renderDefinitions(out, cmd.ErrOrStderr(), definitionRows(matches))
+			})
 		},
 	}
 
@@ -237,39 +233,5 @@ func unsupportedOutputError(format generator.Output, allowed []generator.Output)
 	for _, a := range allowed {
 		names = append(names, string(a))
 	}
-	return fmt.Errorf("%w %q: supported formats are %s", ErrUnsupportedOutput, format, strings.Join(names, ", "))
-}
-
-func renderRawDefinitions(out io.Writer, defs []definitions.Definition, format generator.Output) error {
-	switch format {
-	case generator.OutputJSON:
-		kartas := make([]*v1alpha1.Karta, 0, len(defs))
-		for _, def := range defs {
-			kartas = append(kartas, def.Karta)
-		}
-		encoder := json.NewEncoder(out)
-		encoder.SetIndent("", "  ")
-		if err := encoder.Encode(kartas); err != nil {
-			return fmt.Errorf("encode definitions as json: %w", err)
-		}
-		return nil
-
-	case generator.OutputYAML:
-		docs := make([]string, 0, len(defs))
-		for _, def := range defs {
-			data, err := yaml.Marshal(def.Karta)
-			if err != nil {
-				return fmt.Errorf("encode definition %q as yaml: %w", def.Karta.Name, err)
-			}
-			docs = append(docs, string(data))
-		}
-		// A document stream, not a List object kubectl would need told about.
-		if _, err := io.WriteString(out, strings.Join(docs, "---\n")); err != nil {
-			return fmt.Errorf("write definitions yaml: %w", err)
-		}
-		return nil
-
-	default:
-		return unsupportedOutputError(format, definitionsOutputs)
-	}
+	return fmt.Errorf("%w %q: supported formats are %s", generator.ErrUnsupportedOutput, format, strings.Join(names, ", "))
 }

--- a/cli/cmd/definitions.go
+++ b/cli/cmd/definitions.go
@@ -4,17 +4,272 @@
 package cmd
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+	"text/tabwriter"
+
 	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"sigs.k8s.io/yaml"
+
+	"github.com/run-ai/karta/cli/pkg/definitions"
+	"github.com/run-ai/karta/cli/pkg/generator"
+	v1alpha1 "github.com/run-ai/karta/pkg/api/runai/v1alpha1"
+	"github.com/run-ai/karta/pkg/catalog"
 )
 
-// newDefinitionsCommand builds the "karta definitions" command tree: inspection
-// of the Karta definitions the CLI understands. Definitions are cluster-scoped,
-// so these commands do not require a namespace.
-func newDefinitionsCommand() *cobra.Command {
-	return &cobra.Command{
+const (
+	flagGroup   = "group"
+	flagKind    = "kind"
+	flagVersion = "version"
+)
+
+// ErrUnsupportedOutput reports a format the root enum accepts but this command
+// cannot render.
+var ErrUnsupportedOutput = errors.New("unsupported output format")
+
+var definitionsOutputs = []generator.Output{
+	generator.OutputTable, generator.OutputJSON, generator.OutputYAML,
+}
+
+func unsupportedOutputError(format generator.Output, allowed []generator.Output) error {
+	names := make([]string, 0, len(allowed))
+	for _, a := range allowed {
+		names = append(names, string(a))
+	}
+	return fmt.Errorf("%w %q: supported formats are %s", ErrUnsupportedOutput, format, strings.Join(names, ", "))
+}
+
+// definitionRow is one row of the table. json and yaml emit the definitions
+// themselves, so this never leaves the process and carries no tags.
+type definitionRow struct {
+	Name       string
+	Kind       string
+	Origin     string
+	Components []string
+}
+
+// newDefinitionsCommand builds the "karta definitions" command. The client getter
+// is a parameter so a test can inject a fake without mutating package state.
+func newDefinitionsCommand(rcg genericclioptions.RESTClientGetter) *cobra.Command {
+	var group, kind, version string
+
+	cmd := &cobra.Command{
 		Use:   "definitions",
-		Short: "Inspect the Karta definitions the CLI understands",
-		Args:  usageArgs(cobra.NoArgs),
-		RunE:  func(cmd *cobra.Command, _ []string) error { return cmd.Help() },
+		Short: "List the Karta definitions the CLI understands",
+		Long: "List the Karta definitions the CLI understands, merging the built-in " +
+			"catalog with the Karta definitions installed in the cluster. " +
+			"A cluster definition overrides a catalog one describing the same " +
+			"workload type and is listed once, as cluster. Definitions are not " +
+			"namespaced, and without cluster access the command still lists the " +
+			"catalog definitions. Use --for to narrow the list to the definitions " +
+			"covering one workload type, in which case json and yaml emit the raw " +
+			"definitions instead of list rows.",
+		Example: "  # Everything the CLI understands (catalog + cluster)\n" +
+			"  karta definitions\n" +
+			"\n" +
+			"  # Which definition covers JobSet?\n" +
+			"  karta definitions --for jobset\n" +
+			"\n" +
+			"  # Dump it as applyable YAML\n" +
+			"  karta definitions --for jobset -o yaml",
+		Args: usageArgs(cobra.NoArgs),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			format, err := supportedOutput(cmd, definitionsOutputs...)
+			if err != nil {
+				return err
+			}
+			// Both validations run before Load: a usage mistake costs no cluster read.
+			filter, err := definitionFilterFrom(cmd, group, kind, version)
+			if err != nil {
+				return err
+			}
+
+			resolver, warnings := definitions.Load(cmd.Context(), rcg)
+			for _, warning := range warnings {
+				fmt.Fprintln(cmd.ErrOrStderr(), warningPrefix+warning.Message)
+			}
+
+			matches := resolver.List()
+			if filter.set {
+				if matches = filter.narrow(matches); len(matches) == 0 {
+					return fmt.Errorf(
+						`no Karta definition covers %q. Run "karta definitions" to see what is available`,
+						filter.String())
+				}
+			}
+
+			if format == generator.OutputTable {
+				return renderDefinitions(cmd.OutOrStdout(), cmd.ErrOrStderr(), definitionRows(matches))
+			}
+			return renderRawDefinitions(cmd.OutOrStdout(), matches, format)
+		},
+	}
+
+	cmd.Flags().StringVar(&group, flagGroup, "", "Show the definitions covering this API group")
+	cmd.Flags().StringVar(&kind, flagKind, "", "Show the definitions covering this kind; needs --"+flagGroup)
+	cmd.Flags().StringVar(&version, flagVersion, "", "Show the definitions covering this version; needs --"+flagKind)
+
+	return cmd
+}
+
+// definitionFilter is the workload type --group, --kind and --version address.
+type definitionFilter struct {
+	group   string
+	kind    string
+	version string
+	set     bool
+}
+
+// definitionFilterFrom rejects a combination that addresses nothing: a kind
+// outside a group would match across unrelated APIs.
+func definitionFilterFrom(cmd *cobra.Command, group, kind, version string) (definitionFilter, error) {
+	groupSet := cmd.Flags().Changed(flagGroup)
+	kindSet := cmd.Flags().Changed(flagKind)
+	versionSet := cmd.Flags().Changed(flagVersion)
+
+	var err error
+	switch {
+	case kindSet && !groupSet:
+		err = fmt.Errorf("--%s needs --%s, for example --%s kubeflow.org --%s PyTorchJob",
+			flagKind, flagGroup, flagGroup, flagKind)
+	case versionSet && !kindSet:
+		err = fmt.Errorf("--%s needs --%s, for example --%s kubeflow.org --%s PyTorchJob --%s v1",
+			flagVersion, flagKind, flagGroup, flagKind, flagVersion)
+	case kindSet && kind == "":
+		err = fmt.Errorf("--%s needs a value, for example --%s PyTorchJob", flagKind, flagKind)
+	case versionSet && version == "":
+		err = fmt.Errorf("--%s needs a value, for example --%s v1", flagVersion, flagVersion)
+	}
+	if err != nil {
+		return definitionFilter{}, usageError(cmd, err)
+	}
+	return definitionFilter{group: group, kind: kind, version: version, set: groupSet}, nil
+}
+
+// narrow returns every definition the filter covers. One kind can be covered at
+// several versions, so a filter stopping short of one matches them all.
+func (f definitionFilter) narrow(defs []definitions.Definition) []definitions.Definition {
+	out := make([]definitions.Definition, 0, len(defs))
+	for _, def := range defs {
+		gvk := catalog.RootKey(def.Karta)
+		// Names no workload type, so no filter covers it.
+		if gvk.Version == "" || gvk.Kind == "" {
+			continue
+		}
+		if gvk.Group != f.group {
+			continue
+		}
+		if f.kind != "" && !strings.EqualFold(gvk.Kind, f.kind) {
+			continue
+		}
+		if f.version != "" && gvk.Version != f.version {
+			continue
+		}
+		out = append(out, def)
+	}
+	return out
+}
+
+// String renders the filter the way apimachinery renders a GVK, trimmed to the
+// segments given.
+func (f definitionFilter) String() string {
+	switch {
+	case f.version != "":
+		return schema.GroupVersionKind{Group: f.group, Version: f.version, Kind: f.kind}.String()
+	case f.kind != "":
+		return fmt.Sprintf("%s, Kind=%s", f.group, f.kind)
+	default:
+		return f.group
+	}
+}
+
+// warningPrefix opens every diagnostic the CLI writes to stderr.
+const warningPrefix = "warning: "
+
+// definitionRows projects definitions into rows sorted by name. Resolver.List
+// sorts by GVK, so display order is set here.
+func definitionRows(defs []definitions.Definition) []definitionRow {
+	rows := make([]definitionRow, 0, len(defs))
+	for _, def := range defs {
+		structure := def.Karta.Spec.StructureDefinition
+		components := make([]string, 0, len(structure.ChildComponents)+1)
+		components = append(components, structure.RootComponent.Name)
+		for _, child := range structure.ChildComponents {
+			components = append(components, child.Name)
+		}
+		rows = append(rows, definitionRow{
+			Name:       def.Karta.Name,
+			Kind:       catalog.RootKey(def.Karta).Kind,
+			Origin:     string(def.Origin),
+			Components: components,
+		})
+	}
+	slices.SortFunc(rows, func(a, b definitionRow) int { return strings.Compare(a.Name, b.Name) })
+	return rows
+}
+
+// renderDefinitions writes the table. The empty note goes to errOut so stdout
+// stays parseable.
+func renderDefinitions(out, errOut io.Writer, rows []definitionRow) error {
+	if len(rows) == 0 {
+		fmt.Fprintln(errOut, "No Karta definitions found.")
+		return nil
+	}
+	w := tabwriter.NewWriter(out, 0, 8, 2, ' ', 0)
+	fmt.Fprintln(w, "NAME\tKIND\tORIGIN\tCOMPONENTS")
+	for _, row := range rows {
+		// Still listed, so its author can see the one they wrote.
+		kind := row.Kind
+		if kind == "" {
+			kind = "<none>"
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+			row.Name, kind, row.Origin, strings.Join(row.Components, ", "))
+	}
+	if err := w.Flush(); err != nil {
+		return fmt.Errorf("write definitions table: %w", err)
+	}
+	return nil
+}
+
+// renderRawDefinitions writes the definitions themselves, so "-o yaml" pipes
+// straight into "kubectl apply -f -".
+func renderRawDefinitions(out io.Writer, defs []definitions.Definition, format generator.Output) error {
+	switch format {
+	case generator.OutputJSON:
+		kartas := make([]*v1alpha1.Karta, 0, len(defs))
+		for _, def := range defs {
+			kartas = append(kartas, def.Karta)
+		}
+		encoder := json.NewEncoder(out)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(kartas); err != nil {
+			return fmt.Errorf("encode definitions as json: %w", err)
+		}
+		return nil
+
+	case generator.OutputYAML:
+		docs := make([]string, 0, len(defs))
+		for _, def := range defs {
+			data, err := yaml.Marshal(def.Karta)
+			if err != nil {
+				return fmt.Errorf("encode definition %q as yaml: %w", def.Karta.Name, err)
+			}
+			docs = append(docs, string(data))
+		}
+		// A document stream, not a List object kubectl would need told about.
+		if _, err := io.WriteString(out, strings.Join(docs, "---\n")); err != nil {
+			return fmt.Errorf("write definitions yaml: %w", err)
+		}
+		return nil
+
+	default:
+		return unsupportedOutputError(format, definitionsOutputs)
 	}
 }

--- a/cli/cmd/definitions.go
+++ b/cli/cmd/definitions.go
@@ -81,7 +81,7 @@ type definitionFilter struct {
 func newDefinitionsCommand(rcg genericclioptions.RESTClientGetter) *cobra.Command {
 	var group, kind, version string
 	var (
-		format generator.Output
+		output *Enum[generator.Output]
 		filter definitionFilter
 	)
 
@@ -93,9 +93,6 @@ func newDefinitionsCommand(rcg genericclioptions.RESTClientGetter) *cobra.Comman
 		Args:    usageArgs(cobra.MaximumNArgs(1)),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			var err error
-			if format, err = outputFormat(cmd); err != nil {
-				return err
-			}
 			filter, err = definitionFilterFrom(cmd, args, group, kind, version)
 			return err
 		},
@@ -128,13 +125,13 @@ func newDefinitionsCommand(rcg genericclioptions.RESTClientGetter) *cobra.Comman
 			for _, def := range matches {
 				kartas = append(kartas, def.Karta)
 			}
-			return generator.Render(cmd.OutOrStdout(), format, kartas, func(out io.Writer) error {
+			return generator.Render(cmd.OutOrStdout(), output.Get(), kartas, func(out io.Writer) error {
 				return renderDefinitions(out, cmd.ErrOrStderr(), definitionRows(matches))
 			})
 		},
 	}
 
-	withOutput(cmd, cmd.Flags(), false)
+	output = withOutput(cmd, cmd.Flags(), false)
 	cmd.Flags().StringVar(&group, flagGroup, "", usageGroup)
 	cmd.Flags().StringVar(&kind, flagKind, "", usageKind)
 	cmd.Flags().StringVar(&version, flagVersion, "", usageVersion)

--- a/cli/cmd/definitions_test.go
+++ b/cli/cmd/definitions_test.go
@@ -3,11 +3,551 @@
 
 package cmd
 
-import "testing"
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
 
-func TestDefinitionsRejectsArgs(t *testing.T) {
-	_, err := execute(t, "definitions", "bogus")
-	if err == nil {
-		t.Fatal("expected error for unknown argument, got nil")
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"sigs.k8s.io/yaml"
+
+	"github.com/run-ai/karta/cli/pkg/definitions"
+	"github.com/run-ai/karta/cli/pkg/generator"
+	v1alpha1 "github.com/run-ai/karta/pkg/api/runai/v1alpha1"
+)
+
+var (
+	deploymentGVK = v1alpha1.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+	jobGVK        = v1alpha1.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"}
+	pytorchGVK    = v1alpha1.GroupVersionKind{Group: "kubeflow.org", Version: "v1", Kind: "PyTorchJob"}
+)
+
+// noClusterGetter is what running without a kubeconfig looks like. NewConfigFlags
+// cannot stand in for it: it defaults the server to http://localhost:8080, turning
+// "no kubeconfig" into a connection attempt against whatever listens there.
+func noClusterGetter() genericclioptions.RESTClientGetter {
+	return genericclioptions.NewTestConfigFlags().WithClientConfig(
+		clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+			&clientcmd.ClientConfigLoadingRules{},
+			&clientcmd.ConfigOverrides{},
+		),
+	)
+}
+
+// countingGetter records whether anything asked it for a REST config, which is
+// how a spec proves a code path never reached the cluster.
+type countingGetter struct {
+	genericclioptions.RESTClientGetter
+	calls int
+}
+
+func (g *countingGetter) ToRESTConfig() (*rest.Config, error) {
+	g.calls++
+	return g.RESTClientGetter.ToRESTConfig()
+}
+
+// kartaListServer answers the Karta list with one definition claiming gvk.
+// Loopback only, and the only way a spec drives the command's own cluster read.
+func kartaListServer(name string, gvk v1alpha1.GroupVersionKind) *httptest.Server {
+	body := fmt.Sprintf(`{"apiVersion":"run.ai/v1alpha1","kind":"KartaList",`+
+		`"metadata":{"resourceVersion":"1"},"items":[`+
+		`{"apiVersion":"run.ai/v1alpha1","kind":"Karta","metadata":{"name":%q},`+
+		`"spec":{"structureDefinition":{"rootComponent":{"name":"root",`+
+		`"kind":{"group":%q,"version":%q,"kind":%q}}}}}]}`,
+		name, gvk.Group, gvk.Version, gvk.Kind)
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, body)
+	}))
+}
+
+// clusterGetter points a client getter at an in-process server.
+func clusterGetter(server *httptest.Server) genericclioptions.RESTClientGetter {
+	api := clientcmdapi.NewConfig()
+	api.Clusters["test"] = &clientcmdapi.Cluster{Server: server.URL}
+	api.Contexts["test"] = &clientcmdapi.Context{Cluster: "test", AuthInfo: "test"}
+	api.AuthInfos["test"] = &clientcmdapi.AuthInfo{}
+	api.CurrentContext = "test"
+
+	return genericclioptions.NewTestConfigFlags().
+		WithClientConfig(clientcmd.NewDefaultClientConfig(*api, &clientcmd.ConfigOverrides{}))
+}
+
+// runDefinitions executes the command alone, capturing stdout and stderr
+// separately so specs can assert warnings never land on stdout.
+func runDefinitions(rcg genericclioptions.RESTClientGetter, args ...string) (string, string, error) {
+	cmd := newDefinitionsCommand(rcg)
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	withOutput(cmd)
+
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetContext(context.Background())
+	// Cobra reads os.Args when handed a nil slice, which a zero-argument variadic
+	// call produces, so it would parse the go test and ginkgo flags.
+	cmd.SetArgs(append([]string{}, args...))
+
+	err := cmd.Execute()
+	return stdout.String(), stderr.String(), err
+}
+
+// tableNames returns the NAME column of a rendered table, header excluded.
+// exitStatus reports the status a failure produces, the way main classifies it.
+func exitStatus(err error) int {
+	var coded interface{ ExitCode() int }
+	if errors.As(err, &coded) {
+		return coded.ExitCode()
+	}
+	return ExitError
+}
+
+func tableNames(table string) []string {
+	lines := strings.Split(strings.TrimSpace(table), "\n")
+	names := make([]string, 0, len(lines))
+	for _, line := range lines[1:] {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		names = append(names, fields[0])
+	}
+	return names
+}
+
+// newTestKarta builds a Karta claiming gvk as its root component, which is the
+// minimum the resolver needs to index it.
+func newTestKarta(name string, gvk v1alpha1.GroupVersionKind, root string, children ...string) *v1alpha1.Karta {
+	structure := v1alpha1.StructureDefinition{
+		RootComponent: v1alpha1.ComponentDefinition{Name: root, Kind: &gvk},
+	}
+	for _, child := range children {
+		structure.ChildComponents = append(structure.ChildComponents,
+			v1alpha1.ComponentDefinition{Name: child})
+	}
+	return &v1alpha1.Karta{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       v1alpha1.KartaSpec{StructureDefinition: structure},
 	}
 }
+
+var _ = Describe("karta definitions", func() {
+	It("rejects a positional argument", func() {
+		_, _, err := runDefinitions(noClusterGetter(), "bogus")
+		Expect(err).To(HaveOccurred())
+	})
+
+	Context("without cluster access", func() {
+		It("lists the catalog and exits without error", func() {
+			stdout, _, err := runDefinitions(noClusterGetter())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stdout).To(ContainSubstring(pytorchDefinition))
+			Expect(stdout).To(ContainSubstring(string(definitions.OriginCatalog)))
+		})
+
+		It("keeps stdout free of warnings", func() {
+			stdout, _, err := runDefinitions(noClusterGetter())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stdout).NotTo(ContainSubstring("warning"))
+		})
+	})
+
+	Context("table output", func() {
+		It("prints the documented header", func() {
+			stdout, _, err := runDefinitions(noClusterGetter())
+			Expect(err).NotTo(HaveOccurred())
+
+			header := strings.Fields(strings.SplitN(stdout, "\n", 2)[0])
+			Expect(header).To(Equal([]string{"NAME", "KIND", "ORIGIN", "COMPONENTS"}))
+		})
+
+		It("sorts rows by name ascending", func() {
+			stdout, _, err := runDefinitions(noClusterGetter())
+			Expect(err).NotTo(HaveOccurred())
+
+			names := tableNames(stdout)
+			Expect(names).NotTo(BeEmpty())
+			Expect(names).To(Equal(slices.Sorted(slices.Values(names))))
+		})
+	})
+
+	Context("machine-readable output", func() {
+		It("emits the definitions themselves, not table rows", func() {
+			stdout, _, err := runDefinitions(noClusterGetter(), "-o", "json")
+			Expect(err).NotTo(HaveOccurred())
+
+			var kartas []v1alpha1.Karta
+			Expect(json.Unmarshal([]byte(stdout), &kartas)).To(Succeed())
+			Expect(kartas).NotTo(BeEmpty())
+			for _, karta := range kartas {
+				Expect(karta.APIVersion).To(Equal("run.ai/v1alpha1"))
+				Expect(karta.Kind).To(Equal("Karta"))
+			}
+			Expect(stdout).NotTo(ContainSubstring(`"origin"`))
+			Expect(stdout).NotTo(ContainSubstring(`"components"`))
+		})
+
+		It("emits a yaml document stream of the same definitions", func() {
+			yamlOut, _, err := runDefinitions(noClusterGetter(), "-o", "yaml")
+			Expect(err).NotTo(HaveOccurred())
+			jsonOut, _, err := runDefinitions(noClusterGetter(), "-o", "json")
+			Expect(err).NotTo(HaveOccurred())
+
+			// A document stream, not a yaml list, so decode document by document.
+			var fromYAML, fromJSON []v1alpha1.Karta
+			for _, doc := range strings.Split(strings.TrimSpace(yamlOut), "\n---\n") {
+				var karta v1alpha1.Karta
+				Expect(yaml.Unmarshal([]byte(doc), &karta)).To(Succeed())
+				fromYAML = append(fromYAML, karta)
+			}
+			Expect(json.Unmarshal([]byte(jsonOut), &fromJSON)).To(Succeed())
+			Expect(fromYAML).To(Equal(fromJSON))
+		})
+
+		It("rejects wide, which the root enum accepts for other commands", func() {
+			_, _, err := runDefinitions(noClusterGetter(), "-o", "wide")
+			Expect(err).To(MatchError(ErrUnsupportedOutput))
+			Expect(err.Error()).To(ContainSubstring("table, json, yaml"))
+		})
+
+		It("rejects an unsupported format before reading the cluster", func() {
+			getter := &countingGetter{RESTClientGetter: noClusterGetter()}
+			_, _, err := runDefinitions(getter, "-o", "wide")
+			Expect(err).To(MatchError(ErrUnsupportedOutput))
+			// A format the command cannot render must cost no round trip: against
+			// an unreachable cluster the read would stall until it times out and
+			// emit a warning the user can do nothing about.
+			Expect(getter.calls).To(BeZero())
+		})
+	})
+})
+
+var _ = Describe("karta definitions against a cluster", func() {
+	// Every other merge spec builds a resolver itself and calls the row builder,
+	// which proves the projection and nothing about the command. The command
+	// builds its own resolver, so only a spec that drives a real cluster read can
+	// show the cluster half of the merge reaches the output at all. Serving a
+	// definition claiming a GVK the built-in catalog already covers pins both
+	// halves at once: the cluster row has to appear and the catalog row it
+	// overrides has to be gone.
+	var server *httptest.Server
+
+	BeforeEach(func() {
+		server = kartaListServer("cluster-pytorch", pytorchGVK)
+		DeferCleanup(server.Close)
+	})
+
+	// Only the table carries ORIGIN; the definitions do not record their source.
+	rowsFrom := func(table string) map[string]definitionRow {
+		GinkgoHelper()
+		lines := strings.Split(strings.TrimSpace(table), "\n")
+		byName := make(map[string]definitionRow, len(lines))
+		for _, line := range lines[1:] {
+			columns := strings.Fields(line)
+			Expect(len(columns)).To(BeNumerically(">=", 3))
+			byName[columns[0]] = definitionRow{Name: columns[0], Kind: columns[1], Origin: columns[2]}
+		}
+		return byName
+	}
+
+	It("lists the cluster definition, as cluster", func() {
+		stdout, _, err := runDefinitions(clusterGetter(server))
+		Expect(err).NotTo(HaveOccurred())
+
+		rows := rowsFrom(stdout)
+		Expect(rows).To(HaveKey("cluster-pytorch"))
+		Expect(rows["cluster-pytorch"].Origin).To(Equal(string(definitions.OriginCluster)))
+		Expect(rows["cluster-pytorch"].Kind).To(Equal("PyTorchJob"))
+	})
+
+	It("drops the catalog definition the cluster one overrides", func() {
+		stdout, _, err := runDefinitions(clusterGetter(server))
+		Expect(err).NotTo(HaveOccurred())
+
+		// Listing the shadowed catalog row alongside the cluster one would tell
+		// the user two definitions cover PyTorchJob when only one ever wins.
+		Expect(rowsFrom(stdout)).NotTo(HaveKey(pytorchDefinition))
+	})
+
+	It("narrows to the cluster definition", func() {
+		stdout, _, err := runDefinitions(clusterGetter(server), "--group", "kubeflow.org", "--kind", "PyTorchJob")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tableNames(stdout)).To(Equal([]string{"cluster-pytorch"}))
+		Expect(stdout).To(ContainSubstring(string(definitions.OriginCluster)))
+	})
+
+	It("still lists the catalog definitions the cluster says nothing about", func() {
+		stdout, _, err := runDefinitions(clusterGetter(server))
+		Expect(err).NotTo(HaveOccurred())
+
+		rows := rowsFrom(stdout)
+		Expect(rows).To(HaveKey(jobsetDefinition))
+		Expect(rows[jobsetDefinition].Origin).To(Equal(string(definitions.OriginCatalog)))
+	})
+})
+
+var _ = Describe("a definition that names no workload type", func() {
+	// Valid per the CRD: rootComponent.kind is optional, so a cluster can hold a
+	// Karta the CLI cannot look anything up with. It still has to be visible.
+	rootless := func(name string) *v1alpha1.Karta {
+		return &v1alpha1.Karta{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: v1alpha1.KartaSpec{StructureDefinition: v1alpha1.StructureDefinition{
+				RootComponent: v1alpha1.ComponentDefinition{Name: "mystery"}}},
+		}
+	}
+
+	It("appears in the table with a placeholder kind", func() {
+		var stdout, stderr bytes.Buffer
+		rows := definitionRows(definitions.New(nil, []*v1alpha1.Karta{rootless("broken-karta")}).List())
+		Expect(renderDefinitions(&stdout, &stderr, rows)).To(Succeed())
+
+		Expect(tableNames(stdout.String())).To(Equal([]string{"broken-karta"}))
+		Expect(stdout.String()).To(ContainSubstring("<none>"))
+	})
+
+	It("never leaks the table placeholder into a machine format", func() {
+		var stdout bytes.Buffer
+		defs := definitions.New(nil, []*v1alpha1.Karta{rootless("broken-karta")}).List()
+		Expect(renderRawDefinitions(&stdout, defs, generator.OutputJSON)).To(Succeed())
+
+		// "<none>" is a column affordance, never part of the data.
+		Expect(stdout.String()).NotTo(ContainSubstring("<none>"))
+		Expect(stdout.String()).To(ContainSubstring("broken-karta"))
+	})
+})
+
+var _ = Describe("definitionRows over a merged resolver", func() {
+	It("lists a cluster override of a catalog GVK once, as cluster", func() {
+		resolver := definitions.New(
+			[]*v1alpha1.Karta{newTestKarta("catalog-pytorch", pytorchGVK, "pytorchjob", "master", "worker")},
+			[]*v1alpha1.Karta{newTestKarta("cluster-pytorch", pytorchGVK, "pytorchjob", "runner")},
+		)
+
+		Expect(definitionRows(resolver.List())).To(Equal([]definitionRow{{
+			Name:       "cluster-pytorch",
+			Kind:       "PyTorchJob",
+			Origin:     string(definitions.OriginCluster),
+			Components: []string{"pytorchjob", "runner"},
+		}}))
+	})
+
+	It("lists every cluster definition claiming one GVK", func() {
+		resolver := definitions.New(nil, []*v1alpha1.Karta{
+			newTestKarta("zulu-job", jobGVK, "job"),
+			newTestKarta("alpha-job", jobGVK, "job"),
+		})
+
+		rows := definitionRows(resolver.List())
+		Expect(rows).To(HaveLen(2))
+		Expect([]string{rows[0].Name, rows[1].Name}).To(Equal([]string{"alpha-job", "zulu-job"}))
+		Expect(rows[0].Origin).To(Equal(string(definitions.OriginCluster)))
+		Expect(rows[1].Origin).To(Equal(string(definitions.OriginCluster)))
+	})
+
+	It("sorts by name even though the resolver lists by GVK", func() {
+		// GVK order puts apps/v1 ahead of batch/v1, so the resolver hands over
+		// zulu first and only the row builder can produce name order.
+		resolver := definitions.New([]*v1alpha1.Karta{
+			newTestKarta("zulu", deploymentGVK, "deployment"),
+			newTestKarta("alpha", jobGVK, "job"),
+		}, nil)
+
+		Expect(resolver.List()[0].Karta.Name).To(Equal("zulu"))
+
+		rows := definitionRows(resolver.List())
+		Expect([]string{rows[0].Name, rows[1].Name}).To(Equal([]string{"alpha", "zulu"}))
+	})
+})
+
+var _ = Describe("rendering an empty definition list", func() {
+	It("notes the empty table on stderr and writes nothing to stdout", func() {
+		var stdout, stderr bytes.Buffer
+		Expect(renderDefinitions(&stdout, &stderr, definitionRows(nil))).To(Succeed())
+		Expect(stdout.String()).To(BeEmpty())
+		Expect(stderr.String()).To(ContainSubstring("No Karta definitions found."))
+	})
+
+	It("emits an empty json array with no note", func() {
+		var stdout bytes.Buffer
+		Expect(renderRawDefinitions(&stdout, nil, generator.OutputJSON)).To(Succeed())
+		Expect(strings.TrimSpace(stdout.String())).To(Equal("[]"))
+	})
+})
+
+var _ = DescribeTable("rendering an output format the command cannot produce",
+	func(format generator.Output) {
+		var stdout bytes.Buffer
+		err := renderRawDefinitions(&stdout, nil, format)
+		Expect(err).To(MatchError(ErrUnsupportedOutput))
+		Expect(err.Error()).To(ContainSubstring("table, json, yaml"))
+		Expect(stdout.String()).To(BeEmpty())
+	},
+	Entry("wide", generator.OutputWide),
+	Entry("a format outside the enum", generator.Output("toml")),
+)
+
+// Asserted verbatim: only the name tells one definition of a kind from another.
+const (
+	jobsetDefinition         = "jobset-x-k8s-io-jobset-v1alpha2"
+	pytorchDefinition        = "kubeflow-org-pytorchjob-v1"
+	dynamoV1alpha1Definition = "nvidia-com-dynamographdeployment-v1alpha1"
+	dynamoV1beta1Definition  = "nvidia-com-dynamographdeployment-v1beta1"
+)
+
+var _ = Describe("karta definitions --group --kind --version", func() {
+	DescribeTable("narrows to the definitions the filter covers",
+		func(args []string, expected ...string) {
+			stdout, _, err := runDefinitions(noClusterGetter(), args...)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tableNames(stdout)).To(Equal(expected))
+		},
+		Entry("a group alone", []string{"--group", "jobset.x-k8s.io"}, jobsetDefinition),
+		Entry("a group and kind", []string{"--group", "jobset.x-k8s.io", "--kind", "JobSet"}, jobsetDefinition),
+		Entry("a kind in the user's casing",
+			[]string{"--group", "jobset.x-k8s.io", "--kind", "jobset"}, jobsetDefinition),
+		Entry("a kind covered at two versions", []string{"--group", "nvidia.com", "--kind", "DynamoGraphDeployment"},
+			dynamoV1alpha1Definition, dynamoV1beta1Definition),
+		Entry("that kind pinned to one version",
+			[]string{"--group", "nvidia.com", "--kind", "DynamoGraphDeployment", "--version", "v1beta1"},
+			dynamoV1beta1Definition),
+		Entry("the core group, which is the empty string",
+			[]string{"--group", "", "--kind", "Pod"}, "core-pod-v1"),
+	)
+
+	It("prints every definition covering a kind rather than picking one", func() {
+		stdout, _, err := runDefinitions(noClusterGetter(), "--group", "nvidia.com", "--kind", "DynamoGraphDeployment")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tableNames(stdout)).To(Equal([]string{dynamoV1alpha1Definition, dynamoV1beta1Definition}))
+		Expect(strings.Count(stdout, "DynamoGraphDeployment")).To(Equal(2))
+	})
+
+	DescribeTable("reports a workload type no definition covers",
+		func(args []string, named string) {
+			stdout, _, err := runDefinitions(noClusterGetter(), args...)
+			Expect(err).To(HaveOccurred())
+			// Not a usage error: the flags were well formed, nothing covers them.
+			Expect(exitStatus(err)).To(Equal(ExitError))
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("no Karta definition covers %q", named)))
+			Expect(err.Error()).To(ContainSubstring(`Run "karta definitions" to see what is available`))
+			Expect(stdout).To(BeEmpty())
+		},
+		Entry("an unknown group", []string{"--group", "nosuch.io"}, "nosuch.io"),
+		Entry("a pluralized kind, which the root kind no longer matches",
+			[]string{"--group", "jobset.x-k8s.io", "--kind", "jobsets"}, "jobset.x-k8s.io, Kind=jobsets"),
+		Entry("a known kind at an unknown version",
+			[]string{"--group", "nvidia.com", "--kind", "DynamoGraphDeployment", "--version", "v9"},
+			"nvidia.com/v9, Kind=DynamoGraphDeployment"),
+		Entry("a known kind in the wrong group",
+			[]string{"--group", "wrong.group", "--kind", "JobSet"}, "wrong.group, Kind=JobSet"),
+	)
+
+	DescribeTable("rejects a filter that addresses nothing",
+		func(args []string, wanted string) {
+			getter := &countingGetter{RESTClientGetter: noClusterGetter()}
+			_, _, err := runDefinitions(getter, args...)
+			Expect(exitStatus(err)).To(Equal(ExitUsage))
+			Expect(err.Error()).To(ContainSubstring(wanted))
+			Expect(getter.calls).To(BeZero())
+		},
+		Entry("a kind with no group", []string{"--kind", "JobSet"}, "--kind needs --group"),
+		Entry("a version with no kind", []string{"--group", "nvidia.com", "--version", "v1"}, "--version needs --kind"),
+		Entry("a version with neither", []string{"--version", "v1"}, "--version needs --kind"),
+		Entry("an empty kind", []string{"--group", "nvidia.com", "--kind", ""}, "--kind needs a value"),
+		Entry("an empty version",
+			[]string{"--group", "nvidia.com", "--kind", "DynamoGraphDeployment", "--version", ""},
+			"--version needs a value"),
+	)
+
+	Context("machine-readable output", func() {
+		It("separates several matches into a yaml document stream", func() {
+			stdout, _, err := runDefinitions(noClusterGetter(),
+				"--group", "nvidia.com", "--kind", "DynamoGraphDeployment", "-o", "yaml")
+			Expect(err).NotTo(HaveOccurred())
+
+			docs := strings.Split(strings.TrimSpace(stdout), "\n---\n")
+			Expect(docs).To(HaveLen(2))
+
+			names := make([]string, 0, len(docs))
+			for _, doc := range docs {
+				var karta v1alpha1.Karta
+				Expect(yaml.Unmarshal([]byte(doc), &karta)).To(Succeed())
+				Expect(karta.Kind).To(Equal("Karta"))
+				names = append(names, karta.Name)
+			}
+			Expect(names).To(Equal([]string{dynamoV1alpha1Definition, dynamoV1beta1Definition}))
+		})
+
+		It("emits the raw definitions as a json array", func() {
+			stdout, _, err := runDefinitions(noClusterGetter(), "--group", "jobset.x-k8s.io", "-o", "json")
+			Expect(err).NotTo(HaveOccurred())
+
+			var kartas []v1alpha1.Karta
+			Expect(json.Unmarshal([]byte(stdout), &kartas)).To(Succeed())
+			Expect(kartas).To(HaveLen(1))
+			Expect(kartas[0].Name).To(Equal(jobsetDefinition))
+			Expect(kartas[0].Spec.StructureDefinition.RootComponent.Name).NotTo(BeEmpty())
+		})
+	})
+})
+
+var _ = Describe("definitionFilter", func() {
+	It("narrows a kind covered at two versions down to the requested one", func() {
+		defs := definitions.New(nil, []*v1alpha1.Karta{
+			newTestKarta("job-v1", jobGVK, "job"),
+			newTestKarta("job-v2", v1alpha1.GroupVersionKind{Group: "batch", Version: "v2", Kind: "Job"}, "job"),
+		}).List()
+
+		Expect(definitionFilter{group: "batch", kind: "Job", set: true}.narrow(defs)).To(HaveLen(2))
+
+		pinned := definitionFilter{group: "batch", kind: "Job", version: "v2", set: true}.narrow(defs)
+		Expect(pinned).To(HaveLen(1))
+		Expect(pinned[0].Karta.Name).To(Equal("job-v2"))
+		Expect(pinned[0].Origin).To(Equal(definitions.OriginCluster))
+	})
+
+	It("matches a core workload whose root group is empty", func() {
+		defs := definitions.New([]*v1alpha1.Karta{
+			newTestKarta("core-pod", v1alpha1.GroupVersionKind{Version: "v1", Kind: "Pod"}, "pod"),
+		}, nil).List()
+
+		Expect(definitionFilter{group: "", kind: "Pod", set: true}.narrow(defs)).To(HaveLen(1))
+		Expect(definitionFilter{group: "core", kind: "Pod", set: true}.narrow(defs)).To(BeEmpty())
+	})
+
+	It("never matches a definition that names no workload type", func() {
+		defs := definitions.New(nil, []*v1alpha1.Karta{{
+			ObjectMeta: metav1.ObjectMeta{Name: "rootless"},
+			Spec: v1alpha1.KartaSpec{StructureDefinition: v1alpha1.StructureDefinition{
+				RootComponent: v1alpha1.ComponentDefinition{Name: "mystery"}}},
+		}}).List()
+
+		// Its root GVK is the zero value, which --group "" would otherwise sweep up.
+		Expect(definitionFilter{group: "", set: true}.narrow(defs)).To(BeEmpty())
+	})
+
+	DescribeTable("names the filter the way apimachinery names a GVK",
+		func(filter definitionFilter, want string) {
+			Expect(filter.String()).To(Equal(want))
+		},
+		Entry("group only", definitionFilter{group: "nvidia.com"}, "nvidia.com"),
+		Entry("group and kind", definitionFilter{group: "nvidia.com", kind: "Dynamo"}, "nvidia.com, Kind=Dynamo"),
+		Entry("all three", definitionFilter{group: "nvidia.com", version: "v1", kind: "Dynamo"},
+			"nvidia.com/v1, Kind=Dynamo"),
+		Entry("the core group", definitionFilter{group: "", version: "v1", kind: "Pod"}, "/v1, Kind=Pod"),
+	)
+})

--- a/cli/cmd/definitions_test.go
+++ b/cli/cmd/definitions_test.go
@@ -147,7 +147,7 @@ func newTestKarta(name string, gvk v1alpha1.GroupVersionKind, root string, child
 	}
 }
 
-var _ = Describe("karta definitions", func() {
+var _ = Describe("kli definitions", func() {
 	It("rejects a positional argument", func() {
 		_, _, err := runDefinitions(noClusterGetter(), []string{"bogus"})
 		Expect(err).To(HaveOccurred())
@@ -236,7 +236,7 @@ var _ = Describe("karta definitions", func() {
 	})
 })
 
-var _ = Describe("karta definitions against a cluster", func() {
+var _ = Describe("kli definitions against a cluster", func() {
 	// Only a spec driving a real cluster read shows the cluster half of the merge
 	// reaching the output. Serving a GVK the catalog already covers pins both
 	// halves: the cluster row appears and the catalog row it overrides is gone.
@@ -390,7 +390,7 @@ const (
 	dynamoV1beta1Definition  = "nvidia-com-dynamographdeployment-v1beta1"
 )
 
-var _ = Describe("karta definitions NAME", func() {
+var _ = Describe("kli definitions NAME", func() {
 	It("narrows the table to the named definition", func() {
 		stdout, _, err := runDefinitions(noClusterGetter(), []string{pytorchDefinition})
 		Expect(err).NotTo(HaveOccurred())
@@ -436,7 +436,7 @@ var _ = Describe("karta definitions NAME", func() {
 		stdout, _, err := runDefinitions(noClusterGetter(), []string{"nosuchname"})
 		Expect(exitStatus(err)).To(Equal(ExitError))
 		Expect(err.Error()).To(ContainSubstring(`no Karta definition named "nosuchname"`))
-		Expect(err.Error()).To(ContainSubstring(`Run "karta definitions" to see what is available`))
+		Expect(err.Error()).To(ContainSubstring(`Run "kli definitions" to see what is available`))
 		Expect(stdout).To(BeEmpty())
 	})
 
@@ -459,7 +459,7 @@ var _ = Describe("karta definitions NAME", func() {
 	})
 })
 
-var _ = Describe("karta definitions --group --kind --version", func() {
+var _ = Describe("kli definitions --group --kind --version", func() {
 	DescribeTable("narrows to the definitions the filter covers",
 		func(args []string, expected []string) {
 			stdout, _, err := runDefinitions(noClusterGetter(), args)
@@ -495,7 +495,7 @@ var _ = Describe("karta definitions --group --kind --version", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(exitStatus(err)).To(Equal(ExitError))
 			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("no Karta definition covers %q", named)))
-			Expect(err.Error()).To(ContainSubstring(`Run "karta definitions" to see what is available`))
+			Expect(err.Error()).To(ContainSubstring(`Run "kli definitions" to see what is available`))
 			Expect(stdout).To(BeEmpty())
 		},
 		Entry("an unknown group", []string{"--group", "nosuch.io"}, "nosuch.io"),

--- a/cli/cmd/definitions_test.go
+++ b/cli/cmd/definitions_test.go
@@ -46,8 +46,7 @@ func noClusterGetter() genericclioptions.RESTClientGetter {
 	)
 }
 
-// countingGetter records whether anything asked it for a REST config, which is
-// how a spec proves a code path never reached the cluster.
+// countingGetter proves a code path never reached the cluster.
 type countingGetter struct {
 	genericclioptions.RESTClientGetter
 	calls int
@@ -59,7 +58,6 @@ func (g *countingGetter) ToRESTConfig() (*rest.Config, error) {
 }
 
 // kartaListServer answers the Karta list with one definition claiming gvk.
-// Loopback only, and the only way a spec drives the command's own cluster read.
 func kartaListServer(name string, gvk v1alpha1.GroupVersionKind) *httptest.Server {
 	body := fmt.Sprintf(`{"apiVersion":"run.ai/v1alpha1","kind":"KartaList",`+
 		`"metadata":{"resourceVersion":"1"},"items":[`+
@@ -74,7 +72,6 @@ func kartaListServer(name string, gvk v1alpha1.GroupVersionKind) *httptest.Serve
 	}))
 }
 
-// clusterGetter points a client getter at an in-process server.
 func clusterGetter(server *httptest.Server) genericclioptions.RESTClientGetter {
 	api := clientcmdapi.NewConfig()
 	api.Clusters["test"] = &clientcmdapi.Cluster{Server: server.URL}
@@ -86,9 +83,9 @@ func clusterGetter(server *httptest.Server) genericclioptions.RESTClientGetter {
 		WithClientConfig(clientcmd.NewDefaultClientConfig(*api, &clientcmd.ConfigOverrides{}))
 }
 
-// runDefinitions executes the command alone, capturing stdout and stderr
-// separately so specs can assert warnings never land on stdout.
-func runDefinitions(rcg genericclioptions.RESTClientGetter, args ...string) (string, string, error) {
+// runDefinitions captures stdout and stderr separately, so a spec can assert
+// warnings never land on stdout.
+func runDefinitions(rcg genericclioptions.RESTClientGetter, args []string) (string, string, error) {
 	cmd := newDefinitionsCommand(rcg)
 	cmd.SilenceUsage = true
 	cmd.SilenceErrors = true
@@ -106,7 +103,6 @@ func runDefinitions(rcg genericclioptions.RESTClientGetter, args ...string) (str
 	return stdout.String(), stderr.String(), err
 }
 
-// tableNames returns the NAME column of a rendered table, header excluded.
 // exitStatus reports the status a failure produces, the way main classifies it.
 func exitStatus(err error) int {
 	var coded interface{ ExitCode() int }
@@ -129,9 +125,8 @@ func tableNames(table string) []string {
 	return names
 }
 
-// newTestKarta builds a Karta claiming gvk as its root component, which is the
-// minimum the resolver needs to index it.
-func newTestKarta(name string, gvk v1alpha1.GroupVersionKind, root string, children ...string) *v1alpha1.Karta {
+// newTestKarta claims gvk as its root component, the minimum to be indexed.
+func newTestKarta(name string, gvk v1alpha1.GroupVersionKind, root string, children []string) *v1alpha1.Karta {
 	structure := v1alpha1.StructureDefinition{
 		RootComponent: v1alpha1.ComponentDefinition{Name: root, Kind: &gvk},
 	}
@@ -147,20 +142,20 @@ func newTestKarta(name string, gvk v1alpha1.GroupVersionKind, root string, child
 
 var _ = Describe("karta definitions", func() {
 	It("rejects a positional argument", func() {
-		_, _, err := runDefinitions(noClusterGetter(), "bogus")
+		_, _, err := runDefinitions(noClusterGetter(), []string{"bogus"})
 		Expect(err).To(HaveOccurred())
 	})
 
 	Context("without cluster access", func() {
 		It("lists the catalog and exits without error", func() {
-			stdout, _, err := runDefinitions(noClusterGetter())
+			stdout, _, err := runDefinitions(noClusterGetter(), nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(stdout).To(ContainSubstring(pytorchDefinition))
 			Expect(stdout).To(ContainSubstring(string(definitions.OriginCatalog)))
 		})
 
 		It("keeps stdout free of warnings", func() {
-			stdout, _, err := runDefinitions(noClusterGetter())
+			stdout, _, err := runDefinitions(noClusterGetter(), nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(stdout).NotTo(ContainSubstring("warning"))
 		})
@@ -168,7 +163,7 @@ var _ = Describe("karta definitions", func() {
 
 	Context("table output", func() {
 		It("prints the documented header", func() {
-			stdout, _, err := runDefinitions(noClusterGetter())
+			stdout, _, err := runDefinitions(noClusterGetter(), nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			header := strings.Fields(strings.SplitN(stdout, "\n", 2)[0])
@@ -176,7 +171,7 @@ var _ = Describe("karta definitions", func() {
 		})
 
 		It("sorts rows by name ascending", func() {
-			stdout, _, err := runDefinitions(noClusterGetter())
+			stdout, _, err := runDefinitions(noClusterGetter(), nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			names := tableNames(stdout)
@@ -187,7 +182,7 @@ var _ = Describe("karta definitions", func() {
 
 	Context("machine-readable output", func() {
 		It("emits the definitions themselves, not table rows", func() {
-			stdout, _, err := runDefinitions(noClusterGetter(), "-o", "json")
+			stdout, _, err := runDefinitions(noClusterGetter(), []string{"-o", "json"})
 			Expect(err).NotTo(HaveOccurred())
 
 			var kartas []v1alpha1.Karta
@@ -202,9 +197,9 @@ var _ = Describe("karta definitions", func() {
 		})
 
 		It("emits a yaml document stream of the same definitions", func() {
-			yamlOut, _, err := runDefinitions(noClusterGetter(), "-o", "yaml")
+			yamlOut, _, err := runDefinitions(noClusterGetter(), []string{"-o", "yaml"})
 			Expect(err).NotTo(HaveOccurred())
-			jsonOut, _, err := runDefinitions(noClusterGetter(), "-o", "json")
+			jsonOut, _, err := runDefinitions(noClusterGetter(), []string{"-o", "json"})
 			Expect(err).NotTo(HaveOccurred())
 
 			// A document stream, not a yaml list, so decode document by document.
@@ -219,31 +214,25 @@ var _ = Describe("karta definitions", func() {
 		})
 
 		It("rejects wide, which the root enum accepts for other commands", func() {
-			_, _, err := runDefinitions(noClusterGetter(), "-o", "wide")
+			_, _, err := runDefinitions(noClusterGetter(), []string{"-o", "wide"})
 			Expect(err).To(MatchError(ErrUnsupportedOutput))
 			Expect(err.Error()).To(ContainSubstring("table, json, yaml"))
 		})
 
 		It("rejects an unsupported format before reading the cluster", func() {
 			getter := &countingGetter{RESTClientGetter: noClusterGetter()}
-			_, _, err := runDefinitions(getter, "-o", "wide")
+			_, _, err := runDefinitions(getter, []string{"-o", "wide"})
 			Expect(err).To(MatchError(ErrUnsupportedOutput))
-			// A format the command cannot render must cost no round trip: against
-			// an unreachable cluster the read would stall until it times out and
-			// emit a warning the user can do nothing about.
+			// A format the command cannot render must cost no round trip.
 			Expect(getter.calls).To(BeZero())
 		})
 	})
 })
 
 var _ = Describe("karta definitions against a cluster", func() {
-	// Every other merge spec builds a resolver itself and calls the row builder,
-	// which proves the projection and nothing about the command. The command
-	// builds its own resolver, so only a spec that drives a real cluster read can
-	// show the cluster half of the merge reaches the output at all. Serving a
-	// definition claiming a GVK the built-in catalog already covers pins both
-	// halves at once: the cluster row has to appear and the catalog row it
-	// overrides has to be gone.
+	// Only a spec driving a real cluster read shows the cluster half of the merge
+	// reaching the output. Serving a GVK the catalog already covers pins both
+	// halves: the cluster row appears and the catalog row it overrides is gone.
 	var server *httptest.Server
 
 	BeforeEach(func() {
@@ -265,7 +254,7 @@ var _ = Describe("karta definitions against a cluster", func() {
 	}
 
 	It("lists the cluster definition, as cluster", func() {
-		stdout, _, err := runDefinitions(clusterGetter(server))
+		stdout, _, err := runDefinitions(clusterGetter(server), nil)
 		Expect(err).NotTo(HaveOccurred())
 
 		rows := rowsFrom(stdout)
@@ -275,23 +264,21 @@ var _ = Describe("karta definitions against a cluster", func() {
 	})
 
 	It("drops the catalog definition the cluster one overrides", func() {
-		stdout, _, err := runDefinitions(clusterGetter(server))
+		stdout, _, err := runDefinitions(clusterGetter(server), nil)
 		Expect(err).NotTo(HaveOccurred())
 
-		// Listing the shadowed catalog row alongside the cluster one would tell
-		// the user two definitions cover PyTorchJob when only one ever wins.
 		Expect(rowsFrom(stdout)).NotTo(HaveKey(pytorchDefinition))
 	})
 
 	It("narrows to the cluster definition", func() {
-		stdout, _, err := runDefinitions(clusterGetter(server), "--group", "kubeflow.org", "--kind", "PyTorchJob")
+		stdout, _, err := runDefinitions(clusterGetter(server), []string{"--group", "kubeflow.org", "--kind", "PyTorchJob"})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(tableNames(stdout)).To(Equal([]string{"cluster-pytorch"}))
 		Expect(stdout).To(ContainSubstring(string(definitions.OriginCluster)))
 	})
 
 	It("still lists the catalog definitions the cluster says nothing about", func() {
-		stdout, _, err := runDefinitions(clusterGetter(server))
+		stdout, _, err := runDefinitions(clusterGetter(server), nil)
 		Expect(err).NotTo(HaveOccurred())
 
 		rows := rowsFrom(stdout)
@@ -301,8 +288,7 @@ var _ = Describe("karta definitions against a cluster", func() {
 })
 
 var _ = Describe("a definition that names no workload type", func() {
-	// Valid per the CRD: rootComponent.kind is optional, so a cluster can hold a
-	// Karta the CLI cannot look anything up with. It still has to be visible.
+	// rootComponent.kind is optional per the CRD, so this is valid and must list.
 	rootless := func(name string) *v1alpha1.Karta {
 		return &v1alpha1.Karta{
 			ObjectMeta: metav1.ObjectMeta{Name: name},
@@ -334,8 +320,8 @@ var _ = Describe("a definition that names no workload type", func() {
 var _ = Describe("definitionRows over a merged resolver", func() {
 	It("lists a cluster override of a catalog GVK once, as cluster", func() {
 		resolver := definitions.New(
-			[]*v1alpha1.Karta{newTestKarta("catalog-pytorch", pytorchGVK, "pytorchjob", "master", "worker")},
-			[]*v1alpha1.Karta{newTestKarta("cluster-pytorch", pytorchGVK, "pytorchjob", "runner")},
+			[]*v1alpha1.Karta{newTestKarta("catalog-pytorch", pytorchGVK, "pytorchjob", []string{"master", "worker"})},
+			[]*v1alpha1.Karta{newTestKarta("cluster-pytorch", pytorchGVK, "pytorchjob", []string{"runner"})},
 		)
 
 		Expect(definitionRows(resolver.List())).To(Equal([]definitionRow{{
@@ -348,8 +334,8 @@ var _ = Describe("definitionRows over a merged resolver", func() {
 
 	It("lists every cluster definition claiming one GVK", func() {
 		resolver := definitions.New(nil, []*v1alpha1.Karta{
-			newTestKarta("zulu-job", jobGVK, "job"),
-			newTestKarta("alpha-job", jobGVK, "job"),
+			newTestKarta("zulu-job", jobGVK, "job", nil),
+			newTestKarta("alpha-job", jobGVK, "job", nil),
 		})
 
 		rows := definitionRows(resolver.List())
@@ -363,8 +349,8 @@ var _ = Describe("definitionRows over a merged resolver", func() {
 		// GVK order puts apps/v1 ahead of batch/v1, so the resolver hands over
 		// zulu first and only the row builder can produce name order.
 		resolver := definitions.New([]*v1alpha1.Karta{
-			newTestKarta("zulu", deploymentGVK, "deployment"),
-			newTestKarta("alpha", jobGVK, "job"),
+			newTestKarta("zulu", deploymentGVK, "deployment", nil),
+			newTestKarta("alpha", jobGVK, "job", nil),
 		}, nil)
 
 		Expect(resolver.List()[0].Karta.Name).To(Equal("zulu"))
@@ -411,26 +397,29 @@ const (
 
 var _ = Describe("karta definitions --group --kind --version", func() {
 	DescribeTable("narrows to the definitions the filter covers",
-		func(args []string, expected ...string) {
-			stdout, _, err := runDefinitions(noClusterGetter(), args...)
+		func(args []string, expected []string) {
+			stdout, _, err := runDefinitions(noClusterGetter(), args)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(tableNames(stdout)).To(Equal(expected))
 		},
-		Entry("a group alone", []string{"--group", "jobset.x-k8s.io"}, jobsetDefinition),
-		Entry("a group and kind", []string{"--group", "jobset.x-k8s.io", "--kind", "JobSet"}, jobsetDefinition),
+		Entry("a group alone",
+			[]string{"--group", "jobset.x-k8s.io"}, []string{jobsetDefinition}),
+		Entry("a group and kind",
+			[]string{"--group", "jobset.x-k8s.io", "--kind", "JobSet"}, []string{jobsetDefinition}),
 		Entry("a kind in the user's casing",
-			[]string{"--group", "jobset.x-k8s.io", "--kind", "jobset"}, jobsetDefinition),
-		Entry("a kind covered at two versions", []string{"--group", "nvidia.com", "--kind", "DynamoGraphDeployment"},
-			dynamoV1alpha1Definition, dynamoV1beta1Definition),
+			[]string{"--group", "jobset.x-k8s.io", "--kind", "jobset"}, []string{jobsetDefinition}),
+		Entry("a kind covered at two versions",
+			[]string{"--group", "nvidia.com", "--kind", "DynamoGraphDeployment"},
+			[]string{dynamoV1alpha1Definition, dynamoV1beta1Definition}),
 		Entry("that kind pinned to one version",
 			[]string{"--group", "nvidia.com", "--kind", "DynamoGraphDeployment", "--version", "v1beta1"},
-			dynamoV1beta1Definition),
+			[]string{dynamoV1beta1Definition}),
 		Entry("the core group, which is the empty string",
-			[]string{"--group", "", "--kind", "Pod"}, "core-pod-v1"),
+			[]string{"--group", "", "--kind", "Pod"}, []string{"core-pod-v1"}),
 	)
 
 	It("prints every definition covering a kind rather than picking one", func() {
-		stdout, _, err := runDefinitions(noClusterGetter(), "--group", "nvidia.com", "--kind", "DynamoGraphDeployment")
+		stdout, _, err := runDefinitions(noClusterGetter(), []string{"--group", "nvidia.com", "--kind", "DynamoGraphDeployment"})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(tableNames(stdout)).To(Equal([]string{dynamoV1alpha1Definition, dynamoV1beta1Definition}))
 		Expect(strings.Count(stdout, "DynamoGraphDeployment")).To(Equal(2))
@@ -438,9 +427,8 @@ var _ = Describe("karta definitions --group --kind --version", func() {
 
 	DescribeTable("reports a workload type no definition covers",
 		func(args []string, named string) {
-			stdout, _, err := runDefinitions(noClusterGetter(), args...)
+			stdout, _, err := runDefinitions(noClusterGetter(), args)
 			Expect(err).To(HaveOccurred())
-			// Not a usage error: the flags were well formed, nothing covers them.
 			Expect(exitStatus(err)).To(Equal(ExitError))
 			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("no Karta definition covers %q", named)))
 			Expect(err.Error()).To(ContainSubstring(`Run "karta definitions" to see what is available`))
@@ -459,7 +447,7 @@ var _ = Describe("karta definitions --group --kind --version", func() {
 	DescribeTable("rejects a filter that addresses nothing",
 		func(args []string, wanted string) {
 			getter := &countingGetter{RESTClientGetter: noClusterGetter()}
-			_, _, err := runDefinitions(getter, args...)
+			_, _, err := runDefinitions(getter, args)
 			Expect(exitStatus(err)).To(Equal(ExitUsage))
 			Expect(err.Error()).To(ContainSubstring(wanted))
 			Expect(getter.calls).To(BeZero())
@@ -475,8 +463,7 @@ var _ = Describe("karta definitions --group --kind --version", func() {
 
 	Context("machine-readable output", func() {
 		It("separates several matches into a yaml document stream", func() {
-			stdout, _, err := runDefinitions(noClusterGetter(),
-				"--group", "nvidia.com", "--kind", "DynamoGraphDeployment", "-o", "yaml")
+			stdout, _, err := runDefinitions(noClusterGetter(), []string{"--group", "nvidia.com", "--kind", "DynamoGraphDeployment", "-o", "yaml"})
 			Expect(err).NotTo(HaveOccurred())
 
 			docs := strings.Split(strings.TrimSpace(stdout), "\n---\n")
@@ -493,7 +480,7 @@ var _ = Describe("karta definitions --group --kind --version", func() {
 		})
 
 		It("emits the raw definitions as a json array", func() {
-			stdout, _, err := runDefinitions(noClusterGetter(), "--group", "jobset.x-k8s.io", "-o", "json")
+			stdout, _, err := runDefinitions(noClusterGetter(), []string{"--group", "jobset.x-k8s.io", "-o", "json"})
 			Expect(err).NotTo(HaveOccurred())
 
 			var kartas []v1alpha1.Karta
@@ -508,8 +495,8 @@ var _ = Describe("karta definitions --group --kind --version", func() {
 var _ = Describe("definitionFilter", func() {
 	It("narrows a kind covered at two versions down to the requested one", func() {
 		defs := definitions.New(nil, []*v1alpha1.Karta{
-			newTestKarta("job-v1", jobGVK, "job"),
-			newTestKarta("job-v2", v1alpha1.GroupVersionKind{Group: "batch", Version: "v2", Kind: "Job"}, "job"),
+			newTestKarta("job-v1", jobGVK, "job", nil),
+			newTestKarta("job-v2", v1alpha1.GroupVersionKind{Group: "batch", Version: "v2", Kind: "Job"}, "job", nil),
 		}).List()
 
 		Expect(definitionFilter{group: "batch", kind: "Job", set: true}.narrow(defs)).To(HaveLen(2))
@@ -522,7 +509,7 @@ var _ = Describe("definitionFilter", func() {
 
 	It("matches a core workload whose root group is empty", func() {
 		defs := definitions.New([]*v1alpha1.Karta{
-			newTestKarta("core-pod", v1alpha1.GroupVersionKind{Version: "v1", Kind: "Pod"}, "pod"),
+			newTestKarta("core-pod", v1alpha1.GroupVersionKind{Version: "v1", Kind: "Pod"}, "pod", nil),
 		}, nil).List()
 
 		Expect(definitionFilter{group: "", kind: "Pod", set: true}.narrow(defs)).To(HaveLen(1))

--- a/cli/cmd/definitions_test.go
+++ b/cli/cmd/definitions_test.go
@@ -390,6 +390,75 @@ const (
 	dynamoV1beta1Definition  = "nvidia-com-dynamographdeployment-v1beta1"
 )
 
+var _ = Describe("karta definitions NAME", func() {
+	It("narrows the table to the named definition", func() {
+		stdout, _, err := runDefinitions(noClusterGetter(), []string{pytorchDefinition})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tableNames(stdout)).To(Equal([]string{pytorchDefinition}))
+	})
+
+	It("emits that definition itself as a json array of one", func() {
+		stdout, _, err := runDefinitions(noClusterGetter(), []string{pytorchDefinition, "-o", "json"})
+		Expect(err).NotTo(HaveOccurred())
+
+		var kartas []v1alpha1.Karta
+		Expect(json.Unmarshal([]byte(stdout), &kartas)).To(Succeed())
+		Expect(kartas).To(HaveLen(1))
+		Expect(kartas[0].Name).To(Equal(pytorchDefinition))
+		Expect(kartas[0].Kind).To(Equal("Karta"))
+	})
+
+	It("emits that definition itself as a single yaml document", func() {
+		stdout, _, err := runDefinitions(noClusterGetter(), []string{pytorchDefinition, "-o", "yaml"})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Separator between documents, so one match carries none and the output
+		// is a bare Karta rather than a list of one.
+		Expect(stdout).NotTo(ContainSubstring("---"))
+
+		var karta v1alpha1.Karta
+		Expect(yaml.Unmarshal([]byte(stdout), &karta)).To(Succeed())
+		Expect(karta.Name).To(Equal(pytorchDefinition))
+		Expect(karta.Kind).To(Equal("Karta"))
+	})
+
+	It("prefers the cluster definition when a name exists in both sources", func() {
+		server := kartaListServer(pytorchDefinition, pytorchGVK)
+		DeferCleanup(server.Close)
+
+		stdout, _, err := runDefinitions(clusterGetter(server), []string{pytorchDefinition})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stdout).To(ContainSubstring(string(definitions.OriginCluster)))
+		Expect(stdout).NotTo(ContainSubstring(string(definitions.OriginCatalog)))
+	})
+
+	It("reports a name no definition carries", func() {
+		stdout, _, err := runDefinitions(noClusterGetter(), []string{"nosuchname"})
+		Expect(exitStatus(err)).To(Equal(ExitError))
+		Expect(err.Error()).To(ContainSubstring(`no Karta definition named "nosuchname"`))
+		Expect(err.Error()).To(ContainSubstring(`Run "karta definitions" to see what is available`))
+		Expect(stdout).To(BeEmpty())
+	})
+
+	DescribeTable("rejects a name given alongside a filter",
+		func(args []string) {
+			getter := &countingGetter{RESTClientGetter: noClusterGetter()}
+			_, _, err := runDefinitions(getter, args)
+			Expect(exitStatus(err)).To(Equal(ExitUsage))
+			Expect(err.Error()).To(ContainSubstring("give one or the other"))
+			Expect(getter.calls).To(BeZero())
+		},
+		Entry("a group", []string{pytorchDefinition, "--group", "kubeflow.org"}),
+		Entry("the core group, which is the empty string",
+			[]string{pytorchDefinition, "--group", ""}),
+	)
+
+	It("rejects a second name", func() {
+		_, _, err := runDefinitions(noClusterGetter(), []string{"one", "two"})
+		Expect(exitStatus(err)).To(Equal(ExitUsage))
+	})
+})
+
 var _ = Describe("karta definitions --group --kind --version", func() {
 	DescribeTable("narrows to the definitions the filter covers",
 		func(args []string, expected []string) {

--- a/cli/cmd/definitions_test.go
+++ b/cli/cmd/definitions_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"slices"
@@ -104,6 +105,12 @@ func runDefinitions(rcg genericclioptions.RESTClientGetter, args []string) (stri
 }
 
 // exitStatus reports the status a failure produces, the way main classifies it.
+// unusedTable fails the spec if a machine format reaches the table callback.
+func unusedTable(io.Writer) error {
+	Fail("the table renderer must not run for a machine format")
+	return nil
+}
+
 func exitStatus(err error) int {
 	var coded interface{ ExitCode() int }
 	if errors.As(err, &coded) {
@@ -215,14 +222,14 @@ var _ = Describe("karta definitions", func() {
 
 		It("rejects wide, which the root enum accepts for other commands", func() {
 			_, _, err := runDefinitions(noClusterGetter(), []string{"-o", "wide"})
-			Expect(err).To(MatchError(ErrUnsupportedOutput))
+			Expect(err).To(MatchError(generator.ErrUnsupportedOutput))
 			Expect(err.Error()).To(ContainSubstring("table, json, yaml"))
 		})
 
 		It("rejects an unsupported format before reading the cluster", func() {
 			getter := &countingGetter{RESTClientGetter: noClusterGetter()}
 			_, _, err := runDefinitions(getter, []string{"-o", "wide"})
-			Expect(err).To(MatchError(ErrUnsupportedOutput))
+			Expect(err).To(MatchError(generator.ErrUnsupportedOutput))
 			// A format the command cannot render must cost no round trip.
 			Expect(getter.calls).To(BeZero())
 		})
@@ -308,8 +315,8 @@ var _ = Describe("a definition that names no workload type", func() {
 
 	It("never leaks the table placeholder into a machine format", func() {
 		var stdout bytes.Buffer
-		defs := definitions.New(nil, []*v1alpha1.Karta{rootless("broken-karta")}).List()
-		Expect(renderRawDefinitions(&stdout, defs, generator.OutputJSON)).To(Succeed())
+		kartas := []*v1alpha1.Karta{rootless("broken-karta")}
+		Expect(generator.Render(&stdout, generator.OutputJSON, kartas, unusedTable)).To(Succeed())
 
 		// "<none>" is a column affordance, never part of the data.
 		Expect(stdout.String()).NotTo(ContainSubstring("<none>"))
@@ -370,22 +377,10 @@ var _ = Describe("rendering an empty definition list", func() {
 
 	It("emits an empty json array with no note", func() {
 		var stdout bytes.Buffer
-		Expect(renderRawDefinitions(&stdout, nil, generator.OutputJSON)).To(Succeed())
+		Expect(generator.Render[*v1alpha1.Karta](&stdout, generator.OutputJSON, nil, unusedTable)).To(Succeed())
 		Expect(strings.TrimSpace(stdout.String())).To(Equal("[]"))
 	})
 })
-
-var _ = DescribeTable("rendering an output format the command cannot produce",
-	func(format generator.Output) {
-		var stdout bytes.Buffer
-		err := renderRawDefinitions(&stdout, nil, format)
-		Expect(err).To(MatchError(ErrUnsupportedOutput))
-		Expect(err.Error()).To(ContainSubstring("table, json, yaml"))
-		Expect(stdout.String()).To(BeEmpty())
-	},
-	Entry("wide", generator.OutputWide),
-	Entry("a format outside the enum", generator.Output("toml")),
-)
 
 // Asserted verbatim: only the name tells one definition of a kind from another.
 const (

--- a/cli/cmd/definitions_test.go
+++ b/cli/cmd/definitions_test.go
@@ -34,6 +34,12 @@ var (
 	pytorchGVK    = v1alpha1.GroupVersionKind{Group: "kubeflow.org", Version: "v1", Kind: "PyTorchJob"}
 )
 
+// countingGetter proves a code path never reached the cluster.
+type countingGetter struct {
+	genericclioptions.RESTClientGetter
+	calls int
+}
+
 // noClusterGetter is what running without a kubeconfig looks like. NewConfigFlags
 // cannot stand in for it: it defaults the server to http://localhost:8080, turning
 // "no kubeconfig" into a connection attempt against whatever listens there.
@@ -44,12 +50,6 @@ func noClusterGetter() genericclioptions.RESTClientGetter {
 			&clientcmd.ConfigOverrides{},
 		),
 	)
-}
-
-// countingGetter proves a code path never reached the cluster.
-type countingGetter struct {
-	genericclioptions.RESTClientGetter
-	calls int
 }
 
 func (g *countingGetter) ToRESTConfig() (*rest.Config, error) {

--- a/cli/cmd/definitions_test.go
+++ b/cli/cmd/definitions_test.go
@@ -90,7 +90,7 @@ func runDefinitions(rcg genericclioptions.RESTClientGetter, args []string) (stri
 	cmd := newDefinitionsCommand(rcg)
 	cmd.SilenceUsage = true
 	cmd.SilenceErrors = true
-	withOutput(cmd)
+	cmd.SetFlagErrorFunc(usageError)
 
 	var stdout, stderr bytes.Buffer
 	cmd.SetOut(&stdout)
@@ -222,14 +222,15 @@ var _ = Describe("kli definitions", func() {
 
 		It("rejects wide, which the root enum accepts for other commands", func() {
 			_, _, err := runDefinitions(noClusterGetter(), []string{"-o", "wide"})
-			Expect(err).To(MatchError(generator.ErrUnsupportedOutput))
-			Expect(err.Error()).To(ContainSubstring("table, json, yaml"))
+			Expect(exitStatus(err)).To(Equal(ExitUsage))
+			// The flag lists what this command renders, so wide never parses here.
+			Expect(err.Error()).To(ContainSubstring("must be one of table, json, yaml"))
 		})
 
 		It("rejects an unsupported format before reading the cluster", func() {
 			getter := &countingGetter{RESTClientGetter: noClusterGetter()}
 			_, _, err := runDefinitions(getter, []string{"-o", "wide"})
-			Expect(err).To(MatchError(generator.ErrUnsupportedOutput))
+			Expect(exitStatus(err)).To(Equal(ExitUsage))
 			// A format the command cannot render must cost no round trip.
 			Expect(getter.calls).To(BeZero())
 		})

--- a/cli/cmd/definitions_test.go
+++ b/cli/cmd/definitions_test.go
@@ -5,8 +5,8 @@ package cmd
 
 import "testing"
 
-func TestDefinitionRejectsArgs(t *testing.T) {
-	_, err := execute(t, "definition", "bogus")
+func TestDefinitionsRejectsArgs(t *testing.T) {
+	_, err := execute(t, "definitions", "bogus")
 	if err == nil {
 		t.Fatal("expected error for unknown argument, got nil")
 	}

--- a/cli/cmd/enum.go
+++ b/cli/cmd/enum.go
@@ -57,8 +57,13 @@ func (e *Enum[T]) Allowed() []string {
 }
 
 // NewOutputFlag returns an Enum backing the -o/--output flag, defaulting to
-// table.
-func NewOutputFlag() *Enum[generator.Output] {
-	return NewEnum("output", generator.OutputTable,
-		generator.OutputTable, generator.OutputWide, generator.OutputJSON, generator.OutputYAML)
+// table. A command rendering no extra columns leaves wide out, so the flag
+// rejects it at parse time rather than the command rejecting it later.
+func NewOutputFlag(supportsWide bool) *Enum[generator.Output] {
+	allowed := []generator.Output{generator.OutputTable}
+	if supportsWide {
+		allowed = append(allowed, generator.OutputWide)
+	}
+	allowed = append(allowed, generator.OutputJSON, generator.OutputYAML)
+	return NewEnum("output", generator.OutputTable, allowed...)
 }

--- a/cli/cmd/enum_test.go
+++ b/cli/cmd/enum_test.go
@@ -5,13 +5,14 @@ package cmd
 
 import (
 	"errors"
+	"slices"
 	"testing"
 
 	"github.com/run-ai/karta/cli/pkg/generator"
 )
 
 func TestOutputSetValid(t *testing.T) {
-	o := NewOutputFlag()
+	o := NewOutputFlag(true)
 	for _, v := range o.Allowed() {
 		if err := o.Set(v); err != nil {
 			t.Errorf("Set(%q) returned error: %v", v, err)
@@ -26,7 +27,7 @@ func TestOutputSetValid(t *testing.T) {
 }
 
 func TestOutputSetInvalid(t *testing.T) {
-	o := NewOutputFlag()
+	o := NewOutputFlag(true)
 	err := o.Set("bogus")
 	if err == nil {
 		t.Fatal("expected error for invalid output value, got nil")
@@ -40,8 +41,23 @@ func TestOutputSetInvalid(t *testing.T) {
 	}
 }
 
+// A command rendering no extra columns leaves wide out, so the flag refuses it
+// at parse time rather than the command refusing it later.
+func TestOutputWithoutWide(t *testing.T) {
+	o := NewOutputFlag(false)
+	if slices.Contains(o.Allowed(), string(generator.OutputWide)) {
+		t.Errorf("wide is still allowed: %v", o.Allowed())
+	}
+	if err := o.Set(string(generator.OutputWide)); !errors.Is(err, ErrInvalidValue) {
+		t.Errorf("Set(wide) = %v, want ErrInvalidValue", err)
+	}
+	if !slices.Contains(NewOutputFlag(true).Allowed(), string(generator.OutputWide)) {
+		t.Error("wide is missing when the command supports it")
+	}
+}
+
 func TestOutputType(t *testing.T) {
-	if got := NewOutputFlag().Type(); got != "output" {
+	if got := NewOutputFlag(true).Type(); got != "output" {
 		t.Errorf("Type() = %q, want %q", got, "output")
 	}
 }

--- a/cli/cmd/flags.go
+++ b/cli/cmd/flags.go
@@ -4,16 +4,25 @@
 package cmd
 
 import (
+	"errors"
+	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/run-ai/karta/cli/pkg/generator"
 )
 
 const (
 	flagConfig = "config"
 	flagOutput = "output"
 )
+
+// ErrOutputFlagUnavailable reports -o/--output missing from a command's scope,
+// a wiring mistake rather than anything a user can cause.
+var ErrOutputFlagUnavailable = errors.New("output flag not available")
 
 var kubeFlags *genericclioptions.ConfigFlags
 
@@ -27,6 +36,34 @@ func withOutput(cmd *cobra.Command) {
 		func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 			return out.Allowed(), cobra.ShellCompDirectiveNoFileComp
 		}))
+}
+
+// outputFormat returns the typed value of -o/--output. Lookup resolves the flag
+// wherever an ancestor registered it, so a leaf reads what the root parsed.
+func outputFormat(cmd *cobra.Command) (generator.Output, error) {
+	f := cmd.Flags().Lookup(flagOutput)
+	if f == nil {
+		return "", fmt.Errorf("%w: --%s is not registered", ErrOutputFlagUnavailable, flagOutput)
+	}
+	out, ok := f.Value.(*Enum[generator.Output])
+	if !ok {
+		return "", fmt.Errorf("%w: --%s is backed by %T", ErrOutputFlagUnavailable, flagOutput, f.Value)
+	}
+	return out.Get(), nil
+}
+
+// supportedOutput rejects a format the caller does not render. The allowed set
+// is a parameter because commands differ. Validating before any cluster read
+// keeps a bad format from costing a round trip.
+func supportedOutput(cmd *cobra.Command, allowed ...generator.Output) (generator.Output, error) {
+	format, err := outputFormat(cmd)
+	if err != nil {
+		return "", err
+	}
+	if !slices.Contains(allowed, format) {
+		return "", usageError(cmd, unsupportedOutputError(format, allowed))
+	}
+	return format, nil
 }
 
 // withConfig registers the --config persistent flag on cmd.

--- a/cli/cmd/flags.go
+++ b/cli/cmd/flags.go
@@ -6,10 +6,10 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	"github.com/run-ai/karta/cli/pkg/generator"
@@ -24,11 +24,12 @@ var ErrOutputFlagUnavailable = errors.New("output flag not available")
 
 var kubeFlags *genericclioptions.ConfigFlags
 
-// withOutput registers the -o/--output enum persistent flag on cmd, backed by
-// generator.Output, along with its shell completion.
-func withOutput(cmd *cobra.Command) {
-	out := NewOutputFlag()
-	cmd.PersistentFlags().VarP(out, flagOutput, "o",
+// withOutput registers the -o/--output enum on flags, backed by generator.Output,
+// along with its shell completion. A command registering its own on cmd.Flags()
+// shadows the root's for that command.
+func withOutput(cmd *cobra.Command, flags *pflag.FlagSet, supportsWide bool) {
+	out := NewOutputFlag(supportsWide)
+	flags.VarP(out, flagOutput, "o",
 		"Output format: one of "+strings.Join(out.Allowed(), ", "))
 	cobra.CheckErr(cmd.RegisterFlagCompletionFunc(flagOutput,
 		func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
@@ -48,17 +49,6 @@ func outputFormat(cmd *cobra.Command) (generator.Output, error) {
 		return "", fmt.Errorf("%w: --%s is backed by %T", ErrOutputFlagUnavailable, flagOutput, f.Value)
 	}
 	return out.Get(), nil
-}
-
-func supportedOutput(cmd *cobra.Command, allowed []generator.Output) (generator.Output, error) {
-	format, err := outputFormat(cmd)
-	if err != nil {
-		return "", err
-	}
-	if !slices.Contains(allowed, format) {
-		return "", usageError(cmd, unsupportedOutputError(format, allowed))
-	}
-	return format, nil
 }
 
 // withConfig registers the --config persistent flag on cmd.

--- a/cli/cmd/flags.go
+++ b/cli/cmd/flags.go
@@ -4,8 +4,6 @@
 package cmd
 
 import (
-	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -20,14 +18,12 @@ const (
 	flagOutput = "output"
 )
 
-var ErrOutputFlagUnavailable = errors.New("output flag not available")
-
 var kubeFlags *genericclioptions.ConfigFlags
 
 // withOutput registers the -o/--output enum on flags, backed by generator.Output,
 // along with its shell completion. A command registering its own on cmd.Flags()
 // shadows the root's for that command.
-func withOutput(cmd *cobra.Command, flags *pflag.FlagSet, supportsWide bool) {
+func withOutput(cmd *cobra.Command, flags *pflag.FlagSet, supportsWide bool) *Enum[generator.Output] {
 	out := NewOutputFlag(supportsWide)
 	flags.VarP(out, flagOutput, "o",
 		"Output format: one of "+strings.Join(out.Allowed(), ", "))
@@ -35,20 +31,7 @@ func withOutput(cmd *cobra.Command, flags *pflag.FlagSet, supportsWide bool) {
 		func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 			return out.Allowed(), cobra.ShellCompDirectiveNoFileComp
 		}))
-}
-
-// outputFormat returns the typed value of -o/--output. Lookup resolves the flag
-// wherever an ancestor registered it, so a leaf reads what the root parsed.
-func outputFormat(cmd *cobra.Command) (generator.Output, error) {
-	f := cmd.Flags().Lookup(flagOutput)
-	if f == nil {
-		return "", fmt.Errorf("%w: --%s is not registered", ErrOutputFlagUnavailable, flagOutput)
-	}
-	out, ok := f.Value.(*Enum[generator.Output])
-	if !ok {
-		return "", fmt.Errorf("%w: --%s is backed by %T", ErrOutputFlagUnavailable, flagOutput, f.Value)
-	}
-	return out.Get(), nil
+	return out
 }
 
 // withConfig registers the --config persistent flag on cmd.

--- a/cli/cmd/flags.go
+++ b/cli/cmd/flags.go
@@ -20,8 +20,6 @@ const (
 	flagOutput = "output"
 )
 
-// ErrOutputFlagUnavailable reports -o/--output missing from a command's scope,
-// a wiring mistake rather than anything a user can cause.
 var ErrOutputFlagUnavailable = errors.New("output flag not available")
 
 var kubeFlags *genericclioptions.ConfigFlags
@@ -52,10 +50,7 @@ func outputFormat(cmd *cobra.Command) (generator.Output, error) {
 	return out.Get(), nil
 }
 
-// supportedOutput rejects a format the caller does not render. The allowed set
-// is a parameter because commands differ. Validating before any cluster read
-// keeps a bad format from costing a round trip.
-func supportedOutput(cmd *cobra.Command, allowed ...generator.Output) (generator.Output, error) {
+func supportedOutput(cmd *cobra.Command, allowed []generator.Output) (generator.Output, error) {
 	format, err := outputFormat(cmd)
 	if err != nil {
 		return "", err

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -62,7 +62,7 @@ func NewRootCommand() *cobra.Command {
 	cmd.SetFlagErrorFunc(usageError)
 
 	kubeFlags.AddFlags(cmd.PersistentFlags())
-	withOutput(cmd)
+	withOutput(cmd, cmd.PersistentFlags(), true)
 	withConfig(cmd)
 
 	cmd.AddCommand(newWorkloadCommand())

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -66,7 +66,7 @@ func NewRootCommand() *cobra.Command {
 	withConfig(cmd)
 
 	cmd.AddCommand(newWorkloadCommand())
-	cmd.AddCommand(newDefinitionsCommand())
+	cmd.AddCommand(newDefinitionsCommand(kubeFlags))
 
 	cmd.InitDefaultCompletionCmd()
 	for _, sub := range cmd.Commands() {

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -66,7 +66,7 @@ func NewRootCommand() *cobra.Command {
 	withConfig(cmd)
 
 	cmd.AddCommand(newWorkloadCommand())
-	cmd.AddCommand(newDefinitionCommand())
+	cmd.AddCommand(newDefinitionsCommand())
 
 	cmd.InitDefaultCompletionCmd()
 	for _, sub := range cmd.Commands() {

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -14,13 +14,13 @@ import (
 	"github.com/run-ai/karta/pkg/version"
 )
 
-// NewRootCommand builds the root command for the karta binary. Global flags are
+// NewRootCommand builds the root command for the kli binary. Global flags are
 // registered as persistent flags so every subcommand inherits them.
 func NewRootCommand() *cobra.Command {
 	kubeFlags = genericclioptions.NewConfigFlags(true)
 
 	cmd := &cobra.Command{
-		Use:   "karta",
+		Use:   "kli",
 		Short: "Workload-aware visibility for any Kubernetes workload type",
 		Long: "Karta gives operators a uniform view of any Kubernetes workload type, " +
 			"built on the Karta abstraction layer. Inspect workloads running in a " +

--- a/cli/cmd/workload.go
+++ b/cli/cmd/workload.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// newWorkloadCommand builds the "karta workload" command tree.
+// newWorkloadCommand builds the "kli workload" command tree.
 func newWorkloadCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "workload",

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -11,6 +11,7 @@ require (
 	k8s.io/apimachinery v0.36.3
 	k8s.io/cli-runtime v0.36.3
 	k8s.io/client-go v0.36.3
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -79,7 +80,6 @@ require (
 	sigs.k8s.io/kustomize/kyaml v0.21.1 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.3 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
 replace github.com/run-ai/karta => ../

--- a/cli/main.go
+++ b/cli/main.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 NVIDIA Corporation
 
-// Command karta is the Karta CLI: workload-aware visibility for any Kubernetes
+// Command kli is the Karta CLI: workload-aware visibility for any Kubernetes
 // workload type. It builds on the Karta abstraction layer to list and describe
 // workloads and the definitions Karta understands.
 package main
@@ -37,7 +37,7 @@ func main() {
 	// Silencing Cobra also silenced its usage hint, which is the whole value of
 	// distinguishing a usage error.
 	if coded.ExitCode() == cmd.ExitUsage {
-		path := "karta"
+		path := "kli"
 		var located interface{ UsagePath() string }
 		if errors.As(err, &located) && located.UsagePath() != "" {
 			path = located.UsagePath()

--- a/cli/pkg/definitions/resolver_test.go
+++ b/cli/pkg/definitions/resolver_test.go
@@ -213,9 +213,9 @@ var _ = Describe("Resolver List", func() {
 
 		Expect(namesOf(New(catalog, cluster).List())).To(Equal(want))
 
-		reversedCommunity := []*v1alpha1.Karta{catalog[1], catalog[0]}
+		reversedCatalog := []*v1alpha1.Karta{catalog[1], catalog[0]}
 		reversedCluster := []*v1alpha1.Karta{cluster[1], cluster[0]}
-		Expect(namesOf(New(reversedCommunity, reversedCluster).List())).To(Equal(want))
+		Expect(namesOf(New(reversedCatalog, reversedCluster).List())).To(Equal(want))
 	})
 })
 

--- a/cli/pkg/generator/render.go
+++ b/cli/pkg/generator/render.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package generator
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+)
+
+var ErrUnsupportedOutput = errors.New("unsupported output format")
+
+// Render writes items in the machine formats and hands the human ones to table.
+func Render[T any](out io.Writer, format Output, items []T, table func(io.Writer) error) error {
+	switch format {
+	case OutputTable, OutputWide:
+		return table(out)
+
+	case OutputJSON:
+		if items == nil {
+			// A nil slice marshals as null, where an empty result is an empty list.
+			items = []T{}
+		}
+		encoder := json.NewEncoder(out)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(items); err != nil {
+			return fmt.Errorf("encode as json: %w", err)
+		}
+		return nil
+
+	case OutputYAML:
+		docs := make([]string, 0, len(items))
+		for _, item := range items {
+			data, err := yaml.Marshal(item)
+			if err != nil {
+				return fmt.Errorf("encode as yaml: %w", err)
+			}
+			docs = append(docs, string(data))
+		}
+		// A document stream, not a List object kubectl would need told about.
+		if _, err := io.WriteString(out, strings.Join(docs, "---\n")); err != nil {
+			return fmt.Errorf("write yaml: %w", err)
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("%w %q", ErrUnsupportedOutput, format)
+	}
+}

--- a/cli/pkg/generator/render_test.go
+++ b/cli/pkg/generator/render_test.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package generator_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/run-ai/karta/cli/pkg/generator"
+)
+
+type item struct {
+	Name string `json:"name"`
+}
+
+var items = []item{{Name: "alpha"}, {Name: "beta"}}
+
+// unusedTable fails the spec if a machine format reaches the table callback.
+func unusedTable(io.Writer) error {
+	Fail("the table callback must not run for a machine format")
+	return nil
+}
+
+var _ = Describe("Render", func() {
+	DescribeTable("hands the human formats to the table callback",
+		func(format generator.Output) {
+			var out bytes.Buffer
+			called := false
+			Expect(generator.Render(&out, format, items, func(w io.Writer) error {
+				called = true
+				_, err := io.WriteString(w, "TABLE")
+				return err
+			})).To(Succeed())
+
+			Expect(called).To(BeTrue())
+			Expect(out.String()).To(Equal("TABLE"))
+		},
+		Entry("table", generator.OutputTable),
+		// wide reaches the callback so a command that renders extra columns can.
+		// One that cannot must reject wide before calling Render.
+		Entry("wide", generator.OutputWide),
+	)
+
+	It("returns what the table callback returns", func() {
+		boom := errors.New("boom")
+		err := generator.Render(io.Discard, generator.OutputTable, items,
+			func(io.Writer) error { return boom })
+		Expect(err).To(MatchError(boom))
+	})
+
+	It("encodes json through the json tags", func() {
+		var out bytes.Buffer
+		Expect(generator.Render(&out, generator.OutputJSON, items, unusedTable)).To(Succeed())
+		Expect(out.String()).To(ContainSubstring(`"name": "alpha"`))
+	})
+
+	It("emits an empty json array for no items, not null", func() {
+		var out bytes.Buffer
+		Expect(generator.Render[item](&out, generator.OutputJSON, nil, unusedTable)).To(Succeed())
+		Expect(strings.TrimSpace(out.String())).To(Equal("[]"))
+	})
+
+	It("emits yaml as a document stream, not a list", func() {
+		var out bytes.Buffer
+		Expect(generator.Render(&out, generator.OutputYAML, items, unusedTable)).To(Succeed())
+
+		// Separator between documents, so two documents carry one separator.
+		Expect(strings.Count(out.String(), "\n---\n")).To(Equal(1))
+		Expect(strings.Split(out.String(), "\n---\n")).To(HaveLen(2))
+		Expect(out.String()).NotTo(ContainSubstring("- name:"))
+	})
+
+	It("names the format it cannot render", func() {
+		var out bytes.Buffer
+		err := generator.Render(&out, generator.Output("toml"), items, unusedTable)
+		Expect(err).To(MatchError(generator.ErrUnsupportedOutput))
+		Expect(err.Error()).To(ContainSubstring(`"toml"`))
+		Expect(out.String()).To(BeEmpty())
+	})
+})

--- a/cli/pkg/generator/suite_test.go
+++ b/cli/pkg/generator/suite_test.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package generator_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestGenerator(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Generator Suite")
+}


### PR DESCRIPTION
## What does this PR do?

Adds `karta definitions`, which lists every Karta definition the CLI understands. It
merges the built-in catalog with the definitions installed in the cluster, and a cluster
definition overriding a catalog one for the same workload type is listed once, as
cluster. Without cluster access the command still lists the catalog , which is
the catalog-only user the issue is written for.

`--group`, with optional `--kind` and `--version`, narrows the list to one workload type.
They nest: a kind outside a group would match across unrelated APIs, and a version
outside a kind is not a workload type. A filter that stops short matches everything below
it, which is a result rather than an ambiguity, because the catalog ships
DynamoGraphDeployment at two versions.

The table is the human view and the only rendering carrying ORIGIN. `-o json` and
`-o yaml` always emit the definitions themselves, so `karta definitions -o yaml |
kubectl apply -f -` round-trips. 

## Related issue(s)

#202

## Tests

Unit, `cli/cmd`: 63 specs.

- lists the catalog with no cluster access, and keeps warnings off stdout
- merges a cluster definition over a catalog one, and lists the ones the cluster does not
  mention
- the three filters, alone and combined, including a kind in the user's casing and the
  core group as the empty string
- a filter matching nothing, and each way the flags can be combined wrongly
- json and yaml emit the definitions, and agree with each other
- an unsupported format is rejected before any cluster read

End to end, against minikube with the CRD installed. Fixtures were created, asserted and
deleted; the cluster's existing definition was left untouched.

- a cluster definition lists as cluster
- a cluster definition overriding a catalog GVK collapses to one row
- two cluster definitions on one GVK warn and both list
- `-o yaml` output is accepted by `kubectl apply --dry-run=server`, 24 of 24 documents
- a definition naming no workload type lists as `<none>` and no filter matches it
- list permission denied warns and still lists the catalog, exit 0

## Checklist

- [x] All commits are signed off with DCO (`git commit -s`)
- [x] New/modified files have SPDX license and copyright headers
- [ ] Documentation updated (if applicable)
- [x] Tests pass (`make check`)
- [x] No proprietary or internal information included

#202 still describes the removed `--for` flag and a positional argument. It is being
updated separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added named-definition selection to the `definitions` command.
  * Added consistent table, wide, JSON, and YAML output.
  * Added filtering, sorting, merging, overrides, and rootless definition support.

* **Bug Fixes**
  * Improved validation and error messages for invalid names and output formats.
  * JSON output now represents empty results as empty arrays.
  * YAML output is emitted as properly separated documents.

* **Tests**
  * Expanded coverage for listing, selection, formatting, validation, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->