### PR TITLE
feat(operator)!: read fipsMode from global values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -356,7 +356,7 @@ CRD_CONFIGMAP_MAX_BYTES ?= 1000000
 .PHONY: helm-validate
 helm-validate: ## Validate the chart renders and the CRD ConfigMap fits in etcd
 	helm template $(KARTA_CHART_DIR)
-	helm template $(KARTA_CHART_DIR) --set fipsMode=only
+	helm template $(KARTA_CHART_DIR) --set global.fipsMode=only
 	@set -e; tmp=$$(mktemp); trap 'rm -f "$$tmp"' EXIT; helm template $(KARTA_CHART_DIR) -s templates/hooks/pre/crd-upgrader-configmap.yaml > "$$tmp"; s=$$(wc -c < "$$tmp"); echo "crd-upgrader ConfigMap: $$s bytes (max $(CRD_CONFIGMAP_MAX_BYTES))"; test $$s -le $(CRD_CONFIGMAP_MAX_BYTES) || { echo "error: CRD ConfigMap is $$s bytes, over the $(CRD_CONFIGMAP_MAX_BYTES) limit; it must fit in a single ~1 MiB etcd object"; exit 1; }
 
 ##@ Air-gap

--- a/charts/karta/templates/_helpers.tpl
+++ b/charts/karta/templates/_helpers.tpl
@@ -71,14 +71,22 @@ must match the --webhook-service-name flag passed to the operator.
 {{- end -}}
 
 {{/*
-Validates fipsMode. Included from both deployment.yaml and crd-upgrader-job.yaml,
-since deployment.yaml renders nothing when operator.enabled=false (CRD-only
+Resolves and validates global.fipsMode, returning "off", "on", or "only". The
+value lives under global rather than scoped to this chart, so an umbrella
+chart embedding karta as a dependency can drive it with one flag alongside
+its other components. An unquoted on/off/yes/no/true/false in values.yaml
+parses as a YAML 1.1 boolean, so that case is coerced before validating.
+Included from both deployment.yaml and crd-upgrader-job.yaml, since
+deployment.yaml renders nothing when operator.enabled=false (CRD-only
 install) and crd-upgrader-job.yaml reads fipsMode independently of that flag.
-%v, not %q: an unquoted on/off/yes/no/true/false in values.yaml parses as a YAML
-1.1 boolean, and %q on a non-string prints "%!q(bool=true)" instead of the value.
 */}}
-{{- define "karta.validateFipsMode" -}}
-{{- if not (has .Values.fipsMode (list "off" "on" "only")) -}}
-  {{- fail (printf "fipsMode must be a quoted string, one of: off, on, only (got %v)" .Values.fipsMode) -}}
+{{- define "karta.fipsMode" -}}
+{{- $fipsMode := (.Values.global).fipsMode | default "off" -}}
+{{- if kindIs "bool" $fipsMode -}}
+  {{- $fipsMode = ternary "on" "off" $fipsMode -}}
 {{- end -}}
+{{- if not (has $fipsMode (list "off" "on" "only")) -}}
+  {{- fail (printf "global.fipsMode must be one of: off, on, only (got %v)" $fipsMode) -}}
+{{- end -}}
+{{- $fipsMode -}}
 {{- end -}}

--- a/charts/karta/templates/deployment.yaml
+++ b/charts/karta/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- include "karta.validateFipsMode" . -}}
+{{- $fipsMode := include "karta.fipsMode" . -}}
 {{- if .Values.operator.enabled -}}
 {{- if and (gt (int .Values.replicaCount) 1) (not .Values.leaderElection.enabled) -}}
   {{- fail "replicaCount > 1 requires leaderElection.enabled=true; without leader election multiple replicas reconcile concurrently" -}}
@@ -35,10 +35,10 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ required "image.repository is required" .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if ne .Values.fipsMode "off" }}
+          {{- if ne $fipsMode "off" }}
           env:
             - name: GODEBUG
-              value: "fips140={{ .Values.fipsMode }}"
+              value: "fips140={{ $fipsMode }}"
           {{- end }}
           args:
             {{- if .Values.leaderElection.enabled }}

--- a/charts/karta/templates/hooks/pre/crd-upgrader-job.yaml
+++ b/charts/karta/templates/hooks/pre/crd-upgrader-job.yaml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 NVIDIA Corporation
-{{- include "karta.validateFipsMode" . -}}
+{{- $fipsMode := include "karta.fipsMode" . -}}
 {{- if .Values.crdUpgrader.enabled }}
 apiVersion: batch/v1
 kind: Job
@@ -42,9 +42,9 @@ spec:
           env:
             - name: KUBECACHEDIR
               value: /tmp/kube-cache
-            {{- if ne .Values.fipsMode "off" }}
+            {{- if ne $fipsMode "off" }}
             - name: GODEBUG
-              value: {{ if eq .Values.fipsMode "only" }}"fips140=only,tlsmlkem=0"{{ else }}"fips140={{ .Values.fipsMode }}"{{ end }}
+              value: {{ if eq $fipsMode "only" }}"fips140=only,tlsmlkem=0"{{ else }}"fips140={{ $fipsMode }}"{{ end }}
             {{- end }}
           volumeMounts:
             - name: crds

--- a/charts/karta/values.yaml
+++ b/charts/karta/values.yaml
@@ -1,6 +1,10 @@
 # Default values for the karta operator chart.
 # Override with --set key=value or -f my-values.yaml.
 
+global:
+  # Go FIPS 140-3 runtime mode: off, on, or only. See docs/FIPS.md.
+  fipsMode: "off"
+
 # Set false to install only the CRD, without deploying the operator workload.
 operator:
   enabled: true
@@ -24,9 +28,6 @@ image:
   # stay in lockstep.
   tag: ""
   pullPolicy: IfNotPresent
-
-# Go FIPS 140-3 runtime mode: off, on, or only. See docs/FIPS.md.
-fipsMode: "off"
 
 # Image pull secrets for private registries.
 imagePullSecrets: []

--- a/docs/FIPS.md
+++ b/docs/FIPS.md
@@ -7,19 +7,20 @@ The Karta operator image is built with Go's native [FIPS 140-3
 support](https://go.dev/doc/security/fips140) (`GOFIPS140=v1.0.0`), so all
 `crypto/*` operations are served by the CMVP-validated Go Cryptographic Module.
 This is a single image: the FIPS module is always linked in, and the
-`fipsMode` chart value only controls how strictly it is enforced at runtime.
+`global.fipsMode` chart value only controls how strictly it is enforced at runtime.
 There is no separate `-fips` image variant.
 
 ## Setting the mode
 
 ```yaml
-fipsMode: "off"
+global:
+  fipsMode: "off"
 ```
 
-`fipsMode` sets `GODEBUG=fips140=<mode>` on the operator container and on the
-`crd-upgrader` pre-install/pre-upgrade hook Job. This is a runtime switch, not
-a build-time one: `GOFIPS140=v1.0.0` always links the FIPS module into the
-operator image, regardless of `fipsMode`. Valid values:
+`global.fipsMode` sets `GODEBUG=fips140=<mode>` on the operator container and
+on the `crd-upgrader` pre-install/pre-upgrade hook Job. This is a runtime
+switch, not a build-time one. `GOFIPS140=v1.0.0` always links the FIPS module
+into the operator image, regardless of `global.fipsMode`. Valid values:
 
 - `off` (default) - FIPS mode disabled at runtime; the module is present in
   the binary but not engaged, and no self-tests run.
@@ -30,7 +31,7 @@ operator image, regardless of `fipsMode`. Valid values:
 
 ```sh
 helm upgrade --install karta oci://ghcr.io/run-ai/karta/karta \
-  -n karta-system --create-namespace --set fipsMode=only
+  -n karta-system --create-namespace --set global.fipsMode=only
 ```
 
 ## `only` mode is a testing aid, not a production mode
@@ -59,7 +60,7 @@ A future Kubernetes or Go version could change that negotiation. If the
 operator starts failing outbound TLS handshakes under `fips140=only`, the
 fix is to also set `tlsmlkem=0` on the operator container. That requires
 updating the chart's `deployment.yaml`. There is no values-based override
-for it today. The `GODEBUG` value is hardcoded from `fipsMode`, and
+for it today. The `GODEBUG` value is hardcoded from `global.fipsMode`, and
 `extraArgs` only appends container arguments, not environment variables.
 
 The `crd-upgrader` Job is a separate case. Its default image
@@ -72,7 +73,7 @@ handshake trips the restriction depends on which Go toolchain version built
 it: testing found one build that failed during OpenAPI schema validation,
 which `tlsmlkem=0` fixed. Because that risk could not be ruled out for any
 given build, `crd-upgrader` always sets `GODEBUG=fips140=only,tlsmlkem=0`
-(not just `fips140=only`) when `fipsMode` is `only`.
+(not just `fips140=only`) when `global.fipsMode` is `only`.
 
 No FIPS-built `kubectl` image is published upstream today. If `crd-upgrader`
 needs to run a CMVP-certified module for your compliance requirements,


### PR DESCRIPTION
## What does this PR do?

Moves the `fipsMode` chart value to `global.fipsMode`.

Karta is typically consumed as a dependency of a larger umbrella chart
alongside other components. A chart-scoped `fipsMode` could never be driven
by a shared top-level flag: a parent chart's `values.yaml` is never
templated by Helm (confirmed empirically - neither a literal
`.Values.global.fipsMode` string nor a `{{ .Values.global.fipsMode }}`
template expression in a values file resolves; the latter fails YAML parsing
outright before Helm even loads templates), so there is no way to derive
`karta.fipsMode` from a shared `global.fipsMode` value in an umbrella
chart's `values.yaml` unless karta reads the global value directly itself.

Reading `global.fipsMode` instead lets a single flag on an umbrella install
drive every component uniformly, karta included, since Helm automatically
injects a parent chart's `global.*` block into every subchart's context.

### Renames

- `values.yaml`: `fipsMode` -> `global.fipsMode` (still defaults to `"off"`)
- `_helpers.tpl`: `karta.validateFipsMode` (validate only) -> `karta.fipsMode`
  (resolves `.Values.global.fipsMode`, applies the same YAML 1.1
  boolean-coercion handling and validation as before, and returns the mode
  string), included once per template into a `$fipsMode` variable instead of
  re-reading `.Values.fipsMode` at each render site
- `deployment.yaml`, `crd-upgrader-job.yaml`: use `$fipsMode`
- `docs/FIPS.md` and the `helm-validate` render in `Makefile` updated to match

## Related issue(s)

Relates to #334

## Checklist

- [x] All commits are signed off with DCO (`git commit -s`)
- [x] New/modified files have SPDX license and copyright headers
- [x] Documentation updated (`docs/FIPS.md`)
- [x] Tests pass (`make check`)
- [x] No proprietary or internal information included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added centralized FIPS mode configuration through the global Helm setting.
  - FIPS mode now supports `off`, `on`, and `only`, including boolean value conversion and validation.
  - Deployments and CRD upgrades consistently apply the resolved FIPS mode at runtime.

- **Documentation**
  - Updated FIPS configuration, Helm command, runtime behavior, and `GODEBUG` guidance to use the global setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->