### PR TITLE
feat(operator)!: read fipsMode from global values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ helm-lint: ## Lint the helm chart
 .PHONY: helm-validate
 helm-validate: ## Validate the helm chart renders
 	helm template $(KARTA_CHART_DIR)
-	helm template $(KARTA_CHART_DIR) --set fipsMode=only
+	helm template $(KARTA_CHART_DIR) --set global.fipsMode=only
 
 ##@ Air-gap
 

--- a/charts/karta/templates/_helpers.tpl
+++ b/charts/karta/templates/_helpers.tpl
@@ -43,12 +43,19 @@ Name of the ServiceAccount to use. When create=true the chart owns the name
 {{- end -}}
 
 {{/*
-Validates fipsMode. %v, not %q: an unquoted on/off/yes/no/true/false in
-values.yaml parses as a YAML 1.1 boolean, and %q on a non-string prints
-"%!q(bool=true)" instead of the value.
+Resolves and validates global.fipsMode, returning "off", "on", or "only". The
+value lives under global rather than scoped to this chart, so an umbrella
+chart embedding karta as a dependency can drive it with one flag alongside
+its other components. An unquoted on/off/yes/no/true/false in values.yaml
+parses as a YAML 1.1 boolean, so that case is coerced before validating.
 */}}
-{{- define "karta.validateFipsMode" -}}
-{{- if not (has .Values.fipsMode (list "off" "on" "only")) -}}
-  {{- fail (printf "fipsMode must be a quoted string, one of: off, on, only (got %v)" .Values.fipsMode) -}}
+{{- define "karta.fipsMode" -}}
+{{- $fipsMode := (.Values.global).fipsMode | default "off" -}}
+{{- if kindIs "bool" $fipsMode -}}
+  {{- $fipsMode = ternary "on" "off" $fipsMode -}}
 {{- end -}}
+{{- if not (has $fipsMode (list "off" "on" "only")) -}}
+  {{- fail (printf "global.fipsMode must be one of: off, on, only (got %v)" $fipsMode) -}}
+{{- end -}}
+{{- $fipsMode -}}
 {{- end -}}

--- a/charts/karta/templates/deployment.yaml
+++ b/charts/karta/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- include "karta.validateFipsMode" . -}}
+{{- $fipsMode := include "karta.fipsMode" . -}}
 {{- if .Values.operator.enabled -}}
 {{- if and (gt (int .Values.replicaCount) 1) (not .Values.leaderElection.enabled) -}}
   {{- fail "replicaCount > 1 requires leaderElection.enabled=true; without leader election multiple replicas reconcile concurrently" -}}
@@ -35,10 +35,10 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ required "image.repository is required" .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if ne .Values.fipsMode "off" }}
+          {{- if ne $fipsMode "off" }}
           env:
             - name: GODEBUG
-              value: "fips140={{ .Values.fipsMode }}"
+              value: "fips140={{ $fipsMode }}"
           {{- end }}
           args:
             {{- if .Values.leaderElection.enabled }}

--- a/charts/karta/values.yaml
+++ b/charts/karta/values.yaml
@@ -1,6 +1,10 @@
 # Default values for the karta operator chart.
 # Override with --set key=value or -f my-values.yaml.
 
+global:
+  # Go FIPS 140-3 runtime mode: off, on, or only. See docs/FIPS.md.
+  fipsMode: "off"
+
 # Set false to install only the CRD, without deploying the operator workload.
 operator:
   enabled: true
@@ -24,9 +28,6 @@ image:
   # stay in lockstep.
   tag: ""
   pullPolicy: IfNotPresent
-
-# Go FIPS 140-3 runtime mode: off, on, or only. See docs/FIPS.md.
-fipsMode: "off"
 
 # Image pull secrets for private registries.
 imagePullSecrets: []

--- a/docs/FIPS.md
+++ b/docs/FIPS.md
@@ -7,18 +7,19 @@ The Karta operator image is built with Go's native [FIPS 140-3
 support](https://go.dev/doc/security/fips140) (`GOFIPS140=v1.0.0`), so all
 `crypto/*` operations are served by the CMVP-validated Go Cryptographic Module.
 This is a single image: the FIPS module is always linked in, and the
-`fipsMode` chart value only controls how strictly it is enforced at runtime.
+`global.fipsMode` chart value only controls how strictly it is enforced at runtime.
 There is no separate `-fips` image variant.
 
 ## Setting the mode
 
 ```yaml
-fipsMode: "off"
+global:
+  fipsMode: "off"
 ```
 
-`fipsMode` sets `GODEBUG=fips140=<mode>` on the operator container. This is a
+`global.fipsMode` sets `GODEBUG=fips140=<mode>` on the operator container. This is a
 runtime switch, not a build-time one: `GOFIPS140=v1.0.0` always links the FIPS
-module into the operator image, regardless of `fipsMode`. Valid values:
+module into the operator image, regardless of `global.fipsMode`. Valid values:
 
 - `off` (default) - FIPS mode disabled at runtime; the module is present in
   the binary but not engaged, and no self-tests run.
@@ -29,7 +30,7 @@ module into the operator image, regardless of `fipsMode`. Valid values:
 
 ```sh
 helm upgrade --install karta oci://ghcr.io/run-ai/karta/karta \
-  -n karta-system --create-namespace --set fipsMode=only
+  -n karta-system --create-namespace --set global.fipsMode=only
 ```
 
 ## `only` mode is a testing aid, not a production mode


### PR DESCRIPTION
## What does this PR do?

Moves the `fipsMode` chart value to `global.fipsMode`.

Same change as the equivalent PR against `main`. Karta is typically
consumed as a dependency of a larger umbrella chart alongside other
components. A chart-scoped `fipsMode` could never be driven by a shared
top-level flag: a parent chart's `values.yaml` is never templated by Helm,
so there is no way to set `karta.fipsMode` from an expression referencing a
top-level value; the two are entirely disconnected unless karta reads the
shared value directly. Reading `global.fipsMode` instead lets a single flag
on an umbrella install drive every component uniformly, karta included,
since Helm automatically injects a parent chart's `global.*` block into
every subchart's context.

### Renames

- `values.yaml`: `fipsMode` -> `global.fipsMode` (still defaults to `"off"`)
- `_helpers.tpl`: `karta.validateFipsMode` (validate only) -> `karta.fipsMode`
  (resolves `.Values.global.fipsMode`, applies the same YAML 1.1
  boolean-coercion handling and validation as before, and returns the mode
  string), included once into a `$fipsMode` variable instead of re-reading
  `.Values.fipsMode`
- `deployment.yaml`: uses `$fipsMode`
- `docs/FIPS.md` and the `helm-validate` render in `Makefile` updated to match

Anyone already setting `fipsMode` on this branch must switch to
`global.fipsMode`.

## Related issue(s)

Relates to #334

## Checklist

- [x] All commits are signed off with DCO (`git commit -s`)
- [x] New/modified files have SPDX license and copyright headers
- [x] Documentation updated (`docs/FIPS.md`)
- [x] Tests pass (`make check`)
- [x] No proprietary or internal information included