### PR TITLE
feat(cli): resolve a workload into the describe view

### DIFF
--- a/cli/pkg/workload/describe.go
+++ b/cli/pkg/workload/describe.go
@@ -94,7 +94,9 @@ func (r Resources) scaled(replicas int32) Resources {
 }
 
 // ResolveDescribe reads obj through def, placing pods on the component and
-// instance its selectors name. pods must already be scoped; nil is file mode.
+// instance its selectors name. pods must already be scoped. Passing none yields
+// the same view with every live field empty, which is what file mode renders;
+// marking the view FileMode is the caller's, since only it knows the source.
 func ResolveDescribe(
 	ctx context.Context, obj *unstructured.Unstructured, def definitions.Definition, pods []corev1.Pod,
 ) (*DescribeView, error) {
@@ -123,9 +125,10 @@ func ResolveDescribe(
 		if err != nil {
 			return nil, err
 		}
-		// The root takes the same pod filter buildComponent applies to a child,
-		// so a definition that scopes its root's pods is honoured.
-		claimed, err := matchComponentType(ctx, defs[root.Name()].PodSelector, pods, true)
+		// The root takes the same pod filter and the same selectorless rule
+		// buildComponent applies to a child, so being the root is never on its
+		// own a licence to claim a pod another component owns.
+		claimed, err := matchComponentType(ctx, defs[root.Name()].PodSelector, pods, isSolePodOwner(defs))
 		if err != nil {
 			return nil, fmt.Errorf("match pods to root component: %w", err)
 		}

--- a/cli/pkg/workload/describe.go
+++ b/cli/pkg/workload/describe.go
@@ -1,0 +1,559 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package workload
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/run-ai/karta/cli/pkg/definitions"
+	"github.com/run-ai/karta/pkg/api/runai/v1alpha1"
+	"github.com/run-ai/karta/pkg/resource"
+	"github.com/run-ai/karta/pkg/tree"
+)
+
+// gpuResourceName is the extended resource a GPU request is declared under.
+const gpuResourceName = corev1.ResourceName("nvidia.com/gpu")
+
+// DescribeView is one workload in full. Every describe rendering draws from this
+// one struct, so the human and the machine output cannot drift apart.
+type DescribeView struct {
+	Name       string    `json:"name"`
+	Namespace  string    `json:"namespace"`
+	Kind       string    `json:"kind"`
+	APIVersion string    `json:"apiVersion"`
+	CreatedAt  time.Time `json:"createdAt"`
+	Definition string    `json:"definition"`
+	Origin     string    `json:"origin"`
+	Phases     []string  `json:"phases"`
+	// FileMode marks a view built from a manifest: the structure and desired
+	// scale are real, everything live is absent rather than zero.
+	FileMode bool `json:"fileMode"`
+	// Resources is the whole workload's request, the sum over Components.
+	Resources  Resources       `json:"resources"`
+	Components []ComponentView `json:"components"`
+}
+
+// ComponentView is one component, or one instance of a multi-instance
+// component, with the pods that were attributed to it.
+type ComponentView struct {
+	Name string `json:"name"`
+	// Kind is empty for a logical grouping component, which owns no objects.
+	Kind      string    `json:"kind,omitempty"`
+	Replicas  Replicas  `json:"replicas"`
+	Resources Resources `json:"resources"`
+	// Nodes are the distinct nodes this component's pods landed on.
+	Nodes    []string        `json:"nodes,omitempty"`
+	Pods     []PodView       `json:"pods,omitempty"`
+	Children []ComponentView `json:"children,omitempty"`
+}
+
+// Replicas counts a component three ways: what the spec asks for, how many
+// pods exist, and how many of those are ready.
+type Replicas struct {
+	Desired int32 `json:"desired"`
+	Current int32 `json:"current"`
+	Ready   int32 `json:"ready"`
+}
+
+// PodView is one live pod attributed to a component.
+type PodView struct {
+	Name  string `json:"name"`
+	Phase string `json:"phase"`
+	Ready bool   `json:"ready"`
+	// Node is null for a pod that has not been scheduled.
+	Node *string `json:"node"`
+	// Reason explains a pod that is not running, e.g. "Unschedulable".
+	Reason    string    `json:"reason,omitempty"`
+	Resources Resources `json:"resources"`
+}
+
+// Resources is a request total. CPU is in millicores and memory in bytes, so
+// every field is an integer a consumer can sum without unit handling.
+type Resources struct {
+	GPUs        int64 `json:"gpus"`
+	CPUMillis   int64 `json:"cpuMillis"`
+	MemoryBytes int64 `json:"memoryBytes"`
+}
+
+func (r *Resources) add(other Resources) {
+	r.GPUs += other.GPUs
+	r.CPUMillis += other.CPUMillis
+	r.MemoryBytes += other.MemoryBytes
+}
+
+func (r Resources) scaled(replicas int32) Resources {
+	return Resources{
+		GPUs:        r.GPUs * int64(replicas),
+		CPUMillis:   r.CPUMillis * int64(replicas),
+		MemoryBytes: r.MemoryBytes * int64(replicas),
+	}
+}
+
+// ResolveDescribe reads obj through def, placing pods on the component and
+// instance its selectors name. pods must already be scoped; nil is file mode.
+func ResolveDescribe(
+	ctx context.Context, obj *unstructured.Unstructured, def definitions.Definition, pods []corev1.Pod,
+) (*DescribeView, error) {
+	factory := resource.NewComponentFactoryFromObject(def.Karta, obj)
+
+	workloadTree, err := tree.Build(ctx, factory)
+	if err != nil {
+		return nil, fmt.Errorf("build tree: %w", err)
+	}
+
+	view := &DescribeView{
+		Name:       obj.GetName(),
+		Namespace:  obj.GetNamespace(),
+		Kind:       obj.GetKind(),
+		APIVersion: obj.GetAPIVersion(),
+		CreatedAt:  obj.GetCreationTimestamp().Time,
+		Definition: def.Karta.Name,
+		Origin:     string(def.Origin),
+		Phases:     phases(workloadTree),
+		Components: []ComponentView{},
+	}
+
+	defs := indexComponentDefs(def.Karta)
+
+	// tree.Build drops the root, but Deployment, StatefulSet, Job and Pod carry
+	// their pod template on it, so the root itself can be pod-bearing.
+	root, err := factory.GetRootComponent()
+	if err != nil {
+		return nil, fmt.Errorf("get root component: %w", err)
+	}
+	if root.HasPodDefinition() {
+		instances, err := rootInstances(ctx, root)
+		if err != nil {
+			return nil, err
+		}
+		component, err := buildComponent(ctx, root.Name(), kindOf(root.Kind()), defs[root.Name()], instances, pods, defs)
+		if err != nil {
+			return nil, fmt.Errorf("build root component: %w", err)
+		}
+		view.Components = appendComponent(view.Components, component, true)
+	}
+
+	for _, node := range workloadTree.Children {
+		component, err := buildNode(ctx, node, defs, pods)
+		if err != nil {
+			return nil, fmt.Errorf("build component %q: %w", node.Name, err)
+		}
+		view.Components = appendComponent(view.Components, component, node.HasPodDefinition)
+	}
+
+	for _, component := range view.Components {
+		view.Resources.add(component.Resources)
+	}
+	return view, nil
+}
+
+// rootInstances rebuilds the instance nodes tree.Build discards for the root,
+// so a root-hosted pod template goes through the same path as any component.
+func rootInstances(ctx context.Context, root *resource.Component) ([]tree.InstanceNode, error) {
+	extracted, err := root.GetExtractedInstances(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("extract root instances: %w", err)
+	}
+
+	instances := make([]tree.InstanceNode, 0, len(extracted))
+	for _, id := range slices.Sorted(maps.Keys(extracted)) {
+		instance := extracted[id]
+		node := tree.InstanceNode{Scale: instance.Scale, ExtractedInstance: &instance}
+		if id != "" {
+			node.InstanceKey = &id
+		}
+		instances = append(instances, node)
+	}
+	return instances, nil
+}
+
+func indexComponentDefs(karta *v1alpha1.Karta) map[string]v1alpha1.ComponentDefinition {
+	defs := make(map[string]v1alpha1.ComponentDefinition, len(karta.Spec.StructureDefinition.ChildComponents)+1)
+	defs[karta.Spec.StructureDefinition.RootComponent.Name] = karta.Spec.StructureDefinition.RootComponent
+	for _, child := range karta.Spec.StructureDefinition.ChildComponents {
+		defs[child.Name] = child
+	}
+	return defs
+}
+
+// buildNode renders one ComponentNode: a grouping component only recurses, a
+// pod-bearing one claims the pods its ComponentTypeSelector accepts.
+func buildNode(
+	ctx context.Context, node tree.ComponentNode, defs map[string]v1alpha1.ComponentDefinition, pods []corev1.Pod,
+) (ComponentView, error) {
+	kind := kindOf(node.Kind)
+	def := defs[node.Name]
+
+	claimed := pods
+	if node.HasPodDefinition {
+		var err error
+		if claimed, err = matchComponentType(ctx, def.PodSelector, pods); err != nil {
+			return ComponentView{}, fmt.Errorf("match pods to component %q: %w", node.Name, err)
+		}
+	}
+
+	if !isMultiInstance(node.Instances) {
+		if node.HasPodDefinition {
+			return buildComponent(ctx, node.Name, kind, def, node.Instances, claimed, defs)
+		}
+		return buildGrouping(ctx, node.Name, kind, node.Instances, claimed, defs)
+	}
+
+	// A grouping component takes this path too: it holds no pods itself, but its
+	// ReplicaSelector still decides which pods its descendants may see.
+	parent := ComponentView{Name: node.Name, Kind: kind}
+	for _, instance := range node.Instances {
+		scoped, err := filterByInstance(ctx, def.PodSelector, instance, claimed)
+		if err != nil {
+			return ComponentView{}, fmt.Errorf("match pods to instance of %q: %w", node.Name, err)
+		}
+
+		label := instanceLabel(node.Name, instance)
+		one := []tree.InstanceNode{instance}
+
+		var child ComponentView
+		if node.HasPodDefinition {
+			child, err = buildComponent(ctx, label, kind, def, one, scoped, defs)
+		} else {
+			child, err = buildGrouping(ctx, label, kind, one, scoped, defs)
+		}
+		if err != nil {
+			return ComponentView{}, err
+		}
+
+		parent.Children = appendComponent(parent.Children, child, node.HasPodDefinition)
+		parent.aggregate(child)
+	}
+	return parent, nil
+}
+
+// buildGrouping renders a component that owns no pods of its own: it carries
+// only its descendants and their roll-up.
+func buildGrouping(
+	ctx context.Context,
+	name, kind string,
+	instances []tree.InstanceNode,
+	pods []corev1.Pod,
+	defs map[string]v1alpha1.ComponentDefinition,
+) (ComponentView, error) {
+	component := ComponentView{Name: name, Kind: kind}
+	for _, instance := range instances {
+		for _, node := range instance.Children {
+			child, err := buildNode(ctx, node, defs, pods)
+			if err != nil {
+				return ComponentView{}, err
+			}
+			component.Children = appendComponent(component.Children, child, node.HasPodDefinition)
+			component.aggregate(child)
+		}
+	}
+	return component, nil
+}
+
+// buildComponent renders a pod-bearing component from the pods already matched
+// to it, plus the desired scale and per-replica request read off its spec.
+func buildComponent(
+	ctx context.Context,
+	name, kind string,
+	def v1alpha1.ComponentDefinition,
+	instances []tree.InstanceNode,
+	pods []corev1.Pod,
+	defs map[string]v1alpha1.ComponentDefinition,
+) (ComponentView, error) {
+	component := ComponentView{Name: name, Kind: kind}
+	component.attach(pods)
+
+	for _, instance := range instances {
+		replicas := replicasOf(instance.Scale)
+		component.Replicas.Desired += replicas
+		if instance.ExtractedInstance != nil {
+			component.Resources.add(requestOf(*instance.ExtractedInstance).scaled(replicas))
+		}
+
+		for _, node := range instance.Children {
+			child, err := buildNode(ctx, node, defs, pods)
+			if err != nil {
+				return ComponentView{}, err
+			}
+			component.Children = appendComponent(component.Children, child, node.HasPodDefinition)
+			// Only the totals roll up: a child's own pods are its own rows.
+			component.Resources.add(child.Resources)
+			component.Nodes = mergeNodes(component.Nodes, child.Nodes)
+		}
+	}
+	return component, nil
+}
+
+// attach records the pods matched to a component: one row each, plus the counts
+// and nodes derived from them.
+func (c *ComponentView) attach(pods []corev1.Pod) {
+	for i := range pods {
+		pod := &pods[i]
+		ready := isPodReady(pod)
+		c.Replicas.Current++
+		if ready {
+			c.Replicas.Ready++
+		}
+
+		row := PodView{
+			Name:      pod.Name,
+			Phase:     string(pod.Status.Phase),
+			Ready:     ready,
+			Resources: podRequest(pod.Spec),
+		}
+		if node := pod.Spec.NodeName; node != "" {
+			row.Node = &node
+			c.Nodes = mergeNodes(c.Nodes, []string{node})
+		}
+		if !ready {
+			row.Reason = podReason(pod.Status)
+		}
+		c.Pods = append(c.Pods, row)
+	}
+	slices.SortFunc(c.Pods, func(a, b PodView) int { return strings.Compare(a.Name, b.Name) })
+}
+
+// appendComponent drops plumbing the workload never populated, such as a
+// Deployment's ReplicaSet. A pod-bearing component stays even at zero replicas.
+func appendComponent(components []ComponentView, component ComponentView, podBearing bool) []ComponentView {
+	if !podBearing && component.empty() {
+		return components
+	}
+	return append(components, component)
+}
+
+func (c ComponentView) empty() bool {
+	return len(c.Pods) == 0 && len(c.Children) == 0 &&
+		c.Replicas == Replicas{} && c.Resources == Resources{}
+}
+
+// aggregate folds a child's totals into a parent that wraps it.
+func (c *ComponentView) aggregate(child ComponentView) {
+	c.Replicas.Desired += child.Replicas.Desired
+	c.Replicas.Current += child.Replicas.Current
+	c.Replicas.Ready += child.Replicas.Ready
+	c.Resources.add(child.Resources)
+	c.Nodes = mergeNodes(c.Nodes, child.Nodes)
+}
+
+// podReason explains a pod that is not ready. The scheduler's reason is the
+// short form a tree row has space for; a failure falls back to its own.
+func podReason(status corev1.PodStatus) string {
+	for _, condition := range status.Conditions {
+		if condition.Type == corev1.PodScheduled && condition.Status == corev1.ConditionFalse {
+			return condition.Reason
+		}
+	}
+	return status.Reason
+}
+
+func isPodReady(pod *corev1.Pod) bool {
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+func mergeNodes(existing, add []string) []string {
+	merged := append(slices.Clone(existing), add...)
+	slices.Sort(merged)
+	return slices.Compact(merged)
+}
+
+// isMultiInstance reports a component whose instances are told apart by an
+// instance key or a replica key, and so render as one row each.
+func isMultiInstance(instances []tree.InstanceNode) bool {
+	if len(instances) <= 1 {
+		return false
+	}
+	for _, instance := range instances {
+		if instance.InstanceKey != nil || instance.ReplicaKey != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func instanceLabel(componentName string, instance tree.InstanceNode) string {
+	switch {
+	case instance.InstanceKey != nil:
+		return *instance.InstanceKey
+	case instance.ReplicaKey != nil:
+		return fmt.Sprintf("%s[%s]", componentName, *instance.ReplicaKey)
+	default:
+		return componentName
+	}
+}
+
+// matchComponentType keeps the pods a component's ComponentTypeSelector accepts.
+// A nil selector claims every candidate, right for a root-only workload.
+func matchComponentType(ctx context.Context, selector *v1alpha1.PodSelector, pods []corev1.Pod) ([]corev1.Pod, error) {
+	if selector == nil || selector.ComponentTypeSelector == nil {
+		return pods, nil
+	}
+	var matched []corev1.Pod
+	for i := range pods {
+		ok, err := resource.NewPodQuerier(&pods[i]).MatchesComponentType(ctx, selector.ComponentTypeSelector)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			matched = append(matched, pods[i])
+		}
+	}
+	return matched, nil
+}
+
+// filterByInstance narrows a component's pods to one instance, by instance id or
+// replica key. With neither, every pod reaches every instance.
+func filterByInstance(
+	ctx context.Context, selector *v1alpha1.PodSelector, instance tree.InstanceNode, pods []corev1.Pod,
+) ([]corev1.Pod, error) {
+	if selector == nil {
+		return pods, nil
+	}
+	var matched []corev1.Pod
+	for i := range pods {
+		querier := resource.NewPodQuerier(&pods[i])
+		if instance.InstanceKey != nil {
+			id, found, err := querier.ExtractInstanceId(ctx, selector.ComponentInstanceSelector)
+			if err != nil {
+				return nil, err
+			}
+			if !found || id != *instance.InstanceKey {
+				continue
+			}
+		}
+		if instance.ReplicaKey != nil {
+			key, found, err := querier.ExtractReplicaKey(ctx, selector.ReplicaSelector)
+			if err != nil {
+				return nil, err
+			}
+			if !found || key != *instance.ReplicaKey {
+				continue
+			}
+		}
+		matched = append(matched, pods[i])
+	}
+	return matched, nil
+}
+
+// replicasOf reports the desired replica count. A component declaring only a
+// scaling envelope falls back to its minimum, then to one.
+func replicasOf(scale *resource.Scale) int32 {
+	switch {
+	case scale == nil:
+		return 1
+	case scale.Replicas != nil:
+		return *scale.Replicas
+	case scale.MinReplicas != nil:
+		return *scale.MinReplicas
+	default:
+		return 1
+	}
+}
+
+// requestOf sums what one replica of an instance requests. The spec shapes are
+// mutually exclusive, so a definition naming several counts only the first.
+func requestOf(instance resource.ExtractedInstance) Resources {
+	switch {
+	case instance.PodTemplateSpec != nil:
+		return podRequest(instance.PodTemplateSpec.Spec)
+	case instance.PodSpec != nil:
+		return podRequest(*instance.PodSpec)
+	case instance.FragmentedPodSpec != nil:
+		return fragmentedRequest(*instance.FragmentedPodSpec)
+	default:
+		return Resources{}
+	}
+}
+
+func fragmentedRequest(spec resource.FragmentedPodSpec) Resources {
+	switch {
+	case len(spec.Containers) > 0:
+		return sumContainers(spec.Containers)
+	case spec.Container != nil:
+		return sumContainers([]corev1.Container{*spec.Container})
+	case spec.Resources != nil:
+		return requirementsOf(*spec.Resources)
+	default:
+		return Resources{}
+	}
+}
+
+// podRequest mirrors the effective pod request Kubernetes schedules against:
+// max(largest init container, regular containers plus sidecars).
+func podRequest(spec corev1.PodSpec) Resources {
+	running := sumContainers(spec.Containers)
+
+	var largestInit Resources
+	for _, container := range spec.InitContainers {
+		request := requirementsOf(container.Resources)
+		// A sidecar never exits, so it accumulates rather than peaking.
+		if container.RestartPolicy != nil && *container.RestartPolicy == corev1.ContainerRestartPolicyAlways {
+			running.add(request)
+			continue
+		}
+		largestInit = Resources{
+			GPUs:        max(largestInit.GPUs, request.GPUs),
+			CPUMillis:   max(largestInit.CPUMillis, request.CPUMillis),
+			MemoryBytes: max(largestInit.MemoryBytes, request.MemoryBytes),
+		}
+	}
+
+	return Resources{
+		GPUs:        max(largestInit.GPUs, running.GPUs),
+		CPUMillis:   max(largestInit.CPUMillis, running.CPUMillis),
+		MemoryBytes: max(largestInit.MemoryBytes, running.MemoryBytes),
+	}
+}
+
+func sumContainers(containers []corev1.Container) Resources {
+	var total Resources
+	for _, container := range containers {
+		total.add(requirementsOf(container.Resources))
+	}
+	return total
+}
+
+// requirementsOf falls back to limits: an extended resource such as a GPU is
+// often declared there only, and a limit without a request implies it.
+func requirementsOf(requirements corev1.ResourceRequirements) Resources {
+	return Resources{
+		GPUs:        quantityOf(requirements, gpuResourceName),
+		CPUMillis:   quantityOf(requirements, corev1.ResourceCPU),
+		MemoryBytes: quantityOf(requirements, corev1.ResourceMemory),
+	}
+}
+
+func quantityOf(requirements corev1.ResourceRequirements, name corev1.ResourceName) int64 {
+	quantity, ok := requirements.Requests[name]
+	if !ok {
+		if quantity, ok = requirements.Limits[name]; !ok {
+			return 0
+		}
+	}
+	if name == corev1.ResourceCPU {
+		return quantity.MilliValue()
+	}
+	return quantity.Value()
+}
+
+func kindOf(gvk *metav1.GroupVersionKind) string {
+	if gvk == nil {
+		return ""
+	}
+	return gvk.Kind
+}

--- a/cli/pkg/workload/describe.go
+++ b/cli/pkg/workload/describe.go
@@ -136,7 +136,7 @@ func ResolveDescribe(
 		if err != nil {
 			return nil, err
 		}
-		component, err := buildComponent(ctx, root.Name(), kindOf(root.Kind()), defs[root.Name()], instances, pods, defs)
+		component, err := buildPodBearingComponent(ctx, root.Name(), kindOf(root.Kind()), instances, pods, defs)
 		if err != nil {
 			return nil, fmt.Errorf("build root component: %w", err)
 		}
@@ -144,7 +144,7 @@ func ResolveDescribe(
 	}
 
 	for _, node := range workloadTree.Children {
-		component, err := buildNode(ctx, node, defs, pods)
+		component, err := buildComponent(ctx, node, defs, pods)
 		if err != nil {
 			return nil, fmt.Errorf("build component %q: %w", node.Name, err)
 		}
@@ -186,9 +186,9 @@ func indexComponentDefs(karta *v1alpha1.Karta) map[string]v1alpha1.ComponentDefi
 	return defs
 }
 
-// buildNode renders one ComponentNode: a grouping component only recurses, a
-// pod-bearing one claims the pods its ComponentTypeSelector accepts.
-func buildNode(
+// buildComponent renders one ComponentNode and the subtree under it, choosing
+// between the two kinds of component by whether the node carries pods.
+func buildComponent(
 	ctx context.Context, node tree.ComponentNode, defs map[string]v1alpha1.ComponentDefinition, pods []corev1.Pod,
 ) (ComponentView, error) {
 	kind := kindOf(node.Kind)
@@ -204,9 +204,9 @@ func buildNode(
 
 	if !isMultiInstance(node.Instances) {
 		if node.HasPodDefinition {
-			return buildComponent(ctx, node.Name, kind, def, node.Instances, claimed, defs)
+			return buildPodBearingComponent(ctx, node.Name, kind, node.Instances, claimed, defs)
 		}
-		return buildGrouping(ctx, node.Name, kind, node.Instances, claimed, defs)
+		return buildGroupingComponent(ctx, node.Name, kind, node.Instances, claimed, defs)
 	}
 
 	// A grouping component takes this path too: it holds no pods itself, but its
@@ -223,9 +223,9 @@ func buildNode(
 
 		var child ComponentView
 		if node.HasPodDefinition {
-			child, err = buildComponent(ctx, label, kind, def, one, scoped, defs)
+			child, err = buildPodBearingComponent(ctx, label, kind, one, scoped, defs)
 		} else {
-			child, err = buildGrouping(ctx, label, kind, one, scoped, defs)
+			child, err = buildGroupingComponent(ctx, label, kind, one, scoped, defs)
 		}
 		if err != nil {
 			return ComponentView{}, err
@@ -237,9 +237,8 @@ func buildNode(
 	return parent, nil
 }
 
-// buildGrouping renders a component that owns no pods of its own: it carries
-// only its descendants and their roll-up.
-func buildGrouping(
+// buildGroupingComponent renders a component that owns no pods, only descendants.
+func buildGroupingComponent(
 	ctx context.Context,
 	name, kind string,
 	instances []tree.InstanceNode,
@@ -249,7 +248,7 @@ func buildGrouping(
 	component := ComponentView{Name: name, Kind: kind}
 	for _, instance := range instances {
 		for _, node := range instance.Children {
-			child, err := buildNode(ctx, node, defs, pods)
+			child, err := buildComponent(ctx, node, defs, pods)
 			if err != nil {
 				return ComponentView{}, err
 			}
@@ -260,12 +259,11 @@ func buildGrouping(
 	return component, nil
 }
 
-// buildComponent renders a pod-bearing component from the pods already matched
-// to it, plus the desired scale and per-replica request read off its spec.
-func buildComponent(
+// buildPodBearingComponent renders a component that carries pods. pods must
+// already be matched to it: the scale and per-replica request come off the spec.
+func buildPodBearingComponent(
 	ctx context.Context,
 	name, kind string,
-	def v1alpha1.ComponentDefinition,
 	instances []tree.InstanceNode,
 	pods []corev1.Pod,
 	defs map[string]v1alpha1.ComponentDefinition,
@@ -281,7 +279,7 @@ func buildComponent(
 		}
 
 		for _, node := range instance.Children {
-			child, err := buildNode(ctx, node, defs, pods)
+			child, err := buildComponent(ctx, node, defs, pods)
 			if err != nil {
 				return ComponentView{}, err
 			}
@@ -294,8 +292,8 @@ func buildComponent(
 	return component, nil
 }
 
-// attach records the pods matched to a component: one row each, plus the counts
-// and nodes derived from them.
+// attach records the pods matched to a component, name-ordered so a re-run
+// reads the same.
 func (c *ComponentView) attach(pods []corev1.Pod) {
 	for i := range pods {
 		pod := &pods[i]
@@ -450,8 +448,8 @@ func filterByInstance(
 	return matched, nil
 }
 
-// replicasOf reports the desired replica count. A component declaring only a
-// scaling envelope falls back to its minimum, then to one.
+// replicasOf reports the desired replica count, defaulting to one for a
+// component that declares only a scaling envelope.
 func replicasOf(scale *resource.Scale) int32 {
 	switch {
 	case scale == nil:

--- a/cli/pkg/workload/describe.go
+++ b/cli/pkg/workload/describe.go
@@ -9,7 +9,6 @@ import (
 	"maps"
 	"slices"
 	"strings"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,14 +26,9 @@ const gpuResourceName = corev1.ResourceName("nvidia.com/gpu")
 // DescribeView is one workload in full. Every describe rendering draws from this
 // one struct, so the human and the machine output cannot drift apart.
 type DescribeView struct {
-	Name       string    `json:"name"`
-	Namespace  string    `json:"namespace"`
-	Kind       string    `json:"kind"`
-	APIVersion string    `json:"apiVersion"`
-	CreatedAt  time.Time `json:"createdAt"`
-	Definition string    `json:"definition"`
-	Origin     string    `json:"origin"`
-	Phases     []string  `json:"phases"`
+	// View is embedded, so its fields stay flat in JSON and cannot drift from
+	// what the get command reports for the same workload.
+	View `json:",inline"`
 	// FileMode marks a view built from a manifest: the structure and desired
 	// scale are real, everything live is absent rather than zero.
 	FileMode bool `json:"fileMode"`
@@ -112,14 +106,7 @@ func ResolveDescribe(
 	}
 
 	view := &DescribeView{
-		Name:       obj.GetName(),
-		Namespace:  obj.GetNamespace(),
-		Kind:       obj.GetKind(),
-		APIVersion: obj.GetAPIVersion(),
-		CreatedAt:  obj.GetCreationTimestamp().Time,
-		Definition: def.Karta.Name,
-		Origin:     string(def.Origin),
-		Phases:     phases(workloadTree),
+		View:       viewOf(obj, def, workloadTree),
 		Components: []ComponentView{},
 	}
 
@@ -136,7 +123,14 @@ func ResolveDescribe(
 		if err != nil {
 			return nil, err
 		}
-		component, err := buildPodBearingComponent(ctx, root.Name(), kindOf(root.Kind()), instances, pods, defs)
+		// The root takes the same pod filter buildComponent applies to a child,
+		// so a definition that scopes its root's pods is honoured.
+		claimed, err := matchComponentType(ctx, defs[root.Name()].PodSelector, pods, true)
+		if err != nil {
+			return nil, fmt.Errorf("match pods to root component: %w", err)
+		}
+
+		component, err := buildPodBearingComponent(ctx, root.Name(), kindOf(root.Kind()), instances, claimed, defs)
 		if err != nil {
 			return nil, fmt.Errorf("build root component: %w", err)
 		}
@@ -177,6 +171,18 @@ func rootInstances(ctx context.Context, root *resource.Component) ([]tree.Instan
 	return instances, nil
 }
 
+// isSolePodOwner reports a definition with a single pod-bearing component, the
+// one case where a component needs no selector to be sure a pod is its own.
+func isSolePodOwner(defs map[string]v1alpha1.ComponentDefinition) bool {
+	owners := 0
+	for _, def := range defs {
+		if def.SpecDefinition != nil {
+			owners++
+		}
+	}
+	return owners == 1
+}
+
 func indexComponentDefs(karta *v1alpha1.Karta) map[string]v1alpha1.ComponentDefinition {
 	defs := make(map[string]v1alpha1.ComponentDefinition, len(karta.Spec.StructureDefinition.ChildComponents)+1)
 	defs[karta.Spec.StructureDefinition.RootComponent.Name] = karta.Spec.StructureDefinition.RootComponent
@@ -197,7 +203,7 @@ func buildComponent(
 	claimed := pods
 	if node.HasPodDefinition {
 		var err error
-		if claimed, err = matchComponentType(ctx, def.PodSelector, pods); err != nil {
+		if claimed, err = matchComponentType(ctx, def.PodSelector, pods, isSolePodOwner(defs)); err != nil {
 			return ComponentView{}, fmt.Errorf("match pods to component %q: %w", node.Name, err)
 		}
 	}
@@ -254,6 +260,18 @@ func buildGroupingComponent(
 			}
 			component.Children = appendComponent(component.Children, child, node.HasPodDefinition)
 			component.aggregate(child)
+		}
+	}
+
+	// With descendants the roll-up already carries the declared scale, since it
+	// multiplies through to them. With none, only a scale the component really
+	// declares is reported: defaulting to one would resurrect the plumbing
+	// components appendComponent drops.
+	if len(component.Children) == 0 {
+		for _, instance := range instances {
+			if instance.Scale != nil {
+				component.Replicas.Desired += replicasOf(instance.Scale)
+			}
 		}
 	}
 	return component, nil
@@ -352,7 +370,17 @@ func podReason(status corev1.PodStatus) string {
 			return condition.Reason
 		}
 	}
-	return status.Reason
+	if status.Reason != "" {
+		return status.Reason
+	}
+	// A pod that ran and stopped carries no status reason, so the ready
+	// condition is the only thing that separates "completed" from "stuck".
+	for _, condition := range status.Conditions {
+		if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionFalse {
+			return condition.Reason
+		}
+	}
+	return ""
 }
 
 func isPodReady(pod *corev1.Pod) bool {
@@ -396,10 +424,17 @@ func instanceLabel(componentName string, instance tree.InstanceNode) string {
 }
 
 // matchComponentType keeps the pods a component's ComponentTypeSelector accepts.
-// A nil selector claims every candidate, right for a root-only workload.
-func matchComponentType(ctx context.Context, selector *v1alpha1.PodSelector, pods []corev1.Pod) ([]corev1.Pod, error) {
+// claimsAll settles the nil-selector case: with nothing to tell components
+// apart, claiming every pod is right for the only one that can own them and
+// wrong for a peer that would double-count what a sibling already reported.
+func matchComponentType(
+	ctx context.Context, selector *v1alpha1.PodSelector, pods []corev1.Pod, claimsAll bool,
+) ([]corev1.Pod, error) {
 	if selector == nil || selector.ComponentTypeSelector == nil {
-		return pods, nil
+		if claimsAll {
+			return pods, nil
+		}
+		return nil, nil
 	}
 	var matched []corev1.Pod
 	for i := range pods {

--- a/cli/pkg/workload/describe_test.go
+++ b/cli/pkg/workload/describe_test.go
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package workload
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	apiresource "k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+
+	"github.com/run-ai/karta/cli/pkg/definitions"
+	"github.com/run-ai/karta/pkg/catalog"
+)
+
+// describeFixture resolves a manifest from testdata through the built-in
+// catalog, the way the describe command resolves a live object.
+func describeFixture(name string, pods ...corev1.Pod) *DescribeView {
+	GinkgoHelper()
+
+	raw, err := os.ReadFile(filepath.Join("testdata", name))
+	Expect(err).NotTo(HaveOccurred())
+
+	obj := &unstructured.Unstructured{}
+	Expect(yaml.Unmarshal(raw, obj)).To(Succeed())
+
+	def, err := definitions.New(catalog.List(), nil).Resolve(obj.GroupVersionKind())
+	Expect(err).NotTo(HaveOccurred())
+
+	view, err := ResolveDescribe(context.Background(), obj, def, pods)
+	Expect(err).NotTo(HaveOccurred())
+	return view
+}
+
+// componentNamed finds a component at any depth, so a test does not have to
+// spell out the path through grouping components.
+func componentNamed(components []ComponentView, name string) *ComponentView {
+	for i := range components {
+		if components[i].Name == name {
+			return &components[i]
+		}
+		if found := componentNamed(components[i].Children, name); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+// livePod builds a scheduled, ready pod carrying labels a PodSelector matches.
+func livePod(name, node string, labels map[string]string, gpus string) corev1.Pod {
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "ml-team", Labels: labels},
+		Spec: corev1.PodSpec{
+			NodeName: node,
+			Containers: []corev1.Container{{
+				Name: "main",
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{gpuResourceName: resourceQuantity(gpus)},
+				},
+			}},
+		},
+		Status: corev1.PodStatus{
+			Phase:      corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+		},
+	}
+}
+
+// unschedulablePod is the failing pod truncation must never hide.
+func unschedulablePod(name string, labels map[string]string) corev1.Pod {
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "ml-team", Labels: labels},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+			Conditions: []corev1.PodCondition{{
+				Type: corev1.PodScheduled, Status: corev1.ConditionFalse, Reason: "Unschedulable",
+			}},
+		},
+	}
+}
+
+func masterLabels() map[string]string {
+	return map[string]string{"training.kubeflow.org/replica-type": "master"}
+}
+
+func workerLabels() map[string]string {
+	return map[string]string{"training.kubeflow.org/replica-type": "worker"}
+}
+
+var _ = Describe("ResolveDescribe", func() {
+	Context("without pods, as file mode builds it", func() {
+		It("carries the structure, the desired scale and the requested resources", func() {
+			view := describeFixture("pytorchjob.yaml")
+
+			Expect(view.Name).To(Equal("llama-finetune"))
+			Expect(view.Kind).To(Equal("PyTorchJob"))
+			Expect(view.Definition).To(Equal("kubeflow-org-pytorchjob-v1"))
+			Expect(view.Origin).To(Equal(string(definitions.OriginCatalog)))
+
+			master := componentNamed(view.Components, "master")
+			Expect(master).NotTo(BeNil())
+			Expect(master.Replicas).To(Equal(Replicas{Desired: 1}))
+			Expect(master.Resources.GPUs).To(Equal(int64(1)))
+
+			worker := componentNamed(view.Components, "worker")
+			Expect(worker.Replicas).To(Equal(Replicas{Desired: 4}))
+			Expect(worker.Resources.GPUs).To(Equal(int64(32)), "8 per replica across 4 replicas")
+
+			Expect(view.Resources.GPUs).To(Equal(int64(33)))
+		})
+
+		It("leaves every live field empty rather than reporting zeroes as facts", func() {
+			view := describeFixture("pytorchjob.yaml")
+
+			for _, component := range view.Components {
+				Expect(component.Pods).To(BeEmpty())
+				Expect(component.Nodes).To(BeEmpty())
+				Expect(component.Replicas.Current).To(BeZero())
+				Expect(component.Replicas.Ready).To(BeZero())
+			}
+		})
+	})
+
+	Context("with live pods", func() {
+		It("attributes each pod to the component its selector names", func() {
+			view := describeFixture("pytorchjob.yaml",
+				livePod("llama-finetune-master-0", "node-01", masterLabels(), "1"),
+				livePod("llama-finetune-worker-1", "node-03", workerLabels(), "8"),
+				livePod("llama-finetune-worker-0", "node-02", workerLabels(), "8"),
+				livePod("llama-finetune-worker-2", "node-04", workerLabels(), "8"),
+				unschedulablePod("llama-finetune-worker-3", workerLabels()),
+			)
+
+			master := componentNamed(view.Components, "master")
+			Expect(master.Replicas).To(Equal(Replicas{Desired: 1, Current: 1, Ready: 1}))
+			Expect(master.Nodes).To(Equal([]string{"node-01"}))
+
+			worker := componentNamed(view.Components, "worker")
+			Expect(worker.Replicas).To(Equal(Replicas{Desired: 4, Current: 4, Ready: 3}))
+			Expect(worker.Nodes).To(Equal([]string{"node-02", "node-03", "node-04"}))
+
+			names := make([]string, 0, len(worker.Pods))
+			for _, pod := range worker.Pods {
+				names = append(names, pod.Name)
+			}
+			Expect(names).To(Equal([]string{
+				"llama-finetune-worker-0", "llama-finetune-worker-1",
+				"llama-finetune-worker-2", "llama-finetune-worker-3",
+			}), "pod rows are name-ordered, so a re-run reads the same")
+		})
+
+		It("reports an unscheduled pod as a null node with its reason", func() {
+			view := describeFixture("pytorchjob.yaml",
+				unschedulablePod("llama-finetune-worker-3", workerLabels()))
+
+			pending := componentNamed(view.Components, "worker").Pods[0]
+			Expect(pending.Node).To(BeNil())
+			Expect(pending.Ready).To(BeFalse())
+			Expect(pending.Phase).To(Equal("Pending"))
+			Expect(pending.Reason).To(Equal("Unschedulable"))
+		})
+
+		// The selector says which role a pod plays, so a worker pod must not
+		// land under master just because both belong to the workload.
+		It("does not claim a pod for a component whose selector rejects it", func() {
+			view := describeFixture("pytorchjob.yaml",
+				livePod("llama-finetune-worker-0", "node-02", workerLabels(), "8"))
+
+			Expect(componentNamed(view.Components, "master").Pods).To(BeEmpty())
+			Expect(componentNamed(view.Components, "worker").Pods).To(HaveLen(1))
+		})
+
+		// Requested resources come from the spec, so they do not move when a
+		// replica is missing; only the counts do.
+		It("keeps the requested totals independent of how many pods exist", func() {
+			withPods := describeFixture("pytorchjob.yaml",
+				livePod("llama-finetune-master-0", "node-01", masterLabels(), "1"))
+
+			Expect(withPods.Resources.GPUs).To(Equal(describeFixture("pytorchjob.yaml").Resources.GPUs))
+		})
+	})
+
+	// tree.Build drops the root, so a Deployment's own pod template is only
+	// visible to a consumer that asks the root component for it.
+	It("renders a workload whose pod template lives on the root", func() {
+		view := describeFixture("deployment.yaml")
+
+		Expect(view.Components).To(HaveLen(1))
+		Expect(view.Components[0].Name).To(Equal("deployment"))
+		Expect(view.Components[0].Replicas.Desired).To(Equal(int32(3)))
+		Expect(view.Resources.GPUs).To(Equal(int64(6)), "a limit counts when no request is set")
+	})
+
+	// The Deployment definition names a ReplicaSet child that carries no pods,
+	// no scale and no descendants of its own.
+	It("collapses an intermediate component that carries nothing", func() {
+		Expect(componentNamed(describeFixture("deployment.yaml").Components, "replicaset")).To(BeNil())
+	})
+
+	// Scaled to zero is a state a workload is deliberately in, not plumbing the
+	// definition named and the workload never used.
+	It("keeps a pod-bearing component scaled to zero", func() {
+		view := describeObject([]byte(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: embed-svc
+  namespace: ml-team
+spec:
+  replicas: 0
+  template:
+    spec:
+      containers:
+        - name: server
+`))
+
+		Expect(view.Components).To(HaveLen(1))
+		Expect(view.Components[0].Name).To(Equal("deployment"))
+		Expect(view.Components[0].Replicas).To(Equal(Replicas{}))
+	})
+
+	// A multi-instance component renders one child per instance, named by its
+	// instance key rather than by the component.
+	It("splits a multi-instance component into one child per instance", func() {
+		view := describeFixture("dynamographdeployment.yaml")
+
+		frontend := componentNamed(view.Components, "Frontend")
+		Expect(frontend).NotTo(BeNil())
+		Expect(frontend.Replicas.Desired).To(Equal(int32(2)))
+		Expect(frontend.Resources.GPUs).To(Equal(int64(2)))
+
+		prefill := componentNamed(view.Components, "PrefillWorker")
+		Expect(prefill.Replicas.Desired).To(Equal(int32(4)))
+		Expect(prefill.Resources.GPUs).To(Equal(int64(32)))
+
+		Expect(view.Resources.GPUs).To(Equal(int64(34)))
+	})
+
+	It("sums cpu as millicores and memory as bytes", func() {
+		view := describeObject([]byte(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: embed-svc
+  namespace: ml-team
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+        - name: server
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "1Gi"
+`))
+
+		Expect(view.Resources.CPUMillis).To(Equal(int64(1000)))
+		Expect(view.Resources.MemoryBytes).To(Equal(int64(2 * 1024 * 1024 * 1024)))
+	})
+})
+
+// describeObject resolves an inline manifest through the built-in catalog.
+func describeObject(manifest []byte) *DescribeView {
+	GinkgoHelper()
+
+	obj := &unstructured.Unstructured{}
+	Expect(yaml.Unmarshal(manifest, obj)).To(Succeed())
+
+	def, err := definitions.New(catalog.List(), nil).Resolve(obj.GroupVersionKind())
+	Expect(err).NotTo(HaveOccurred())
+
+	view, err := ResolveDescribe(context.Background(), obj, def, nil)
+	Expect(err).NotTo(HaveOccurred())
+	return view
+}
+
+// resourceQuantity parses a quantity a fixture spells as a string.
+func resourceQuantity(value string) apiresource.Quantity {
+	GinkgoHelper()
+	quantity, err := apiresource.ParseQuantity(value)
+	Expect(err).NotTo(HaveOccurred())
+	return quantity
+}

--- a/cli/pkg/workload/describe_test.go
+++ b/cli/pkg/workload/describe_test.go
@@ -17,7 +17,10 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/yaml"
 
+	"k8s.io/utils/ptr"
+
 	"github.com/run-ai/karta/cli/pkg/definitions"
+	"github.com/run-ai/karta/pkg/api/runai/v1alpha1"
 	"github.com/run-ai/karta/pkg/catalog"
 )
 
@@ -83,6 +86,20 @@ func unschedulablePod(name string, labels map[string]string) corev1.Pod {
 			Conditions: []corev1.PodCondition{{
 				Type: corev1.PodScheduled, Status: corev1.ConditionFalse, Reason: "Unschedulable",
 			}},
+		},
+	}
+}
+
+// completedPod is a pod that ran to completion: not ready, but not failing.
+func completedPod(name string, labels map[string]string) corev1.Pod {
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "ml-team", Labels: labels},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodSucceeded,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodScheduled, Status: corev1.ConditionTrue},
+				{Type: corev1.PodReady, Status: corev1.ConditionFalse, Reason: "PodCompleted"},
+			},
 		},
 	}
 }
@@ -243,6 +260,131 @@ spec:
 		Expect(view.Resources.GPUs).To(Equal(int64(34)))
 	})
 
+	// A root can carry a pod template and a selector at once, so the pods it
+	// claims are only the ones that selector accepts.
+	It("applies the root's own component-type selector to its pods", func() {
+		karta := kartaNamed("apps-deployment-v1")
+		karta.Spec.StructureDefinition.RootComponent.PodSelector = &v1alpha1.PodSelector{
+			ComponentTypeSelector: &v1alpha1.ComponentTypeSelector{
+				KeyPath: `.metadata.labels["role"]`,
+				Value:   ptr.To("serve"),
+			},
+		}
+
+		obj := &unstructured.Unstructured{}
+		Expect(yaml.Unmarshal([]byte(`
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: embed-svc, namespace: ml-team}
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers: [{name: server}]
+`), obj)).To(Succeed())
+
+		view, err := ResolveDescribe(context.Background(), obj,
+			definitions.Definition{Karta: karta, Origin: definitions.OriginCatalog},
+			[]corev1.Pod{
+				livePod("embed-svc-0", "node-01", map[string]string{"role": "serve"}, "1"),
+				livePod("embed-svc-sidecar", "node-02", map[string]string{"role": "proxy"}, "1"),
+			})
+		Expect(err).NotTo(HaveOccurred())
+
+		pods := view.Components[0].Pods
+		Expect(pods).To(HaveLen(1))
+		Expect(pods[0].Name).To(Equal("embed-svc-0"))
+	})
+
+	// Nothing else reports this component's scale, so dropping it loses a
+	// replica count the manifest states outright.
+	It("keeps a grouping component that declares its own scale", func() {
+		view := describeObject([]byte(`
+apiVersion: grove.io/v1alpha1
+kind: PodCliqueSet
+metadata:
+  name: serve
+  namespace: ml-team
+spec:
+  replicas: 1
+  template:
+    cliques:
+      - name: worker
+        spec:
+          replicas: 2
+          podSpec:
+            containers: [{name: main}]
+    podCliqueScalingGroups:
+      - name: sg
+        replicas: 3
+`))
+
+		group := componentNamed(view.Components, "scalinggroup")
+		Expect(group).NotTo(BeNil())
+		Expect(group.Replicas.Desired).To(Equal(int32(3)))
+	})
+
+	// A group's scale multiplies through to leader and worker, so counting it
+	// again on the group itself would report twice the workload.
+	It("does not count a grouping component's scale that already reached its children", func() {
+		group := componentNamed(describeFixture("leaderworkerset.yaml").Components, "group")
+
+		Expect(group.Replicas.Desired).To(Equal(int32(8)), "leader 2 plus worker 6, not plus the group's own 2")
+	})
+
+	// Succeeded leaves no status reason, so without the ready condition a
+	// finished pod is indistinguishable from one that is stuck.
+	It("explains a pod that ran to completion", func() {
+		view := describeFixture("pytorchjob.yaml",
+			completedPod("llama-finetune-master-0", masterLabels()))
+
+		pod := componentNamed(view.Components, "master").Pods[0]
+		Expect(pod.Phase).To(Equal("Succeeded"))
+		Expect(pod.Reason).To(Equal("PodCompleted"))
+	})
+
+	// Milvus names 18 pod-bearing components and gives only 12 a selector. Left
+	// unchecked the other six each claim the whole workload, so one pod reports
+	// under seven components and ready counts exceed desired.
+	It("does not let a selectorless component claim a sibling's pods", func() {
+		view := describeObject([]byte(`
+apiVersion: milvus.io/v1beta1
+kind: Milvus
+metadata:
+  name: vectors
+  namespace: ml-team
+spec:
+  components:
+    proxy:
+      replicas: 1
+`), milvusPod("vectors-proxy-0", "proxy"))
+
+		Expect(componentNamed(view.Components, "proxy").Pods).To(HaveLen(1))
+		for _, name := range []string{"etcd", "minio", "pulsar-broker"} {
+			Expect(componentNamed(view.Components, name).Pods).To(BeEmpty(), name+" has no selector and owns no pod")
+		}
+	})
+
+	// With one pod-bearing component there is nothing to confuse a pod with, so
+	// a definition that names no selector still attributes its pods.
+	It("lets the only pod-bearing component claim pods without a selector", func() {
+		view := describeObject([]byte(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: embed-svc
+  namespace: ml-team
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+        - name: server
+`), livePod("embed-svc-0", "node-01", nil, "0"))
+
+		Expect(view.Components[0].Pods).To(HaveLen(1))
+	})
+
 	It("sums cpu as millicores and memory as bytes", func() {
 		view := describeObject([]byte(`
 apiVersion: apps/v1
@@ -268,7 +410,7 @@ spec:
 })
 
 // describeObject resolves an inline manifest through the built-in catalog.
-func describeObject(manifest []byte) *DescribeView {
+func describeObject(manifest []byte, pods ...corev1.Pod) *DescribeView {
 	GinkgoHelper()
 
 	obj := &unstructured.Unstructured{}
@@ -277,9 +419,14 @@ func describeObject(manifest []byte) *DescribeView {
 	def, err := definitions.New(catalog.List(), nil).Resolve(obj.GroupVersionKind())
 	Expect(err).NotTo(HaveOccurred())
 
-	view, err := ResolveDescribe(context.Background(), obj, def, nil)
+	view, err := ResolveDescribe(context.Background(), obj, def, pods)
 	Expect(err).NotTo(HaveOccurred())
 	return view
+}
+
+// milvusPod carries the label Milvus component selectors read.
+func milvusPod(name, component string) corev1.Pod {
+	return livePod(name, "node-01", map[string]string{"app.kubernetes.io/component": component}, "0")
 }
 
 // resourceQuantity parses a quantity a fixture spells as a string.
@@ -288,4 +435,16 @@ func resourceQuantity(value string) apiresource.Quantity {
 	quantity, err := apiresource.ParseQuantity(value)
 	Expect(err).NotTo(HaveOccurred())
 	return quantity
+}
+
+// kartaNamed returns a copy of a catalog definition a test can adjust.
+func kartaNamed(name string) *v1alpha1.Karta {
+	GinkgoHelper()
+	for _, karta := range catalog.List() {
+		if karta.Name == name {
+			return karta.DeepCopy()
+		}
+	}
+	Fail("no catalog definition named " + name)
+	return nil
 }

--- a/cli/pkg/workload/describe_test.go
+++ b/cli/pkg/workload/describe_test.go
@@ -74,7 +74,7 @@ func livePod(name, node string, labels map[string]string, gpus string) corev1.Po
 	}
 }
 
-// unschedulablePod is the failing pod truncation must never hide.
+// unschedulablePod is a pod that never got a node, so its node reads as null.
 func unschedulablePod(name string, labels map[string]string) corev1.Pod {
 	return corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "ml-team", Labels: labels},
@@ -227,8 +227,7 @@ spec:
 		Expect(view.Components[0].Replicas).To(Equal(Replicas{}))
 	})
 
-	// A multi-instance component renders one child per instance, named by its
-	// instance key rather than by the component.
+	// Each child is named by its instance key, not by the component.
 	It("splits a multi-instance component into one child per instance", func() {
 		view := describeFixture("dynamographdeployment.yaml")
 

--- a/cli/pkg/workload/describe_test.go
+++ b/cli/pkg/workload/describe_test.go
@@ -32,15 +32,7 @@ func describeFixture(name string, pods ...corev1.Pod) *DescribeView {
 	raw, err := os.ReadFile(filepath.Join("testdata", name))
 	Expect(err).NotTo(HaveOccurred())
 
-	obj := &unstructured.Unstructured{}
-	Expect(yaml.Unmarshal(raw, obj)).To(Succeed())
-
-	def, err := definitions.New(catalog.List(), nil).Resolve(obj.GroupVersionKind())
-	Expect(err).NotTo(HaveOccurred())
-
-	view, err := ResolveDescribe(context.Background(), obj, def, pods)
-	Expect(err).NotTo(HaveOccurred())
-	return view
+	return describeObject(raw, pods...)
 }
 
 // componentNamed finds a component at any depth, so a test does not have to

--- a/cli/pkg/workload/view.go
+++ b/cli/pkg/workload/view.go
@@ -42,7 +42,13 @@ func Resolve(ctx context.Context, obj *unstructured.Unstructured, def definition
 		return nil, fmt.Errorf("build tree: %w", err)
 	}
 
-	return &View{
+	view := viewOf(obj, def, workloadTree)
+	return &view, nil
+}
+
+// viewOf reads the identity every rendering of a workload shares.
+func viewOf(obj *unstructured.Unstructured, def definitions.Definition, workloadTree *tree.WorkloadTree) View {
+	return View{
 		Name:       obj.GetName(),
 		Namespace:  obj.GetNamespace(),
 		Kind:       obj.GetKind(),
@@ -51,7 +57,7 @@ func Resolve(ctx context.Context, obj *unstructured.Unstructured, def definition
 		Definition: def.Karta.Name,
 		Origin:     string(def.Origin),
 		Phases:     phases(workloadTree),
-	}, nil
+	}
 }
 
 // phases folds "no status mapping" and "mapping matched nothing" into one value.


### PR DESCRIPTION
## What does this PR do?

Adds DescribeView, the single struct every describe section renders from. Values are typed: replicas are {desired, current, ready} numbers rather than a "3/4" a consumer re-parses. Pods are narrowed top-down through the definition's own selectors. Passing no pods yields the same struct with live fields empty, which is what file mode renders.

Part of a seven-PR stack implementing `kli describe` (#206). Targets `feat/cli-describe-pod-attribution`, which must merge first.

## Related issue(s)

Refs #206

## Checklist

- [x] All commits are signed off with DCO (`git commit -s`)
- [x] New/modified files have SPDX license and copyright headers
- [x] Documentation updated (if applicable)
- [x] Tests pass (`make check`)
- [x] No proprietary or internal information included

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detailed workload descriptions in human- and machine-readable formats.
  * Displays workload structure, components, instances, pods, replica counts, node placement, and readiness status.
  * Reports pod failure reasons and aggregates requested CPU, memory, and GPU resources.
  * Supports multiple components, instances, initialization containers, sidecars, and fragmented pod specifications.
  * Handles selector edge cases, root-hosted templates, completed pods, and omitted infrastructure components.
  * Accounts for pod-level resource settings and pod overhead when calculating totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->