### PR TITLE
feat(operator): support FIPS 140-3 runtime mode (v0.2 backport)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,7 @@ helm-lint: ## Lint the helm chart
 .PHONY: helm-validate
 helm-validate: ## Validate the helm chart renders
 	helm template $(KARTA_CHART_DIR)
+	helm template $(KARTA_CHART_DIR) --set fipsMode=only
 
 ##@ Air-gap
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Karta was created at [Run:ai](https://run.ai) (NVIDIA) to power workload managem
 ## Documentation
 
 - [Technical Guide](docs/Technical%20Guide.md) - Full Karta spec, path syntax (jq), validation rules
+- [FIPS 140-3](docs/FIPS.md) - Running the operator with Go's FIPS 140-3 crypto module
 - [Karta definitions](docs/samples/) - Real-world Karta definitions for common workload types
 - [Runnable examples](docs/examples/) - Offline quickstart and an installable controller-runtime example
 - [API Reference](https://pkg.go.dev/github.com/run-ai/karta) - Go package documentation

--- a/charts/karta/templates/_helpers.tpl
+++ b/charts/karta/templates/_helpers.tpl
@@ -41,3 +41,14 @@ Name of the ServiceAccount to use. When create=true the chart owns the name
 {{- required "serviceAccount.name is required when serviceAccount.create is false" .Values.serviceAccount.name -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Validates fipsMode. %v, not %q: an unquoted on/off/yes/no/true/false in
+values.yaml parses as a YAML 1.1 boolean, and %q on a non-string prints
+"%!q(bool=true)" instead of the value.
+*/}}
+{{- define "karta.validateFipsMode" -}}
+{{- if not (has .Values.fipsMode (list "off" "on" "only")) -}}
+  {{- fail (printf "fipsMode must be a quoted string, one of: off, on, only (got %v)" .Values.fipsMode) -}}
+{{- end -}}
+{{- end -}}

--- a/charts/karta/templates/deployment.yaml
+++ b/charts/karta/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "karta.validateFipsMode" . -}}
 {{- if .Values.operator.enabled -}}
 {{- if and (gt (int .Values.replicaCount) 1) (not .Values.leaderElection.enabled) -}}
   {{- fail "replicaCount > 1 requires leaderElection.enabled=true; without leader election multiple replicas reconcile concurrently" -}}
@@ -34,6 +35,11 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ required "image.repository is required" .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if ne .Values.fipsMode "off" }}
+          env:
+            - name: GODEBUG
+              value: "fips140={{ .Values.fipsMode }}"
+          {{- end }}
           args:
             {{- if .Values.leaderElection.enabled }}
             - --leader-elect

--- a/charts/karta/templates/deployment.yaml
+++ b/charts/karta/templates/deployment.yaml
@@ -35,11 +35,9 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ required "image.repository is required" .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if ne .Values.fipsMode "off" }}
           env:
             - name: GODEBUG
               value: "fips140={{ .Values.fipsMode }}"
-          {{- end }}
           args:
             {{- if .Values.leaderElection.enabled }}
             - --leader-elect

--- a/charts/karta/values.yaml
+++ b/charts/karta/values.yaml
@@ -25,6 +25,9 @@ image:
   tag: ""
   pullPolicy: IfNotPresent
 
+# Go FIPS 140-3 runtime mode: off, on, or only. See docs/FIPS.md.
+fipsMode: "off"
+
 # Image pull secrets for private registries.
 imagePullSecrets: []
 

--- a/docs/FIPS.md
+++ b/docs/FIPS.md
@@ -1,0 +1,49 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright (c) 2026 NVIDIA Corporation -->
+
+# FIPS 140-3
+
+The Karta operator image is built with Go's native [FIPS 140-3
+support](https://go.dev/doc/security/fips140) (`GOFIPS140=v1.0.0`), so all
+`crypto/*` operations are served by the CMVP-validated Go Cryptographic Module.
+This is a single image: the FIPS module is always linked in, and the
+`fipsMode` chart value only controls how strictly it is enforced at runtime.
+There is no separate `-fips` image variant.
+
+## Setting the mode
+
+```yaml
+fipsMode: "off"
+```
+
+`fipsMode` sets `GODEBUG=fips140=<mode>` on the operator container. This is a
+runtime switch, not a build-time one: `GOFIPS140=v1.0.0` always links the FIPS
+module into the operator image, regardless of `fipsMode`. Valid values:
+
+- `off` (default) - FIPS mode disabled at runtime; the module is present in
+  the binary but not engaged, and no self-tests run.
+- `on` - the FIPS module is used and runs its startup self-tests, but
+  non-approved algorithms are still allowed (advisory mode).
+- `only` - non-approved algorithms are rejected. See below before using this
+  in production.
+
+```sh
+helm upgrade --install karta oci://ghcr.io/run-ai/karta/karta \
+  -n karta-system --create-namespace --set fipsMode=only
+```
+
+## `only` mode is a testing aid, not a production mode
+
+Per the [`GODEBUG=fips140` option
+docs](https://go.dev/doc/security/fips140#the-fips140-godebug-option),
+`fips140=only` is a best-effort diagnostic for testing, assessment, and
+debugging. Upstream Go explicitly does not recommend it for production. When a
+non-approved cryptographic algorithm is used, the Go FIPS 140-3 module can
+return an error or panic at the call site, depending on the code path; a
+panic crashes the pod instead of degrading gracefully. Using `only` is the
+caller's responsibility: test it against your cluster's actual configuration
+before relying on it, and do not treat it as a substitute for `on` in
+production.
+
+The operator's own crypto usage was tested under `fips140=only` against a
+real cluster: client-go's TLS connection to the API server worked cleanly.

--- a/docs/FIPS.md
+++ b/docs/FIPS.md
@@ -44,6 +44,3 @@ panic crashes the pod instead of degrading gracefully. Using `only` is the
 caller's responsibility: test it against your cluster's actual configuration
 before relying on it, and do not treat it as a substitute for `on` in
 production.
-
-The operator's own crypto usage was tested under `fips140=only` against a
-real cluster: client-go's TLS connection to the API server worked cleanly.

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -18,7 +18,8 @@ ARG VERSION=dev
 WORKDIR /src
 COPY . .
 WORKDIR /src/operator
-RUN CGO_ENABLED=0 GO111MODULE=on GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+# See docs/FIPS.md for FIPS 140-3 support.
+RUN CGO_ENABLED=0 GO111MODULE=on GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOFIPS140=v1.0.0 \
 	go build -trimpath \
 	-ldflags "-X github.com/run-ai/karta/operator/pkg/version.Version=${VERSION}" \
 	-o /karta-operator ./cmd

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -113,12 +113,13 @@ docker-build: ## Build Docker image for the host arch
 		..
 
 .PHONY: docker-buildx-push
-docker-buildx-push: ## Build and push a multi-arch Docker image via BuildKit (requires Docker)
+docker-buildx-push: ## Build and push a multi-arch Docker image with an SBOM attestation via BuildKit (requires Docker)
 	@[ "$(CONTAINER_TOOL)" = "docker" ] || (echo "Error: docker-buildx-push requires CONTAINER_TOOL=docker (got '$(CONTAINER_TOOL)')" >&2; exit 1)
 	$(CONTAINER_TOOL) buildx build $(BUILD_ARGS) \
 		--platform $(PLATFORMS_CSV) \
 		--build-arg VERSION=$(VERSION) \
 		--tag $(IMAGE) \
+		--attest type=sbom \
 		-f Dockerfile \
 		--push \
 		..


### PR DESCRIPTION
## What does this PR do?

Reduced-scope backport of the FIPS 140-3 support added to `main` in #335.
`v0.2` predates the `crd-upgrader` Job and webhook support that #335 also
touched, so this backport is operator-only:

- Pins `GOFIPS140=v1.0.0` in `operator/Dockerfile` so the Go toolchain's
  CMVP-validated FIPS 140-3 crypto module is always linked into the operator
  binary.
- Adds a `fipsMode` chart value (`off` / `on` / `only`, default `off`,
  validated via a shared `karta.validateFipsMode` helper) that sets
  `GODEBUG=fips140=<mode>` on the operator container.
- Adds `--attest type=sbom` to `operator/Makefile`'s `docker-buildx-push`.
- Adds `docs/FIPS.md`, trimmed to this operator-only scope: no
  `crd-upgrader` or `tlsmlkem` content, since that Job and the TLS-curve
  workaround it needed do not apply on this branch.

## Related issue(s)

Relates to #334

## Checklist

- [x] All commits are signed off with DCO (`git commit -s`)
- [x] New/modified files have SPDX license and copyright headers
- [x] Documentation updated (`docs/FIPS.md`, `README.md`)
- [x] Tests pass (`make check`)
- [x] No proprietary or internal information included