### PR TITLE
fix(operator): set GODEBUG explicitly even when fipsMode=off

### DIFF
--- a/charts/karta/templates/deployment.yaml
+++ b/charts/karta/templates/deployment.yaml
@@ -35,9 +35,11 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ required "image.repository is required" .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if ne .Values.fipsMode "off" }}
           env:
             - name: GODEBUG
               value: "fips140={{ .Values.fipsMode }}"
+          {{- end }}
           args:
             {{- if .Values.leaderElection.enabled }}
             - --leader-elect

--- a/charts/karta/templates/deployment.yaml
+++ b/charts/karta/templates/deployment.yaml
@@ -35,11 +35,9 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ required "image.repository is required" .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if ne .Values.fipsMode "off" }}
           env:
             - name: GODEBUG
               value: "fips140={{ .Values.fipsMode }}"
-          {{- end }}
           args:
             {{- if .Values.leaderElection.enabled }}
             - --leader-elect

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -2,6 +2,8 @@ module github.com/run-ai/karta/operator
 
 go 1.26.3
 
+godebug fips140=off
+
 require (
 	github.com/go-logr/logr v1.4.4
 	github.com/onsi/ginkgo/v2 v2.32.1


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in the FIPS 140-3 support added by #335: `fipsMode: off` (the
chart default) silently ran the operator with FIPS mode enabled instead of
disabled.

`GOFIPS140=v1.0.0` at build time makes the operator binary's own compiled-in
`GODEBUG` default `fips140=on` (per Go's own docs: `GOFIPS140` "enable[s]
FIPS 140-3 mode by default", and the `fips140` GODEBUG option "defaults to
off unless GOFIPS140 is set at build time"). `deployment.yaml` wrapped the
`GODEBUG` env var in `{{- if ne .Values.fipsMode "off" }}` to avoid setting
it unnecessarily, per review on #335. That meant `fipsMode=off` set no
`GODEBUG` at all, so the binary fell through to its compiled-in default of
`fips140=on` instead of actually running off.

Found by Aviad Hayumi in review after #335 merged.

Fix: add a `godebug fips140=off` directive to `operator/go.mod`, which
overrides `GOFIPS140`'s default back to off at compile time. The chart's
`{{- if ne .Values.fipsMode "off" }}` guard is kept as-is (an earlier version
of this PR removed it and always rendered `GODEBUG` instead, but fixing the
binary's own default is more direct and keeps the chart's original,
reviewed-and-requested shape).

Verified with `crypto/fips140.Enabled()` run inside the operator module:

```
GOFIPS140=v1.0.0, no GODEBUG at runtime -> Enabled() == false (was true before this fix)
GOFIPS140=v1.0.0, GODEBUG=fips140=on    -> Enabled() == true
GOFIPS140=v1.0.0, GODEBUG=fips140=only  -> Enabled() == true
```

Runtime `GODEBUG` still overrides the `go.mod` default, as expected.

## Related issue(s)

Relates to #334

## Checklist

- [x] All commits are signed off with DCO (`git commit -s`)
- [x] New/modified files have SPDX license and copyright headers
- [x] Documentation updated (if applicable)
- [x] Tests pass (`make check`)
- [x] No proprietary or internal information included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated runtime configuration to disable FIPS 140 mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->