### PR TITLE
feat(cli): give a missing workload its own exit code

### DIFF
--- a/cli/cmd/errors.go
+++ b/cli/cmd/errors.go
@@ -5,10 +5,7 @@ package cmd
 
 import "github.com/spf13/cobra"
 
-// Exit codes. The numbers are not a contract; only that conditions differ. An
-// agent falls back differently per condition, so each one it can act on gets
-// its own code. 5 is reserved for a bare NAME matching more than one workload
-// type, which the describe command will accept later.
+// Exit codes. The numbers are not a contract; only that conditions differ.
 const (
 	ExitError            = 1 // cluster unreachable, auth failure
 	ExitUsage            = 2 // invalid flag value or argument

--- a/cli/cmd/errors.go
+++ b/cli/cmd/errors.go
@@ -5,11 +5,15 @@ package cmd
 
 import "github.com/spf13/cobra"
 
-// Exit codes. The numbers are not a contract; only that conditions differ.
+// Exit codes. The numbers are not a contract; only that conditions differ. An
+// agent falls back differently per condition, so each one it can act on gets
+// its own code. 5 is reserved for a bare NAME matching more than one workload
+// type, which the describe command will accept later.
 const (
-	ExitError    = 1 // cluster unreachable, auth failure, workload not found
-	ExitUsage    = 2 // invalid flag value or argument
-	ExitNotFound = 4 // no Karta definition covers the requested type
+	ExitError            = 1 // cluster unreachable, auth failure
+	ExitUsage            = 2 // invalid flag value or argument
+	ExitWorkloadNotFound = 3 // no such workload of the requested type
+	ExitNotFound         = 4 // no Karta definition covers the requested type
 )
 
 // exitError carries the exit code a failure should produce. A plain error still

--- a/cli/cmd/get.go
+++ b/cli/cmd/get.go
@@ -354,7 +354,9 @@ func collect(
 	mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 	switch {
 	case meta.IsNoMatchError(err) && opts.name != "":
-		return nil, namespace, nil, exitError{code: ExitError,
+		// The type is absent, so the named workload cannot exist: the caller
+		// needs the same "no such workload" fallback as a plain miss.
+		return nil, namespace, nil, exitError{code: ExitWorkloadNotFound,
 			err: fmt.Errorf("%s is not installed in this cluster", gvk.Kind)}
 	case meta.IsNoMatchError(err):
 		// No object of this type can exist, so an empty result is the answer.
@@ -376,7 +378,7 @@ func collect(
 	switch {
 	case err == nil:
 	case apierrors.IsNotFound(err) && opts.name != "":
-		return nil, namespace, nil, exitError{code: ExitError,
+		return nil, namespace, nil, exitError{code: ExitWorkloadNotFound,
 			err: fmt.Errorf("%s %q not found%s", gvk.Kind, opts.name, inNamespace(namespace))}
 	case opts.name != "":
 		return nil, namespace, nil, exitError{code: ExitError,

--- a/cli/cmd/get_test.go
+++ b/cli/cmd/get_test.go
@@ -193,13 +193,14 @@ func TestGetEmptyResultAsJSONIsAnArray(t *testing.T) {
 	}
 }
 
-// A named workload that does not exist is a distinct failure from an empty list.
+// A named workload that does not exist is a distinct failure from an empty
+// list, and from a cluster that could not be reached at all.
 func TestGetNamedWorkloadNotFound(t *testing.T) {
 	fakeCluster(t)
 
 	_, errOut, code := runGetCmd(t, "jobset/absent")
-	if code != ExitError {
-		t.Fatalf("expected exit %d, got %d\n%s", ExitError, code, errOut)
+	if code != ExitWorkloadNotFound {
+		t.Fatalf("expected exit %d, got %d\n%s", ExitWorkloadNotFound, code, errOut)
 	}
 	if !strings.Contains(errOut, "not found") {
 		t.Errorf("unexpected message: %s", errOut)
@@ -266,6 +267,20 @@ func TestGetUninstalledTypeIsAnEmptyResult(t *testing.T) {
 	}
 	if !strings.Contains(errOut, "PyTorchJob is not installed in this cluster") {
 		t.Errorf("expected the not-installed warning, got %q", errOut)
+	}
+}
+
+// Naming a workload of an absent type is not an empty result: the one workload
+// asked for is missing, which is the same fallback as a plain miss.
+func TestGetNamedWorkloadOfUninstalledType(t *testing.T) {
+	fakeCluster(t) // serves JobSet only
+
+	_, errOut, code := runGetCmd(t, "pytorchjob/absent")
+	if code != ExitWorkloadNotFound {
+		t.Fatalf("expected exit %d, got %d\n%s", ExitWorkloadNotFound, code, errOut)
+	}
+	if !strings.Contains(errOut, "PyTorchJob is not installed in this cluster") {
+		t.Errorf("unexpected message: %s", errOut)
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Adds ExitWorkloadNotFound (3) so a missing workload is tellable apart from a cluster that could not be reached, and moves the two named-get misses in collect onto it. ExitError (1) now covers only cluster and auth failures. 5 is reserved for the ambiguous bare-name case describe accepts in a later phase.

Part of a seven-PR stack implementing `kli describe` (#206). Targets `main`, which must merge first.

## Related issue(s)

Refs #206

## Checklist

- [x] All commits are signed off with DCO (`git commit -s`)
- [x] New/modified files have SPDX license and copyright headers
- [x] Documentation updated (if applicable)
- [x] Tests pass (`make check`)
- [x] No proprietary or internal information included

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Workload lookup failures now return a dedicated “workload not found” exit code.
  - Requests for unavailable workload types consistently report a not-found result while preserving diagnostic details.
  - General error codes remain reserved for issues such as cluster or authentication failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->