### PR TITLE
test(e2e): tolerate transition dips in replay and ratchet state coverage

### DIFF
--- a/test/e2e/recorder/recording.go
+++ b/test/e2e/recorder/recording.go
@@ -185,3 +185,9 @@ func (r *Reader) Object() *unstructured.Unstructured {
 }
 
 func (r *Reader) Recording() Recording { return r.rec }
+
+// Len is the number of state frames in the recording.
+func (r *Reader) Len() int { return len(r.stateEvents) }
+
+// Pos is the zero-based index of the current frame.
+func (r *Reader) Pos() int { return r.pos }

--- a/test/e2e/replay_tests/coverage_test.go
+++ b/test/e2e/replay_tests/coverage_test.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package replay
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kartav1alpha1 "github.com/run-ai/karta/pkg/api/runai/v1alpha1"
+	"github.com/run-ai/karta/pkg/resource"
+	"github.com/run-ai/karta/test/e2e/recorder"
+)
+
+// statePair is one (karta, recorded state) the corpus claims a definition can read.
+type statePair struct {
+	Karta string
+	State kartav1alpha1.ResourceStatus
+}
+
+// knownGaps is the reviewed list of pairs the corpus records but no definition matches yet, each with the
+// written reason it is acceptable. An entry whose pair starts matching is stale and fails the suite until
+// it is removed, so coverage can only be traded away or won back through a visible diff.
+var knownGaps = map[statePair]string{
+	{Karta: "serving-knative-dev-service-v1", State: kartav1alpha1.InitializingStatus}:             "Ready=Unknown rule deferred by reviewers",
+	{Karta: "ray-io-raycluster-v1", State: kartav1alpha1.InitializingStatus}:                       "provisioning is reported only through an absent state field; rule deferred by reviewers",
+	{Karta: "serving-kserve-io-inferenceservice-v1beta1", State: kartav1alpha1.InitializingStatus}: "the deploy phase is Ready-undecided, an absence-only window; rule deferred by reviewers",
+}
+
+// The tolerance in judgeFrame forgives per-frame dips, so on its own a deleted catalog matcher could turn
+// every mid-flow frame of a state into tolerated dips without failing replay. This spec closes that hole:
+// every (karta, recorded state) pair appearing in the corpus must be positively matched on at least one
+// frame somewhere, unless a knownGaps entry names the reason.
+var _ = Describe("Karta covers every recorded state at least once", func() {
+	It("matches each (karta, state) pair somewhere in the corpus", func(ctx SpecContext) {
+		recordings, _ := filepath.Glob(recordedGlob)
+		if len(recordings) == 0 {
+			Skip("no recordings under test/e2e/recorded_data")
+		}
+
+		seen := map[statePair][]string{}
+		witnessed := map[statePair]bool{}
+		for _, path := range recordings {
+			r, err := recorder.OpenRecording(path)
+			Expect(err).NotTo(HaveOccurred())
+			karta, err := loadKarta(r.Recording())
+			Expect(err).NotTo(HaveOccurred())
+
+			short := strings.TrimPrefix(path, "../recorded_data/")
+			for r.Next() {
+				state := kartav1alpha1.ResourceStatus(r.State())
+				if state == kartav1alpha1.UndefinedStatus {
+					continue
+				}
+				pair := statePair{Karta: r.Recording().KartaName, State: state}
+				if len(seen[pair]) == 0 || seen[pair][len(seen[pair])-1] != short {
+					seen[pair] = append(seen[pair], short)
+				}
+				if witnessed[pair] {
+					continue
+				}
+				root, err := resource.NewComponentFactoryFromObject(karta, r.Object()).GetRootComponent()
+				Expect(err).NotTo(HaveOccurred())
+				status, err := root.GetStatus(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(status).NotTo(BeNil())
+				for _, m := range status.MatchedStatuses {
+					if m == pair.State {
+						witnessed[pair] = true
+						break
+					}
+				}
+			}
+		}
+
+		var missing, stale []string
+		for pair, fixtures := range seen {
+			if witnessed[pair] {
+				if reason, listed := knownGaps[pair]; listed {
+					stale = append(stale, fmt.Sprintf("%s/%s (%q) now matches; delete the entry", pair.Karta, pair.State, reason))
+				}
+				continue
+			}
+			if _, listed := knownGaps[pair]; listed {
+				continue
+			}
+			missing = append(missing, fmt.Sprintf("%s/%s is never matched (recorded in %s)",
+				pair.Karta, pair.State, strings.Join(fixtures, ", ")))
+		}
+		sort.Strings(missing)
+		sort.Strings(stale)
+		Expect(missing).To(BeEmpty(), "states the corpus records but no definition reads:\n%s", strings.Join(missing, "\n"))
+		Expect(stale).To(BeEmpty(), "stale knownGaps entries:\n%s", strings.Join(stale, "\n"))
+	})
+})

--- a/test/e2e/replay_tests/status_test.go
+++ b/test/e2e/replay_tests/status_test.go
@@ -4,6 +4,7 @@
 package replay
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -22,9 +23,24 @@ const (
 	recordedGlob = "../recorded_data/*/*/*/*.yaml"
 )
 
+// loadKarta reads the catalog definition a recording was captured against.
+func loadKarta(rec recorder.Recording) (*kartav1alpha1.Karta, error) {
+	name := filepath.Base(rec.KartaFile)
+	kartaYAML, err := os.ReadFile(filepath.Join(repoRoot, "docs", "catalog", name))
+	if err != nil {
+		return nil, err
+	}
+	karta := &kartav1alpha1.Karta{}
+	if err := yaml.Unmarshal(kartaYAML, karta); err != nil {
+		return nil, err
+	}
+	return karta, nil
+}
+
 // Each recording is a real flow the recorder captured. Walk it step by step through the recording reader:
 // Karta must parse every CR, and the statuses it reads must include the state the recorder observed from
-// the CR's own fields.
+// the CR's own fields. Karta reading exactly Undefined on a non-last frame is a tolerated transition dip,
+// reported per fixture; the last frame is always strict, and a wrong state fails anywhere (judgeFrame).
 var _ = Describe("Karta reads the recorded state", func() {
 	recordings, _ := filepath.Glob(recordedGlob)
 	if len(recordings) == 0 {
@@ -43,20 +59,46 @@ var _ = Describe("Karta reads the recorded state", func() {
 			name := filepath.Base(r.Recording().KartaFile)
 			Expect(name).To(MatchRegexp(`^[a-zA-Z0-9._-]+\.yaml$`),
 				"recording %q names a suspicious KartaFile %q", path, r.Recording().KartaFile)
-			kartaYAML, err := os.ReadFile(filepath.Join(repoRoot, "docs", "catalog", name))
-			Expect(err).NotTo(HaveOccurred())
-			karta := &kartav1alpha1.Karta{}
-			Expect(yaml.Unmarshal(kartaYAML, karta)).To(Succeed())
+			Expect(r.Recording().Result.Succeeded).To(BeTrue(),
+				"recording %q is not a successful run; re-record it before committing", path)
+			Expect(r.Len()).To(BeNumerically(">", 0),
+				"recording %q holds no state frames; it proves nothing", path)
 
+			karta, err := loadKarta(r.Recording())
+			Expect(err).NotTo(HaveOccurred())
+
+			var tolerated []string
+			var lastRecorded kartav1alpha1.ResourceStatus
 			for r.Next() {
 				state, cr := r.State(), r.Object()
+				lastRecorded = kartav1alpha1.ResourceStatus(state)
 				root, err := resource.NewComponentFactoryFromObject(karta, cr).GetRootComponent()
 				Expect(err).NotTo(HaveOccurred(), "Karta could not parse the %q CR", state)
 				status, err := root.GetStatus(ctx)
 				Expect(err).NotTo(HaveOccurred(), "Karta could not read the %q CR", state)
 				Expect(status).NotTo(BeNil(), "Karta read no status from the %q CR", state)
-				Expect(status.MatchedStatuses).To(ContainElement(kartav1alpha1.ResourceStatus(state)),
-					"Karta read %v, recorded state was %q", status.MatchedStatuses, state)
+
+				last := r.Pos() == r.Len()-1
+				switch judgeFrame(status.MatchedStatuses, kartav1alpha1.ResourceStatus(state), last) {
+				case verdictTolerated:
+					tolerated = append(tolerated, fmt.Sprintf("frame %d/%d: recorded %q, Karta read Undefined",
+						r.Pos()+1, r.Len(), state))
+				case verdictPass:
+				default:
+					Fail(fmt.Sprintf("Karta read %v, recorded state was %q (frame %d/%d of %s)",
+						status.MatchedStatuses, state, r.Pos()+1, r.Len(), path))
+				}
+			}
+			Expect(lastRecorded).NotTo(Equal(kartav1alpha1.UndefinedStatus),
+				"recording %q ends on an Undefined frame; a walk must end on a real state", path)
+			if want := r.Recording().Want; want != "" {
+				Expect(string(lastRecorded)).To(Equal(want),
+					"recording %q ends on %q but its flow declared the terminal %q; the fixture is truncated or edited",
+					path, lastRecorded, want)
+			}
+			if len(tolerated) > 0 {
+				AddReportEntry("tolerated undefined dips in "+strings.TrimPrefix(path, "../recorded_data/"),
+					strings.Join(tolerated, "\n"), ReportEntryVisibilityAlways)
 			}
 		})
 	}

--- a/test/e2e/replay_tests/tolerance.go
+++ b/test/e2e/replay_tests/tolerance.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package replay
+
+import (
+	kartav1alpha1 "github.com/run-ai/karta/pkg/api/runai/v1alpha1"
+)
+
+// verdict of one replayed frame against what Karta read.
+type verdict int
+
+const (
+	verdictPass verdict = iota
+	verdictTolerated
+	verdictFail
+)
+
+// judgeFrame applies the replay tolerance rule. The recorded state among Karta's reads passes. Karta
+// reading exactly Undefined on a non-last frame is a tolerated transition dip: operators report some
+// windows only through fields being absent, and the reviewers chose not to express absence in the
+// catalog. A wrong state anywhere and Undefined on the last frame stay failures - those are the two
+// shapes real catalog bugs take, and both were caught by exactly these checks.
+func judgeFrame(matched []kartav1alpha1.ResourceStatus, recorded kartav1alpha1.ResourceStatus, last bool) verdict {
+	// Undefined is the accessor's no-match fallback and only ever legal alone; a mixed set is a
+	// library contract break, never a pass, even when the recorded state is also present.
+	if len(matched) > 1 {
+		for _, m := range matched {
+			if m == kartav1alpha1.UndefinedStatus {
+				return verdictFail
+			}
+		}
+	}
+	for _, m := range matched {
+		if m == recorded {
+			return verdictPass
+		}
+	}
+	if !last && len(matched) == 1 && matched[0] == kartav1alpha1.UndefinedStatus {
+		return verdictTolerated
+	}
+	return verdictFail
+}

--- a/test/e2e/replay_tests/tolerance_test.go
+++ b/test/e2e/replay_tests/tolerance_test.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package replay
+
+import (
+	"testing"
+
+	kartav1alpha1 "github.com/run-ai/karta/pkg/api/runai/v1alpha1"
+)
+
+func TestJudgeFrame(t *testing.T) {
+	undef := kartav1alpha1.UndefinedStatus
+	initializing := kartav1alpha1.InitializingStatus
+	running := kartav1alpha1.RunningStatus
+
+	cases := []struct {
+		name     string
+		matched  []kartav1alpha1.ResourceStatus
+		recorded kartav1alpha1.ResourceStatus
+		last     bool
+		want     verdict
+	}{
+		{"recorded state among reads", []kartav1alpha1.ResourceStatus{running}, running, false, verdictPass},
+		{"recorded state among overlapping reads", []kartav1alpha1.ResourceStatus{running, initializing}, initializing, true, verdictPass},
+		{"recorder-labeled undefined frame still matches", []kartav1alpha1.ResourceStatus{undef}, undef, true, verdictPass},
+		{"undefined dip mid-flow is tolerated", []kartav1alpha1.ResourceStatus{undef}, initializing, false, verdictTolerated},
+		{"terminal shrug fails", []kartav1alpha1.ResourceStatus{undef}, kartav1alpha1.CompletedStatus, true, verdictFail},
+		{"one-frame fixture is entirely strict", []kartav1alpha1.ResourceStatus{undef}, initializing, true, verdictFail},
+		{"wrong state fails mid-flow", []kartav1alpha1.ResourceStatus{initializing}, running, false, verdictFail},
+		{"wrong state fails on the last frame", []kartav1alpha1.ResourceStatus{initializing}, running, true, verdictFail},
+		{"mixed undefined set is not the tolerance shape", []kartav1alpha1.ResourceStatus{undef, running}, initializing, false, verdictFail},
+		{"mixed undefined set fails even when the recorded state is present", []kartav1alpha1.ResourceStatus{undef, running}, running, false, verdictFail},
+		{"mixed undefined set fails even when recorded is undefined", []kartav1alpha1.ResourceStatus{undef, running}, undef, true, verdictFail},
+		{"empty reads fail", nil, initializing, false, verdictFail},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := judgeFrame(c.matched, c.recorded, c.last); got != c.want {
+				t.Fatalf("judgeFrame(%v, %q, last=%v) = %v, want %v", c.matched, c.recorded, c.last, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The replay suite asserts, per recorded frame, that the recorder's state is among what Karta reads. Operators report some transition windows only through fields being absent, and per review the catalog carries no absence matchers, so those windows read Undefined by design. This PR teaches the replay the same rule the recorder already applies to its own walk in `order.go`: forgive the middle, never the end.

- Karta reading exactly `[Undefined]` on a non-last frame is a tolerated dip, reported per fixture through an always-visible report entry.
- The last frame stays strict, and a wrong state fails anywhere; a multi-status set containing Undefined fails as a library contract break.
- A new coverage spec ratchets state coverage: every `(karta, recorded state)` pair in the corpus must be positively matched somewhere, unless a `knownGaps` entry names the reason; an entry whose pair starts matching fails as stale. Deleting a catalog matcher goes red naming the pair and its fixtures (mutation-verified).
- Three latent holes closed: a committed `succeeded: false` recording replayed green, a truncated fixture passed vacuously, and a fixture ending on a frame other than its flow's declared terminal (`want`) passed.

`knownGaps` seeds with the three absence-only windows deferred by review: knative, raycluster, and kserve Initializing.

Design reviewed by a multi-agent bakeoff and an independent red-team pass; the gate-side counterpart (flows ending on a frame the definition reads) lands in the owning flow PRs above this one.

Ref #196.
