### PR TITLE
feat(cli): carry machine output under items with a count

### DIFF
--- a/cli/cmd/definitions.go
+++ b/cli/cmd/definitions.go
@@ -38,7 +38,7 @@ catalog definitions.
 
 Give a NAME to address one definition, or use --group, and optionally --kind and
 --version, to narrow the list to one workload type. The table is the human view; json
-and yaml always emit the definitions themselves.`
+and yaml carry the definitions themselves, under an items key.`
 
 	definitionsExample = `  # Everything the CLI understands (catalog + cluster)
   kli definitions
@@ -49,7 +49,7 @@ and yaml always emit the definitions themselves.`
   # Which definition covers JobSet?
   kli definitions --group jobset.x-k8s.io --kind JobSet
 
-  # Dump them as applyable YAML
+  # Dump them as YAML
   kli definitions -o yaml`
 )
 

--- a/cli/cmd/definitions_test.go
+++ b/cli/cmd/definitions_test.go
@@ -6,7 +6,6 @@ package cmd
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -192,8 +191,7 @@ var _ = Describe("kli definitions", func() {
 			stdout, _, err := runDefinitions(noClusterGetter(), []string{"-o", "json"})
 			Expect(err).NotTo(HaveOccurred())
 
-			var kartas []v1alpha1.Karta
-			Expect(json.Unmarshal([]byte(stdout), &kartas)).To(Succeed())
+			kartas := decodeKartas(stdout)
 			Expect(kartas).NotTo(BeEmpty())
 			for _, karta := range kartas {
 				Expect(karta.APIVersion).To(Equal("run.ai/v1alpha1"))
@@ -203,21 +201,13 @@ var _ = Describe("kli definitions", func() {
 			Expect(stdout).NotTo(ContainSubstring(`"components"`))
 		})
 
-		It("emits a yaml document stream of the same definitions", func() {
+		It("agrees with json on the same definitions", func() {
 			yamlOut, _, err := runDefinitions(noClusterGetter(), []string{"-o", "yaml"})
 			Expect(err).NotTo(HaveOccurred())
 			jsonOut, _, err := runDefinitions(noClusterGetter(), []string{"-o", "json"})
 			Expect(err).NotTo(HaveOccurred())
 
-			// A document stream, not a yaml list, so decode document by document.
-			var fromYAML, fromJSON []v1alpha1.Karta
-			for _, doc := range strings.Split(strings.TrimSpace(yamlOut), "\n---\n") {
-				var karta v1alpha1.Karta
-				Expect(yaml.Unmarshal([]byte(doc), &karta)).To(Succeed())
-				fromYAML = append(fromYAML, karta)
-			}
-			Expect(json.Unmarshal([]byte(jsonOut), &fromJSON)).To(Succeed())
-			Expect(fromYAML).To(Equal(fromJSON))
+			Expect(decodeKartas(yamlOut)).To(Equal(decodeKartas(jsonOut)))
 		})
 
 		It("rejects wide, which the root enum accepts for other commands", func() {
@@ -376,10 +366,10 @@ var _ = Describe("rendering an empty definition list", func() {
 		Expect(stderr.String()).To(ContainSubstring("No Karta definitions found."))
 	})
 
-	It("emits an empty json array with no note", func() {
+	It("emits an empty json envelope with no note", func() {
 		var stdout bytes.Buffer
 		Expect(generator.Render[*v1alpha1.Karta](&stdout, generator.OutputJSON, nil, unusedTable)).To(Succeed())
-		Expect(strings.TrimSpace(stdout.String())).To(Equal("[]"))
+		Expect(decodeKartas(stdout.String())).To(BeEmpty())
 	})
 })
 
@@ -402,25 +392,20 @@ var _ = Describe("kli definitions NAME", func() {
 		stdout, _, err := runDefinitions(noClusterGetter(), []string{pytorchDefinition, "-o", "json"})
 		Expect(err).NotTo(HaveOccurred())
 
-		var kartas []v1alpha1.Karta
-		Expect(json.Unmarshal([]byte(stdout), &kartas)).To(Succeed())
+		kartas := decodeKartas(stdout)
 		Expect(kartas).To(HaveLen(1))
 		Expect(kartas[0].Name).To(Equal(pytorchDefinition))
 		Expect(kartas[0].Kind).To(Equal("Karta"))
 	})
 
-	It("emits that definition itself as a single yaml document", func() {
+	It("emits that definition itself in the yaml envelope", func() {
 		stdout, _, err := runDefinitions(noClusterGetter(), []string{pytorchDefinition, "-o", "yaml"})
 		Expect(err).NotTo(HaveOccurred())
 
-		// Separator between documents, so one match carries none and the output
-		// is a bare Karta rather than a list of one.
-		Expect(stdout).NotTo(ContainSubstring("---"))
-
-		var karta v1alpha1.Karta
-		Expect(yaml.Unmarshal([]byte(stdout), &karta)).To(Succeed())
-		Expect(karta.Name).To(Equal(pytorchDefinition))
-		Expect(karta.Kind).To(Equal("Karta"))
+		kartas := decodeKartas(stdout)
+		Expect(kartas).To(HaveLen(1))
+		Expect(kartas[0].Name).To(Equal(pytorchDefinition))
+		Expect(kartas[0].Kind).To(Equal("Karta"))
 	})
 
 	It("prefers the cluster definition when a name exists in both sources", func() {
@@ -527,29 +512,26 @@ var _ = Describe("kli definitions --group --kind --version", func() {
 	)
 
 	Context("machine-readable output", func() {
-		It("separates several matches into a yaml document stream", func() {
+		It("carries several matches in one yaml envelope", func() {
 			stdout, _, err := runDefinitions(noClusterGetter(), []string{"--group", "nvidia.com", "--kind", "DynamoGraphDeployment", "-o", "yaml"})
 			Expect(err).NotTo(HaveOccurred())
 
-			docs := strings.Split(strings.TrimSpace(stdout), "\n---\n")
-			Expect(docs).To(HaveLen(2))
+			kartas := decodeKartas(stdout)
+			Expect(kartas).To(HaveLen(2))
 
-			names := make([]string, 0, len(docs))
-			for _, doc := range docs {
-				var karta v1alpha1.Karta
-				Expect(yaml.Unmarshal([]byte(doc), &karta)).To(Succeed())
+			names := make([]string, 0, len(kartas))
+			for _, karta := range kartas {
 				Expect(karta.Kind).To(Equal("Karta"))
 				names = append(names, karta.Name)
 			}
 			Expect(names).To(Equal([]string{dynamoV1alpha1Definition, dynamoV1beta1Definition}))
 		})
 
-		It("emits the raw definitions as a json array", func() {
+		It("emits the raw definitions in the json envelope", func() {
 			stdout, _, err := runDefinitions(noClusterGetter(), []string{"--group", "jobset.x-k8s.io", "-o", "json"})
 			Expect(err).NotTo(HaveOccurred())
 
-			var kartas []v1alpha1.Karta
-			Expect(json.Unmarshal([]byte(stdout), &kartas)).To(Succeed())
+			kartas := decodeKartas(stdout)
 			Expect(kartas).To(HaveLen(1))
 			Expect(kartas[0].Name).To(Equal(jobsetDefinition))
 			Expect(kartas[0].Spec.StructureDefinition.RootComponent.Name).NotTo(BeEmpty())
@@ -603,3 +585,16 @@ var _ = Describe("definitionFilter", func() {
 		Entry("the core group", definitionFilter{group: "", version: "v1", kind: "Pod"}, "/v1, Kind=Pod"),
 	)
 })
+
+// decodeKartas reads the items the machine formats wrap their result in. yaml
+// decodes through json, so one decoder serves both.
+func decodeKartas(out string) []v1alpha1.Karta {
+	GinkgoHelper()
+	var envelope struct {
+		Items []v1alpha1.Karta `json:"items"`
+		Count int              `json:"count"`
+	}
+	Expect(yaml.Unmarshal([]byte(out), &envelope)).To(Succeed())
+	Expect(envelope.Count).To(Equal(len(envelope.Items)))
+	return envelope.Items
+}

--- a/cli/pkg/generator/render.go
+++ b/cli/pkg/generator/render.go
@@ -8,12 +8,26 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"strings"
 
 	"sigs.k8s.io/yaml"
 )
 
 var ErrUnsupportedOutput = errors.New("unsupported output format")
+
+// list is the envelope the machine formats carry, so a consumer reads one shape
+// whatever the result size, and reads the total without walking the items.
+type list[T any] struct {
+	Items []T `json:"items"`
+	Count int `json:"count"`
+}
+
+func newList[T any](items []T) list[T] {
+	if items == nil {
+		// A nil slice marshals as null, where an empty result is an empty list.
+		items = []T{}
+	}
+	return list[T]{Items: items, Count: len(items)}
+}
 
 // Render writes items in the machine formats and hands the human ones to table.
 func Render[T any](out io.Writer, format Output, items []T, table func(io.Writer) error) error {
@@ -22,28 +36,19 @@ func Render[T any](out io.Writer, format Output, items []T, table func(io.Writer
 		return table(out)
 
 	case OutputJSON:
-		if items == nil {
-			// A nil slice marshals as null, where an empty result is an empty list.
-			items = []T{}
-		}
 		encoder := json.NewEncoder(out)
 		encoder.SetIndent("", "  ")
-		if err := encoder.Encode(items); err != nil {
+		if err := encoder.Encode(newList(items)); err != nil {
 			return fmt.Errorf("encode as json: %w", err)
 		}
 		return nil
 
 	case OutputYAML:
-		docs := make([]string, 0, len(items))
-		for _, item := range items {
-			data, err := yaml.Marshal(item)
-			if err != nil {
-				return fmt.Errorf("encode as yaml: %w", err)
-			}
-			docs = append(docs, string(data))
+		data, err := yaml.Marshal(newList(items))
+		if err != nil {
+			return fmt.Errorf("encode as yaml: %w", err)
 		}
-		// A document stream, not a List object kubectl would need told about.
-		if _, err := io.WriteString(out, strings.Join(docs, "---\n")); err != nil {
+		if _, err := out.Write(data); err != nil {
 			return fmt.Errorf("write yaml: %w", err)
 		}
 		return nil

--- a/cli/pkg/generator/render_test.go
+++ b/cli/pkg/generator/render_test.go
@@ -7,10 +7,11 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/yaml"
 
 	"github.com/run-ai/karta/cli/pkg/generator"
 )
@@ -60,20 +61,27 @@ var _ = Describe("Render", func() {
 		Expect(out.String()).To(ContainSubstring(`"name": "alpha"`))
 	})
 
-	It("emits an empty json array for no items, not null", func() {
+	It("emits an empty item list for no items, not null", func() {
 		var out bytes.Buffer
 		Expect(generator.Render[item](&out, generator.OutputJSON, nil, unusedTable)).To(Succeed())
-		Expect(strings.TrimSpace(out.String())).To(Equal("[]"))
+
+		items, count := decodeEnvelope(out.String())
+		Expect(items).To(BeEmpty())
+		Expect(count).To(BeZero())
 	})
 
-	It("emits yaml as a document stream, not a list", func() {
-		var out bytes.Buffer
-		Expect(generator.Render(&out, generator.OutputYAML, items, unusedTable)).To(Succeed())
+	It("wraps yaml in the same envelope as json", func() {
+		var yamlOut, jsonOut bytes.Buffer
+		Expect(generator.Render(&yamlOut, generator.OutputYAML, items, unusedTable)).To(Succeed())
+		Expect(generator.Render(&jsonOut, generator.OutputJSON, items, unusedTable)).To(Succeed())
 
-		// Separator between documents, so two documents carry one separator.
-		Expect(strings.Count(out.String(), "\n---\n")).To(Equal(1))
-		Expect(strings.Split(out.String(), "\n---\n")).To(HaveLen(2))
-		Expect(out.String()).NotTo(ContainSubstring("- name:"))
+		// One document, not a stream, so the two formats decode alike.
+		Expect(yamlOut.String()).NotTo(ContainSubstring("\n---\n"))
+
+		fromYAML, yamlCount := decodeEnvelope(yamlOut.String())
+		fromJSON, jsonCount := decodeEnvelope(jsonOut.String())
+		Expect(fromYAML).To(Equal(fromJSON))
+		Expect(yamlCount).To(Equal(jsonCount))
 	})
 
 	It("names the format it cannot render", func() {
@@ -84,3 +92,15 @@ var _ = Describe("Render", func() {
 		Expect(out.String()).To(BeEmpty())
 	})
 })
+
+// decodeEnvelope reads the items and count the machine formats wrap a result in.
+// yaml decodes through json, so one decoder serves both.
+func decodeEnvelope(out string) ([]item, int) {
+	GinkgoHelper()
+	var envelope struct {
+		Items []item `json:"items"`
+		Count int    `json:"count"`
+	}
+	Expect(yaml.Unmarshal([]byte(out), &envelope)).To(Succeed())
+	return envelope.Items, envelope.Count
+}

--- a/cli/pkg/generator/workload_test.go
+++ b/cli/pkg/generator/workload_test.go
@@ -117,7 +117,7 @@ var _ = Describe("RenderWorkloads", func() {
 			Expect(RenderWorkloads(&out, &errOut, nil,
 				Options{Output: OutputJSON, Namespace: "ml-team"})).To(Succeed())
 
-			Expect(strings.TrimSpace(out.String())).To(Equal("[]"))
+			Expect(out.String()).To(ContainSubstring(`"items": []`))
 			Expect(errOut.Len()).To(BeZero())
 		})
 	})


### PR DESCRIPTION
## What does this PR do?

Wraps the machine-readable output of `kli get` and `kli definitions` in an envelope, so a collection arrives the way a reader expects one to:

```
{"items": [...], "count": 40}
```

A single named request stays wrapped, so a consumer never branches on shape, and the count saves walking the items to report a total.

Split out of #307 because it changes `kli definitions`, which is already merged, and so should stand on its own rather than ship behind the get command.

## Two consequences worth reviewing

`kli definitions -o yaml | kubectl apply -f -` no longer round-trips. kubectl cannot read this envelope; it needs a `v1 List` or a bare document stream. That round-trip was a stated goal in #309, so this is a deliberate reversal, not an oversight. The long help and the example that promised applyable yaml are corrected here. If the round-trip matters more than the envelope, `{"apiVersion":"v1","kind":"List","items":[...]}` would give both, at the cost of the count.

An empty result was already inconsistent, and this fixes it. `-o json` emitted `[]` while `-o yaml` emitted nothing at all, because joining zero documents yields an empty string. Both now report an empty list, and the nil-slice guard that only the json branch had lives in one place.

## Tests

Three specs pinned the old contract and move with it: two decoded a yaml document stream, and one expected a single match as a bare Karta. They now decode the envelope through a shared helper, since yaml decodes through json.

Verified against a live cluster with the Karta CRD and 37 cluster definitions installed: both formats for both commands, single and multiple matches, and the empty result.

## Related issue(s)

Refs #205

## Checklist

- [x] All commits are signed off with DCO (`git commit -s`)
- [x] New/modified files have SPDX license and copyright headers
- [x] Documentation updated (if applicable)
- [x] Tests pass (`make check`)
- [x] No proprietary or internal information included
