### PR TITLE
feat(cli): attribute live pods to a workload

### DIFF
--- a/cli/pkg/workload/pods.go
+++ b/cli/pkg/workload/pods.go
@@ -17,22 +17,15 @@ import (
 	"k8s.io/client-go/dynamic"
 )
 
-// maxOwnerDepth bounds the owner-reference walk. Real controller chains (root
-// -> intermediate -> Pod) are at most two or three hops; this guards against a
-// cycle in adversarial or malformed data.
+// maxOwnerDepth bounds the walk, which is what ends a cycle in malformed data.
+// Real chains are two or three hops.
 const maxOwnerDepth = 6
 
 // podsGVR is the fixed core/v1 Pod resource, which discovery does not need to map.
 var podsGVR = schema.GroupVersionResource{Version: "v1", Resource: "pods"}
 
-// PodAttributor attributes live Pods to a workload root by walking each
-// candidate pod's owner-reference chain, fetching intermediate controller
-// objects (ReplicaSet, Job, and so on) as needed. It caches fetched objects
-// across calls, since sibling pods usually share an intermediate owner.
-//
-// A Karta PodSelector says which component type a pod plays, never which
-// workload it belongs to, so ownership is what scopes a namespace of pods down
-// to one workload.
+// PodAttributor narrows a namespace of pods to the one workload that owns them.
+// A Karta PodSelector names a component type, never a workload.
 type PodAttributor struct {
 	dyn    dynamic.Interface
 	mapper meta.RESTMapper
@@ -104,16 +97,26 @@ func (a *PodAttributor) get(
 		return nil, fmt.Errorf("parse owner apiVersion %q: %w", ref.APIVersion, err)
 	}
 	gvk := gv.WithKind(ref.Kind)
+	mapping, err := a.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return nil, fmt.Errorf("discover %s: %w", gvk.Kind, err)
+	}
+
+	// A cluster-scoped owner is not addressed by namespace, and a namespaced
+	// request for one is a 404 that would drop the pod from its workload.
+	client := dynamic.ResourceInterface(a.dyn.Resource(mapping.Resource))
+	if mapping.Scope.Name() == meta.RESTScopeNameNamespace {
+		client = a.dyn.Resource(mapping.Resource).Namespace(namespace)
+	} else {
+		namespace = ""
+	}
+
 	key := ownerKey{gvk: gvk, namespace: namespace, name: ref.Name}
 	if cached, ok := a.cache[key]; ok {
 		return cached, nil
 	}
 
-	mapping, err := a.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
-	if err != nil {
-		return nil, fmt.Errorf("discover %s: %w", gvk.Kind, err)
-	}
-	obj, err := a.dyn.Resource(mapping.Resource).Namespace(namespace).Get(ctx, ref.Name, metav1.GetOptions{})
+	obj, err := client.Get(ctx, ref.Name, metav1.GetOptions{})
 	// Cache the miss too, so a broken chain is not re-fetched once per pod.
 	a.cache[key] = obj
 	if err != nil {

--- a/cli/pkg/workload/pods.go
+++ b/cli/pkg/workload/pods.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package workload
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+)
+
+// maxOwnerDepth bounds the owner-reference walk. Real controller chains (root
+// -> intermediate -> Pod) are at most two or three hops; this guards against a
+// cycle in adversarial or malformed data.
+const maxOwnerDepth = 6
+
+// podsGVR is the fixed core/v1 Pod resource, which discovery does not need to map.
+var podsGVR = schema.GroupVersionResource{Version: "v1", Resource: "pods"}
+
+// PodAttributor attributes live Pods to a workload root by walking each
+// candidate pod's owner-reference chain, fetching intermediate controller
+// objects (ReplicaSet, Job, and so on) as needed. It caches fetched objects
+// across calls, since sibling pods usually share an intermediate owner.
+//
+// A Karta PodSelector says which component type a pod plays, never which
+// workload it belongs to, so ownership is what scopes a namespace of pods down
+// to one workload.
+type PodAttributor struct {
+	dyn    dynamic.Interface
+	mapper meta.RESTMapper
+	cache  map[ownerKey]*unstructured.Unstructured
+}
+
+type ownerKey struct {
+	gvk       schema.GroupVersionKind
+	namespace string
+	name      string
+}
+
+func NewPodAttributor(dyn dynamic.Interface, mapper meta.RESTMapper) *PodAttributor {
+	return &PodAttributor{dyn: dyn, mapper: mapper, cache: map[ownerKey]*unstructured.Unstructured{}}
+}
+
+// Filter returns the pods whose owner-reference chain reaches rootUID. pods
+// may span namespaces, as in a cluster-wide search.
+func (a *PodAttributor) Filter(ctx context.Context, pods []corev1.Pod, rootUID types.UID) []corev1.Pod {
+	var matched []corev1.Pod
+	for i := range pods {
+		if a.belongsTo(ctx, pods[i].OwnerReferences, pods[i].Namespace, rootUID, 0) {
+			matched = append(matched, pods[i])
+		}
+	}
+	return matched
+}
+
+// belongsTo reports whether any owner in refs is, or transitively leads to,
+// rootUID.
+func (a *PodAttributor) belongsTo(
+	ctx context.Context, refs []metav1.OwnerReference, namespace string, rootUID types.UID, depth int,
+) bool {
+	if depth >= maxOwnerDepth {
+		return false
+	}
+	for _, ref := range refs {
+		if ref.UID == rootUID {
+			return true
+		}
+	}
+	controller := controllerRef(refs)
+	if controller == nil {
+		return false
+	}
+	owner, err := a.get(ctx, *controller, namespace)
+	if err != nil || owner == nil {
+		return false
+	}
+	return a.belongsTo(ctx, owner.GetOwnerReferences(), namespace, rootUID, depth+1)
+}
+
+// controllerRef returns the single owner reference with Controller set, the
+// only one an owner chain can be walked through unambiguously.
+func controllerRef(refs []metav1.OwnerReference) *metav1.OwnerReference {
+	for i := range refs {
+		if refs[i].Controller != nil && *refs[i].Controller {
+			return &refs[i]
+		}
+	}
+	return nil
+}
+
+func (a *PodAttributor) get(
+	ctx context.Context, ref metav1.OwnerReference, namespace string,
+) (*unstructured.Unstructured, error) {
+	gv, err := schema.ParseGroupVersion(ref.APIVersion)
+	if err != nil {
+		return nil, fmt.Errorf("parse owner apiVersion %q: %w", ref.APIVersion, err)
+	}
+	gvk := gv.WithKind(ref.Kind)
+	key := ownerKey{gvk: gvk, namespace: namespace, name: ref.Name}
+	if cached, ok := a.cache[key]; ok {
+		return cached, nil
+	}
+
+	mapping, err := a.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return nil, fmt.Errorf("discover %s: %w", gvk.Kind, err)
+	}
+	obj, err := a.dyn.Resource(mapping.Resource).Namespace(namespace).Get(ctx, ref.Name, metav1.GetOptions{})
+	// Cache the miss too, so a broken chain is not re-fetched once per pod.
+	a.cache[key] = obj
+	if err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+// ListPods reads every pod in namespace once, decoded to the typed shape the
+// attributor and the view both need. An empty namespace lists cluster-wide.
+func ListPods(ctx context.Context, dyn dynamic.Interface, namespace string) ([]corev1.Pod, error) {
+	list, err := dyn.Resource(podsGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	pods := make([]corev1.Pod, 0, len(list.Items))
+	for i := range list.Items {
+		var pod corev1.Pod
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(list.Items[i].Object, &pod); err != nil {
+			return nil, fmt.Errorf("decode pod %s: %w", list.Items[i].GetName(), err)
+		}
+		pods = append(pods, pod)
+	}
+	return pods, nil
+}

--- a/cli/pkg/workload/pods.go
+++ b/cli/pkg/workload/pods.go
@@ -42,16 +42,24 @@ func NewPodAttributor(dyn dynamic.Interface, mapper meta.RESTMapper) *PodAttribu
 	return &PodAttributor{dyn: dyn, mapper: mapper, cache: map[ownerKey]*unstructured.Unstructured{}}
 }
 
-// Filter returns the pods whose owner-reference chain reaches rootUID. pods
-// may span namespaces, as in a cluster-wide search.
-func (a *PodAttributor) Filter(ctx context.Context, pods []corev1.Pod, rootUID types.UID) []corev1.Pod {
+// Filter returns the pods whose owner-reference chain reaches rootUID, decoding
+// only the matches. pods may span namespaces, as in a cluster-wide search.
+func (a *PodAttributor) Filter(
+	ctx context.Context, pods []unstructured.Unstructured, rootUID types.UID,
+) ([]corev1.Pod, error) {
 	var matched []corev1.Pod
 	for i := range pods {
-		if a.belongsTo(ctx, pods[i].OwnerReferences, pods[i].Namespace, rootUID, 0) {
-			matched = append(matched, pods[i])
+		if !a.belongsTo(ctx, pods[i].GetOwnerReferences(), pods[i].GetNamespace(), rootUID, 0) {
+			continue
 		}
+
+		var pod corev1.Pod
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(pods[i].Object, &pod); err != nil {
+			return nil, fmt.Errorf("decode pod %s: %w", pods[i].GetName(), err)
+		}
+		matched = append(matched, pod)
 	}
-	return matched
+	return matched, nil
 }
 
 // belongsTo reports whether any owner in refs is, or transitively leads to,
@@ -125,20 +133,12 @@ func (a *PodAttributor) get(
 	return obj, nil
 }
 
-// ListPods reads every pod in namespace once, decoded to the typed shape the
-// attributor and the view both need. An empty namespace lists cluster-wide.
-func ListPods(ctx context.Context, dyn dynamic.Interface, namespace string) ([]corev1.Pod, error) {
+// ListPods reads every pod in namespace once, left undecoded for Filter to
+// narrow. An empty namespace lists cluster-wide.
+func ListPods(ctx context.Context, dyn dynamic.Interface, namespace string) ([]unstructured.Unstructured, error) {
 	list, err := dyn.Resource(podsGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
-	pods := make([]corev1.Pod, 0, len(list.Items))
-	for i := range list.Items {
-		var pod corev1.Pod
-		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(list.Items[i].Object, &pod); err != nil {
-			return nil, fmt.Errorf("decode pod %s: %w", list.Items[i].GetName(), err)
-		}
-		pods = append(pods, pod)
-	}
-	return pods, nil
+	return list.Items, nil
 }

--- a/cli/pkg/workload/pods.go
+++ b/cli/pkg/workload/pods.go
@@ -136,7 +136,10 @@ func (a *PodAttributor) get(
 // ListPods reads every pod in namespace once, left undecoded for Filter to
 // narrow. An empty namespace lists cluster-wide.
 func ListPods(ctx context.Context, dyn dynamic.Interface, namespace string) ([]unstructured.Unstructured, error) {
-	list, err := dyn.Resource(podsGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
+	// ResourceVersion 0 serves the list from the apiserver's watch cache rather
+	// than etcd, which a describe read can afford to have a moment stale.
+	list, err := dyn.Resource(podsGVR).Namespace(namespace).
+		List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 	if err != nil {
 		return nil, err
 	}

--- a/cli/pkg/workload/pods_test.go
+++ b/cli/pkg/workload/pods_test.go
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package workload
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/utils/ptr"
+)
+
+const namespace = "ml-team"
+
+var (
+	deploymentGVK = schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+	replicaSetGVK = schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "ReplicaSet"}
+	podGVK        = schema.GroupVersionKind{Version: "v1", Kind: "Pod"}
+)
+
+// owned builds an unstructured object of gvk owned by the named controller,
+// which is what the walk climbs.
+func owned(gvk schema.GroupVersionKind, name string, uid types.UID, owner *metav1.OwnerReference) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": gvk.GroupVersion().String(),
+		"kind":       gvk.Kind,
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": namespace,
+			"uid":       string(uid),
+		},
+	}}
+	if owner != nil {
+		obj.SetOwnerReferences([]metav1.OwnerReference{*owner})
+	}
+	return obj
+}
+
+func controllerOf(gvk schema.GroupVersionKind, name string, uid types.UID) *metav1.OwnerReference {
+	return &metav1.OwnerReference{
+		APIVersion: gvk.GroupVersion().String(),
+		Kind:       gvk.Kind,
+		Name:       name,
+		UID:        uid,
+		Controller: ptr.To(true),
+	}
+}
+
+func pod(name string, owner *metav1.OwnerReference) corev1.Pod {
+	p := corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}
+	if owner != nil {
+		p.OwnerReferences = []metav1.OwnerReference{*owner}
+	}
+	return p
+}
+
+// fakeCluster serves objects through a dynamic client whose mapper knows the
+// apps/v1 kinds an owner chain climbs through.
+func fakeCluster(objects ...runtime.Object) (dynamic.Interface, meta.RESTMapper) {
+	mapper := meta.NewDefaultRESTMapper(nil)
+	for _, gvk := range []schema.GroupVersionKind{deploymentGVK, replicaSetGVK, podGVK} {
+		mapper.Add(gvk, meta.RESTScopeNamespace)
+	}
+
+	listKinds := map[schema.GroupVersionResource]string{
+		podsGVR: "PodList",
+		{Group: "apps", Version: "v1", Resource: "replicasets"}: "ReplicaSetList",
+		{Group: "apps", Version: "v1", Resource: "deployments"}: "DeploymentList",
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), listKinds, objects...), mapper
+}
+
+var _ = Describe("PodAttributor", func() {
+	const rootUID = types.UID("root-uid")
+
+	var (
+		ctx        context.Context
+		deployment *unstructured.Unstructured
+		replicaSet *unstructured.Unstructured
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		deployment = owned(deploymentGVK, "web", rootUID, nil)
+		replicaSet = owned(replicaSetGVK, "web-abc", "rs-uid", controllerOf(deploymentGVK, "web", rootUID))
+	})
+
+	It("claims a pod whose chain reaches the root through an intermediate owner", func() {
+		dyn, mapper := fakeCluster(deployment, replicaSet)
+
+		mine := pod("web-abc-1", controllerOf(replicaSetGVK, "web-abc", "rs-uid"))
+		matched := NewPodAttributor(dyn, mapper).Filter(ctx, []corev1.Pod{mine}, rootUID)
+
+		Expect(matched).To(HaveLen(1))
+		Expect(matched[0].Name).To(Equal("web-abc-1"))
+	})
+
+	It("claims a pod the root owns directly, with no walk at all", func() {
+		dyn, mapper := fakeCluster()
+
+		mine := pod("standalone", controllerOf(deploymentGVK, "web", rootUID))
+		Expect(NewPodAttributor(dyn, mapper).Filter(ctx, []corev1.Pod{mine}, rootUID)).To(HaveLen(1))
+	})
+
+	It("leaves a pod belonging to another workload of the same type", func() {
+		other := owned(replicaSetGVK, "api-xyz", "other-rs",
+			controllerOf(deploymentGVK, "api", "other-root"))
+		dyn, mapper := fakeCluster(deployment, replicaSet, other,
+			owned(deploymentGVK, "api", "other-root", nil))
+
+		theirs := pod("api-xyz-1", controllerOf(replicaSetGVK, "api-xyz", "other-rs"))
+		Expect(NewPodAttributor(dyn, mapper).Filter(ctx, []corev1.Pod{theirs}, rootUID)).To(BeEmpty())
+	})
+
+	It("leaves an unowned pod", func() {
+		dyn, mapper := fakeCluster(deployment, replicaSet)
+
+		Expect(NewPodAttributor(dyn, mapper).Filter(ctx, []corev1.Pod{pod("bare", nil)}, rootUID)).To(BeEmpty())
+	})
+
+	// A missing intermediate is a chain that cannot be walked, not a match.
+	It("leaves a pod whose intermediate owner is gone", func() {
+		dyn, mapper := fakeCluster(deployment)
+
+		orphan := pod("web-abc-1", controllerOf(replicaSetGVK, "web-abc", "rs-uid"))
+		Expect(NewPodAttributor(dyn, mapper).Filter(ctx, []corev1.Pod{orphan}, rootUID)).To(BeEmpty())
+	})
+
+	// Sibling pods share an intermediate, and a broken chain must not be
+	// re-fetched once per pod either.
+	It("fetches each owner once across pods, hit or miss", func() {
+		dyn, mapper := fakeCluster(deployment, replicaSet)
+
+		var gets int
+		dyn.(*dynamicfake.FakeDynamicClient).PrependReactor("get", "*",
+			func(k8stesting.Action) (bool, runtime.Object, error) {
+				gets++
+				return false, nil, nil
+			})
+
+		pods := []corev1.Pod{
+			pod("web-abc-1", controllerOf(replicaSetGVK, "web-abc", "rs-uid")),
+			pod("web-abc-2", controllerOf(replicaSetGVK, "web-abc", "rs-uid")),
+			pod("gone-1", controllerOf(replicaSetGVK, "gone", "gone-uid")),
+			pod("gone-2", controllerOf(replicaSetGVK, "gone", "gone-uid")),
+		}
+		attributor := NewPodAttributor(dyn, mapper)
+
+		Expect(attributor.Filter(ctx, pods, rootUID)).To(HaveLen(2))
+		Expect(gets).To(Equal(2), "one fetch for the shared ReplicaSet, one for the missing one")
+	})
+
+	// Malformed data can point an owner chain at itself; the walk must end.
+	It("gives up on a cycle rather than recursing forever", func() {
+		loop := owned(replicaSetGVK, "loop", "loop-uid", controllerOf(replicaSetGVK, "loop", "loop-uid"))
+		dyn, mapper := fakeCluster(loop)
+
+		caught := pod("loop-1", controllerOf(replicaSetGVK, "loop", "loop-uid"))
+		Expect(NewPodAttributor(dyn, mapper).Filter(ctx, []corev1.Pod{caught}, rootUID)).To(BeEmpty())
+	})
+})
+
+var _ = Describe("ListPods", func() {
+	It("decodes every pod in the namespace into the typed shape", func() {
+		running := owned(podGVK, "web-abc-1", "pod-uid", nil)
+		Expect(unstructured.SetNestedField(running.Object, "node-01", "spec", "nodeName")).To(Succeed())
+		dyn, _ := fakeCluster(running)
+
+		pods, err := ListPods(context.Background(), dyn, namespace)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pods).To(HaveLen(1))
+		Expect(pods[0].Name).To(Equal("web-abc-1"))
+		Expect(pods[0].Spec.NodeName).To(Equal("node-01"))
+	})
+})

--- a/cli/pkg/workload/pods_test.go
+++ b/cli/pkg/workload/pods_test.go
@@ -25,9 +25,10 @@ import (
 const namespace = "ml-team"
 
 var (
-	deploymentGVK = schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
-	replicaSetGVK = schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "ReplicaSet"}
-	podGVK        = schema.GroupVersionKind{Version: "v1", Kind: "Pod"}
+	deploymentGVK   = schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+	replicaSetGVK   = schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "ReplicaSet"}
+	podGVK          = schema.GroupVersionKind{Version: "v1", Kind: "Pod"}
+	clusterOwnerGVK = schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "ClusterOwner"}
 )
 
 // owned builds an unstructured object of gvk owned by the named controller,
@@ -45,6 +46,13 @@ func owned(gvk schema.GroupVersionKind, name string, uid types.UID, owner *metav
 	if owner != nil {
 		obj.SetOwnerReferences([]metav1.OwnerReference{*owner})
 	}
+	return obj
+}
+
+// clusterScoped builds an owner that lives outside any namespace.
+func clusterScoped(name string, uid types.UID, owner *metav1.OwnerReference) *unstructured.Unstructured {
+	obj := owned(clusterOwnerGVK, name, uid, owner)
+	unstructured.RemoveNestedField(obj.Object, "metadata", "namespace")
 	return obj
 }
 
@@ -73,11 +81,13 @@ func fakeCluster(objects ...runtime.Object) (dynamic.Interface, meta.RESTMapper)
 	for _, gvk := range []schema.GroupVersionKind{deploymentGVK, replicaSetGVK, podGVK} {
 		mapper.Add(gvk, meta.RESTScopeNamespace)
 	}
+	mapper.Add(clusterOwnerGVK, meta.RESTScopeRoot)
 
 	listKinds := map[schema.GroupVersionResource]string{
 		podsGVR: "PodList",
-		{Group: "apps", Version: "v1", Resource: "replicasets"}: "ReplicaSetList",
-		{Group: "apps", Version: "v1", Resource: "deployments"}: "DeploymentList",
+		{Group: "example.com", Version: "v1", Resource: "clusterowners"}: "ClusterOwnerList",
+		{Group: "apps", Version: "v1", Resource: "replicasets"}:          "ReplicaSetList",
+		{Group: "apps", Version: "v1", Resource: "deployments"}:          "DeploymentList",
 	}
 	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), listKinds, objects...), mapper
 }
@@ -160,6 +170,15 @@ var _ = Describe("PodAttributor", func() {
 
 		Expect(attributor.Filter(ctx, pods, rootUID)).To(HaveLen(2))
 		Expect(gets).To(Equal(2), "one fetch for the shared ReplicaSet, one for the missing one")
+	})
+
+	// Without the scope check the pod is silently dropped from its workload.
+	It("climbs through a cluster-scoped owner", func() {
+		gateway := clusterScoped("gateway", "gateway-uid", controllerOf(deploymentGVK, "web", rootUID))
+		dyn, mapper := fakeCluster(deployment, gateway)
+
+		mine := pod("web-1", controllerOf(clusterOwnerGVK, "gateway", "gateway-uid"))
+		Expect(NewPodAttributor(dyn, mapper).Filter(ctx, []corev1.Pod{mine}, rootUID)).To(HaveLen(1))
 	})
 
 	// Malformed data can point an owner chain at itself; the walk must end.

--- a/cli/pkg/workload/pods_test.go
+++ b/cli/pkg/workload/pods_test.go
@@ -66,12 +66,16 @@ func controllerOf(gvk schema.GroupVersionKind, name string, uid types.UID) *meta
 	}
 }
 
-func pod(name string, owner *metav1.OwnerReference) corev1.Pod {
-	p := corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}
-	if owner != nil {
-		p.OwnerReferences = []metav1.OwnerReference{*owner}
-	}
-	return p
+func pod(name string, owner *metav1.OwnerReference) unstructured.Unstructured {
+	return *owned(podGVK, name, "", owner)
+}
+
+// filter runs the attributor and fails the spec if a matched pod cannot decode.
+func filter(a *PodAttributor, pods []unstructured.Unstructured, rootUID types.UID) []corev1.Pod {
+	GinkgoHelper()
+	matched, err := a.Filter(context.Background(), pods, rootUID)
+	Expect(err).NotTo(HaveOccurred())
+	return matched
 }
 
 // fakeCluster serves objects through a dynamic client whose mapper knows the
@@ -96,13 +100,11 @@ var _ = Describe("PodAttributor", func() {
 	const rootUID = types.UID("root-uid")
 
 	var (
-		ctx        context.Context
 		deployment *unstructured.Unstructured
 		replicaSet *unstructured.Unstructured
 	)
 
 	BeforeEach(func() {
-		ctx = context.Background()
 		deployment = owned(deploymentGVK, "web", rootUID, nil)
 		replicaSet = owned(replicaSetGVK, "web-abc", "rs-uid", controllerOf(deploymentGVK, "web", rootUID))
 	})
@@ -111,7 +113,7 @@ var _ = Describe("PodAttributor", func() {
 		dyn, mapper := fakeCluster(deployment, replicaSet)
 
 		mine := pod("web-abc-1", controllerOf(replicaSetGVK, "web-abc", "rs-uid"))
-		matched := NewPodAttributor(dyn, mapper).Filter(ctx, []corev1.Pod{mine}, rootUID)
+		matched := filter(NewPodAttributor(dyn, mapper), []unstructured.Unstructured{mine}, rootUID)
 
 		Expect(matched).To(HaveLen(1))
 		Expect(matched[0].Name).To(Equal("web-abc-1"))
@@ -121,7 +123,7 @@ var _ = Describe("PodAttributor", func() {
 		dyn, mapper := fakeCluster()
 
 		mine := pod("standalone", controllerOf(deploymentGVK, "web", rootUID))
-		Expect(NewPodAttributor(dyn, mapper).Filter(ctx, []corev1.Pod{mine}, rootUID)).To(HaveLen(1))
+		Expect(filter(NewPodAttributor(dyn, mapper), []unstructured.Unstructured{mine}, rootUID)).To(HaveLen(1))
 	})
 
 	It("leaves a pod belonging to another workload of the same type", func() {
@@ -131,13 +133,13 @@ var _ = Describe("PodAttributor", func() {
 			owned(deploymentGVK, "api", "other-root", nil))
 
 		theirs := pod("api-xyz-1", controllerOf(replicaSetGVK, "api-xyz", "other-rs"))
-		Expect(NewPodAttributor(dyn, mapper).Filter(ctx, []corev1.Pod{theirs}, rootUID)).To(BeEmpty())
+		Expect(filter(NewPodAttributor(dyn, mapper), []unstructured.Unstructured{theirs}, rootUID)).To(BeEmpty())
 	})
 
 	It("leaves an unowned pod", func() {
 		dyn, mapper := fakeCluster(deployment, replicaSet)
 
-		Expect(NewPodAttributor(dyn, mapper).Filter(ctx, []corev1.Pod{pod("bare", nil)}, rootUID)).To(BeEmpty())
+		Expect(filter(NewPodAttributor(dyn, mapper), []unstructured.Unstructured{pod("bare", nil)}, rootUID)).To(BeEmpty())
 	})
 
 	// A missing intermediate is a chain that cannot be walked, not a match.
@@ -145,7 +147,7 @@ var _ = Describe("PodAttributor", func() {
 		dyn, mapper := fakeCluster(deployment)
 
 		orphan := pod("web-abc-1", controllerOf(replicaSetGVK, "web-abc", "rs-uid"))
-		Expect(NewPodAttributor(dyn, mapper).Filter(ctx, []corev1.Pod{orphan}, rootUID)).To(BeEmpty())
+		Expect(filter(NewPodAttributor(dyn, mapper), []unstructured.Unstructured{orphan}, rootUID)).To(BeEmpty())
 	})
 
 	// Sibling pods share an intermediate, and a broken chain must not be
@@ -160,7 +162,7 @@ var _ = Describe("PodAttributor", func() {
 				return false, nil, nil
 			})
 
-		pods := []corev1.Pod{
+		pods := []unstructured.Unstructured{
 			pod("web-abc-1", controllerOf(replicaSetGVK, "web-abc", "rs-uid")),
 			pod("web-abc-2", controllerOf(replicaSetGVK, "web-abc", "rs-uid")),
 			pod("gone-1", controllerOf(replicaSetGVK, "gone", "gone-uid")),
@@ -168,7 +170,7 @@ var _ = Describe("PodAttributor", func() {
 		}
 		attributor := NewPodAttributor(dyn, mapper)
 
-		Expect(attributor.Filter(ctx, pods, rootUID)).To(HaveLen(2))
+		Expect(filter(attributor, pods, rootUID)).To(HaveLen(2))
 		Expect(gets).To(Equal(2), "one fetch for the shared ReplicaSet, one for the missing one")
 	})
 
@@ -178,7 +180,7 @@ var _ = Describe("PodAttributor", func() {
 		dyn, mapper := fakeCluster(deployment, gateway)
 
 		mine := pod("web-1", controllerOf(clusterOwnerGVK, "gateway", "gateway-uid"))
-		Expect(NewPodAttributor(dyn, mapper).Filter(ctx, []corev1.Pod{mine}, rootUID)).To(HaveLen(1))
+		Expect(filter(NewPodAttributor(dyn, mapper), []unstructured.Unstructured{mine}, rootUID)).To(HaveLen(1))
 	})
 
 	// Malformed data can point an owner chain at itself; the walk must end.
@@ -187,12 +189,14 @@ var _ = Describe("PodAttributor", func() {
 		dyn, mapper := fakeCluster(loop)
 
 		caught := pod("loop-1", controllerOf(replicaSetGVK, "loop", "loop-uid"))
-		Expect(NewPodAttributor(dyn, mapper).Filter(ctx, []corev1.Pod{caught}, rootUID)).To(BeEmpty())
+		Expect(filter(NewPodAttributor(dyn, mapper), []unstructured.Unstructured{caught}, rootUID)).To(BeEmpty())
 	})
 })
 
 var _ = Describe("ListPods", func() {
-	It("decodes every pod in the namespace into the typed shape", func() {
+	// Undecoded, but whole: Filter decodes the matches, so anything the view
+	// reads later has to survive the round trip.
+	It("returns every pod in the namespace, decodable in full", func() {
 		running := owned(podGVK, "web-abc-1", "pod-uid", nil)
 		Expect(unstructured.SetNestedField(running.Object, "node-01", "spec", "nodeName")).To(Succeed())
 		dyn, _ := fakeCluster(running)
@@ -200,7 +204,10 @@ var _ = Describe("ListPods", func() {
 		pods, err := ListPods(context.Background(), dyn, namespace)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(pods).To(HaveLen(1))
-		Expect(pods[0].Name).To(Equal("web-abc-1"))
-		Expect(pods[0].Spec.NodeName).To(Equal("node-01"))
+
+		var pod corev1.Pod
+		Expect(runtime.DefaultUnstructuredConverter.FromUnstructured(pods[0].Object, &pod)).To(Succeed())
+		Expect(pod.Name).To(Equal("web-abc-1"))
+		Expect(pod.Spec.NodeName).To(Equal("node-01"))
 	})
 })


### PR DESCRIPTION
## What does this PR do?

Scopes pods to one workload by ownership. A Karta PodSelector says which component type a pod plays, never which workload it belongs to, so matching on the selector alone would claim every PyTorchJob worker in the namespace. PodAttributor walks each pod's controller owner-reference chain to the root UID, caching fetches hit and miss alike.

Part of a seven-PR stack implementing `kli describe` (#206). Targets `feat/cli-describe-exit-codes`, which must merge first.

## Related issue(s)

Refs #206

## Checklist

- [x] All commits are signed off with DCO (`git commit -s`)
- [x] New/modified files have SPDX license and copyright headers
- [x] Documentation updated (if applicable)
- [x] Tests pass (`make check`)
- [x] No proprietary or internal information included

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved Kubernetes workload visibility by accurately associating Pods with their owning workloads, including intermediate controllers.
  - Added support for ownership resolution across namespaces and cluster-scoped controllers.
  - Improved handling of orphaned, unrelated, cyclic, and malformed ownership relationships.
  - Improved Pod retrieval and decoding while preserving node assignment details.
- **Tests**
  - Added coverage for direct and indirect ownership, caching, malformed relationships, cross-scope owners, and Pod decoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->