### PR TITLE
docs(agents): drop the token-shaped placeholder from the bad example

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ Good example value:  image: ghcr.io/example/inference:v1.2.3
 Bad example value:   image: registry.internal.corp/team/inference:latest
 
 Good secret handling:  token := os.Getenv("GITHUB_TOKEN")
-Bad secret handling:   token := "ghp_..." hardcoded in a test
+Bad secret handling:   token := "<a real token pasted here>" hardcoded in a test
 ```
 
 For vulnerability handling and disclosure, `SECURITY.md` is authoritative.


### PR DESCRIPTION
AGENTS.md line 53 illustrates bad secret handling with `token := "ghp_..."`. `ghp_` is GitHub's personal access token prefix, so prefix-matching secret scanners flag the file as containing a credential.

There is no secret in the repo. gitleaks 8.30.1 is clean on both passes:

- `gitleaks detect` over history: 546 commits scanned, no leaks
- `gitleaks detect --no-git` over the working tree: no leaks

But the NVIDIA OSS Health Scorecard's `SIG-SEC-16` ("No secrets in git history") does flag it, reporting "Sensitive pattern detected in recent commits". That signal passed on 2026-09-02 at 15:18 UTC and began failing after #242 merged at 19:55 UTC the same evening, which is the commit that introduced this line. It drags the Security Policy dimension, weighted 20%, and blocks the Publish Ready gate.

This swaps the placeholder for one that carries the same meaning without the prefix:

```
- Bad secret handling:   token := "ghp_..." hardcoded in a test
+ Bad secret handling:   token := "<a real token pasted here>" hardcoded in a test
```

The scanner false positive is reported separately to the scorecard maintainers; this change stops the flag regardless of whether that is fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the secret-handling example to use a generic placeholder instead of a GitHub token format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->